### PR TITLE
feat: add Redis caching skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "100+ AI agent skills for indie developers building startups",
+  "description": "169 AI agent skills for indie developers building startups",
   "plugins": [
     {
       "name": "shipshitdev-startup",
@@ -203,7 +203,7 @@
     {
       "name": "commit-summary",
       "source": "./skills/commit-summary",
-      "description": "Commit message generation."
+      "description": "Generate Conventional Commit messages from staged or unstaged git changes, split unrelated changes i"
     },
     {
       "name": "competitive-intelligence-analyst",
@@ -399,6 +399,31 @@
       "name": "gh-fix-ci",
       "source": "./skills/gh-fix-ci",
       "description": "GitHub Actions CI fixes."
+    },
+    {
+      "name": "gh-inbox",
+      "source": "./skills/gh-inbox",
+      "description": "Collect and triage a GitHub work inbox from assigned issues, review requests, mentions, authored PRs"
+    },
+    {
+      "name": "gh-pr-publish",
+      "source": "./skills/gh-pr-publish",
+      "description": "Create, update, and publish GitHub pull requests with a clean title, durable body, branch hygiene, v"
+    },
+    {
+      "name": "gh-project-board",
+      "source": "./skills/gh-project-board",
+      "description": "Configure GitHub Projects v2 kanban boards with Ship Shit Dev defaults: Status columns, Human Review"
+    },
+    {
+      "name": "gh-review-suggestions",
+      "source": "./skills/gh-review-suggestions",
+      "description": "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks."
+    },
+    {
+      "name": "github-actions-author",
+      "source": "./skills/github-actions-author",
+      "description": "Author, review, and harden GitHub Actions workflows using current official documentation, secure tri"
     },
     {
       "name": "git-safety",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "169 AI agent skills for indie developers building startups",
+  "description": "170 AI agent skills for indie developers building startups",
   "plugins": [
     {
       "name": "shipshitdev-startup",
@@ -679,6 +679,11 @@
       "name": "react-testing-library",
       "source": "./skills/react-testing-library",
       "description": "React Testing Library best practices for writing maintainable, user-centric tests. Use when writing,"
+    },
+    {
+      "name": "redis-caching",
+      "source": "./skills/redis-caching",
+      "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for Type"
     },
     {
       "name": "refactor-code",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Skills Repo — Agent Instructions
 
-This is the shipshitdev/skills repo: 216 AI agent skills for Claude Code and Codex.
+This is the shipshitdev/skills repo: 169 AI agent skills for Claude Code and Codex.
 
 ## Repo Structure
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ![Project Type](https://img.shields.io/badge/Project-Skills-blue)
 
-164 AI agent skills for indie developers. Works with Claude Code and OpenAI Codex.
+169 AI agent skills for indie developers. Works with Claude Code and OpenAI Codex.
 
 ## Directory Structure
 
 ```
 skills/
-├── skills/              # All skills (164)
+├── skills/              # All skills (169)
 ├── commands/            # All commands (35)
 ├── bundles/             # Generated marketplace bundles
 ├── .agents/             # Repo management, memory, meta-skills
@@ -129,7 +129,7 @@ touch skills/my-skill/SKILL.md
 | test | Test tracking |
 | validate | Validation workflow |
 
-## Skills (164)
+## Skills (169)
 
 ### Startup (14)
 
@@ -187,9 +187,9 @@ touch skills/my-skill/SKILL.md
 
 `agent-config-audit`, `analyze-codebase`, `audit`, `claude-code-guide`, `code-review`, `commit-summary`, `de-slop`, `debug`, `deploy`, `deployment-composer`, `llm-structured-output`, `prompt-engineering`, `refactor-code`, `review-pr`, `scaffold`, `session-end`, `session-start`, `shape`, `skill-capture`, `skill-scout`
 
-### GitHub (4)
+### GitHub (9)
 
-`gh-address-comments`, `gh-fix-ci`, `git-safety`, `release-pr-gates`
+`gh-address-comments`, `gh-fix-ci`, `gh-inbox`, `gh-pr-publish`, `gh-project-board`, `gh-review-suggestions`, `github-actions-author`, `git-safety`, `release-pr-gates`
 
 ### Session Management (3)
 

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ![Project Type](https://img.shields.io/badge/Project-Skills-blue)
 
-169 AI agent skills for indie developers. Works with Claude Code and OpenAI Codex.
+170 AI agent skills for indie developers. Works with Claude Code and OpenAI Codex.
 
 ## Directory Structure
 
 ```
 skills/
-├── skills/              # All skills (169)
+├── skills/              # All skills (170)
 ├── commands/            # All commands (35)
 ├── bundles/             # Generated marketplace bundles
 ├── .agents/             # Repo management, memory, meta-skills
@@ -129,7 +129,7 @@ touch skills/my-skill/SKILL.md
 | test | Test tracking |
 | validate | Validation workflow |
 
-## Skills (169)
+## Skills (170)
 
 ### Startup (14)
 
@@ -163,9 +163,9 @@ touch skills/my-skill/SKILL.md
 
 `api-design-expert`, `error-handling-expert`, `graphql-architect`, `incremental-fetch`, `nestjs-expert`, `serializer-specialist`, `turborepo`, `typescript-expert`, `typescript-refactor`
 
-### Infrastructure (11)
+### Infrastructure (12)
 
-`aws-infrastructure`, `docker-expert`, `ec2-backend-deployer`, `mongodb-atlas-checker`, `mongodb-migration-expert`, `monitoring-setup`, `nestjs-queue-architect`, `performance-expert`, `production-audit`, `security-expert`, `workflow-automation`
+`aws-infrastructure`, `docker-expert`, `ec2-backend-deployer`, `mongodb-atlas-checker`, `mongodb-migration-expert`, `monitoring-setup`, `nestjs-queue-architect`, `performance-expert`, `production-audit`, `redis-caching`, `security-expert`, `workflow-automation`
 
 ### Payments (2)
 

--- a/bundles/github/README.md
+++ b/bundles/github/README.md
@@ -13,4 +13,10 @@ GitHub workflow and automation skills
 
 - `gh-address-comments`
 - `gh-fix-ci`
+- `gh-inbox`
+- `gh-pr-publish`
+- `gh-project-board`
+- `gh-review-suggestions`
+- `github-actions-author`
 - `git-safety`
+- `release-pr-gates`

--- a/bundles/github/skills/gh-inbox/SKILL.md
+++ b/bundles/github/skills/gh-inbox/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gh-inbox
+description: "Collect and triage a GitHub work inbox from assigned issues, review requests, mentions, authored PRs with failing checks, and optional project filters. Use when checking what needs attention across GitHub or prioritizing GitHub tasks."
+compatibility: Requires GitHub CLI gh access. The bundled inbox report script runs with Node.js or Bun.
+disable-model-invocation: true
+allowed-tools: Bash(gh *) Bash(node *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, inbox, triage, issues, pull-requests"
+---
+
+# GH Inbox
+
+Turn scattered GitHub work into a small priority queue.
+
+## Contract
+
+Inputs:
+
+- Optional repository, owner, or project filter
+- Optional limit and priority rules
+
+Outputs:
+
+- Prioritized GitHub inbox summary
+- Recommended next actions
+- Commands for follow-up inspection
+
+Creates/Modifies:
+
+- None in report mode
+- May label, comment, assign, close, or move items only after approval
+
+External Side Effects:
+
+- Reads GitHub issues, PRs, reviews, checks, and project membership
+- Writes GitHub issue/PR/project state only after approval
+
+Confirmation Required:
+
+- Before editing labels, assignees, comments, project fields, or issue state
+- Before rerunning workflows
+- Before merging or closing anything
+
+Delegates To:
+
+- `gh-fix-ci` for failing PR checks
+- `gh-address-comments` for existing review comments
+- `gh-review-suggestions` when a PR needs inline review feedback
+- `gh-project-board` when board metadata is missing or inconsistent
+
+## Workflow
+
+1. Verify auth:
+
+   ```bash
+   gh auth status -h github.com
+   gh api user --jq .login
+   ```
+
+2. Generate the inbox:
+
+   ```bash
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs
+   ```
+
+   Common filters:
+
+   ```bash
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --owner shipshitdev
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --repo shipshitdev/shipcode
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --project shipshitdev/1
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --limit 50
+   ```
+
+3. Triage order:
+   - Review requests
+   - Authored PRs with failing checks
+   - Assigned P0/P1 or blocking issues
+   - Mentions needing a response
+   - Stale assigned issues
+   - Project-board items missing status or priority
+
+4. For each item, choose one next action:
+   - Inspect
+   - Fix
+   - Reply
+   - Defer
+   - Reassign
+   - Close
+
+5. Ask before applying any writes. When writing, use the smallest command:
+
+   ```bash
+   gh issue edit <number> --add-label "priority:P1"
+   gh issue comment <number> --body-file <file>
+   gh pr review <number> --comment --body-file <file>
+   ```
+
+## Rules
+
+- Prefer a short queue over a complete dump.
+- Keep review requests above authored work unless production is blocked.
+- Treat failing checks as actionable only after reading the failure.
+- Do not close or defer user-facing issues without leaving a reason.
+- If GitHub search results are noisy, narrow by `--repo`, `--owner`, or
+  `--project` before making recommendations.

--- a/bundles/github/skills/gh-inbox/plugin.json
+++ b/bundles/github/skills/gh-inbox/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-inbox",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Collect and triage assigned issues, review requests, mentions, failing PRs, and project-filtered GitHub work.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/gh-inbox/scripts/gh-inbox-report.mjs
+++ b/bundles/github/skills/gh-inbox/scripts/gh-inbox-report.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const JSON_FIELDS = [
+  'assignees',
+  'author',
+  'commentsCount',
+  'createdAt',
+  'isDraft',
+  'labels',
+  'number',
+  'repository',
+  'state',
+  'title',
+  'updatedAt',
+  'url',
+].join(',');
+
+function parseArgs(argv) {
+  const args = {
+    limit: 20,
+    owner: '',
+    project: '',
+    repo: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--limit') {
+      args.limit = Number.parseInt(readValue(argv, (index += 1), arg), 10);
+    } else if (arg === '--owner') {
+      args.owner = readValue(argv, (index += 1), arg);
+    } else if (arg === '--project') {
+      args.project = readValue(argv, (index += 1), arg);
+    } else if (arg === '--repo') {
+      args.repo = readValue(argv, (index += 1), arg);
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(args.limit) || args.limit <= 0) {
+    fail('--limit must be a positive integer.');
+  }
+
+  return args;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    fail(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node gh-inbox-report.mjs [--repo owner/name] [--owner owner] [--project owner/number] [--limit 20]
+
+Report mode is read-only.
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function gh(args, allowFailure = false) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (allowFailure) {
+      return '';
+    }
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    fail(`gh ${args.join(' ')} failed:\n${stderr || error.message}`);
+  }
+}
+
+function ghJson(args, allowFailure = false) {
+  const output = gh(args, allowFailure);
+  return output ? JSON.parse(output) : [];
+}
+
+function scopeArgs(args) {
+  const scoped = [];
+  if (args.repo) {
+    scoped.push('--repo', args.repo);
+  }
+  if (args.owner) {
+    scoped.push('--owner', args.owner);
+  }
+  if (args.project) {
+    scoped.push('--project', args.project);
+  }
+  return scoped;
+}
+
+function searchIssues(args, bucket, extraArgs = []) {
+  return ghJson(
+    [
+      'search',
+      'issues',
+      '--state',
+      'open',
+      '--json',
+      JSON_FIELDS,
+      '--limit',
+      String(args.limit),
+      ...scopeArgs(args),
+      ...extraArgs,
+    ],
+    true
+  ).map((item) => ({ ...item, bucket }));
+}
+
+function searchPrs(args, bucket, extraArgs = []) {
+  return ghJson(
+    [
+      'search',
+      'prs',
+      '--state',
+      'open',
+      '--json',
+      JSON_FIELDS,
+      '--limit',
+      String(args.limit),
+      ...scopeArgs(args),
+      ...extraArgs,
+    ],
+    true
+  ).map((item) => ({ ...item, bucket }));
+}
+
+function repoName(item) {
+  if (typeof item.repository === 'string') {
+    return item.repository;
+  }
+  return item.repository?.fullName ?? item.repository?.nameWithOwner ?? item.repository?.name ?? '';
+}
+
+function labelNames(item) {
+  return (item.labels ?? []).map((label) => label.name ?? label).filter(Boolean);
+}
+
+function priorityScore(item) {
+  const labels = labelNames(item).join(' ').toLowerCase();
+  if (item.bucket === 'Review requested') return 0;
+  if (item.bucket === 'Failing authored PR') return 1;
+  if (labels.includes('p0') || labels.includes('critical') || labels.includes('blocking')) return 2;
+  if (labels.includes('p1') || labels.includes('high')) return 3;
+  if (item.bucket === 'Assigned issue') return 4;
+  if (item.bucket === 'Mention') return 5;
+  if (item.bucket === 'Project item') return 6;
+  return 10;
+}
+
+function mergeItems(items) {
+  const byUrl = new Map();
+  for (const item of items) {
+    const existing = byUrl.get(item.url);
+    if (!existing) {
+      byUrl.set(item.url, { ...item, buckets: [item.bucket] });
+    } else if (!existing.buckets.includes(item.bucket)) {
+      existing.buckets.push(item.bucket);
+    }
+  }
+  return [...byUrl.values()].sort((a, b) => {
+    const scoreDelta = priorityScore(a) - priorityScore(b);
+    if (scoreDelta !== 0) return scoreDelta;
+    return String(b.updatedAt).localeCompare(String(a.updatedAt));
+  });
+}
+
+function printItems(title, items) {
+  process.stdout.write(`\n## ${title} (${items.length})\n`);
+  if (items.length === 0) {
+    process.stdout.write('No matching items.\n');
+    return;
+  }
+
+  for (const item of items) {
+    const labels = labelNames(item);
+    const labelText = labels.length > 0 ? ` [${labels.join(', ')}]` : '';
+    const repo = repoName(item);
+    const buckets = item.buckets?.join(', ') ?? item.bucket;
+    process.stdout.write(`- ${buckets}: ${repo}#${item.number} ${item.title}${labelText}\n`);
+    process.stdout.write(`  ${item.url}\n`);
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const user = gh(['api', 'user', '--jq', '.login']);
+const items = mergeItems([
+  ...searchPrs(args, 'Review requested', ['--review-requested', '@me']),
+  ...searchPrs(args, 'Failing authored PR', ['--author', '@me', '--checks', 'failure']),
+  ...searchIssues(args, 'Assigned issue', ['--assignee', '@me']),
+  ...searchIssues(args, 'Mention', ['--mentions', user, '--include-prs']),
+  ...(args.project ? searchIssues(args, 'Project item', ['--include-prs']) : []),
+]);
+
+process.stdout.write(`# GitHub Inbox for ${user}\n`);
+const scope = [args.repo && `repo ${args.repo}`, args.owner && `owner ${args.owner}`, args.project && `project ${args.project}`]
+  .filter(Boolean)
+  .join(', ');
+process.stdout.write(`Scope: ${scope || 'all accessible repositories'}\n`);
+printItems('Priority Queue', items.slice(0, args.limit));

--- a/bundles/github/skills/gh-pr-publish/SKILL.md
+++ b/bundles/github/skills/gh-pr-publish/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: gh-pr-publish
+description: "Create, update, and publish GitHub pull requests with a clean title, durable body, branch hygiene, validation notes, and safe push/PR gates. Use when opening a PR, updating a PR description, preparing a draft PR, or publishing local changes to GitHub."
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *)
+metadata:
+  version: "1.0.0"
+  tags: "github, pull-requests, publishing"
+---
+
+# GH PR Publish
+
+Create or update a GitHub pull request from local changes without losing context
+or pushing unsafe work.
+
+## Contract
+
+Inputs:
+
+- Repository root
+- Current branch, target branch, and optional existing PR number
+- Optional user preference: draft or ready PR
+
+Outputs:
+
+- PR URL
+- Title/body summary
+- Checks run or skipped
+- Any remaining approval gates
+
+Creates/Modifies:
+
+- May create a local branch, stage files, create commits, push, and create or
+  edit a GitHub PR after approval
+- May create a temporary PR body file
+
+External Side Effects:
+
+- Writes git history when committing
+- Pushes branches to GitHub
+- Creates or edits GitHub pull requests
+
+Confirmation Required:
+
+- Before staging broad/unrelated files
+- Before creating a commit
+- Before pushing
+- Before creating or editing a PR
+- Before marking a draft PR ready
+
+Delegates To:
+
+- `commit-summary` to create a Conventional Commit
+- `gh-fix-ci` when PR checks fail
+- `release-pr-gates` for develop/staging/production promotion PRs
+- `gh-project-board` when the PR must be added to a project board
+
+## Workflow
+
+1. Verify GitHub and git context:
+
+   ```bash
+   gh auth status -h github.com
+   gh repo view --json nameWithOwner,defaultBranchRef,url
+   git status -sb
+   git branch --show-current
+   git remote -v
+   ```
+
+2. Protect default branches:
+   - If on `main`, `master`, `develop`, or `staging`, create a feature branch
+     before committing unless the user explicitly requested a release PR.
+   - Use branch prefix `codex/` unless the repo has a stronger convention.
+   - Never rewrite shared branch history.
+
+3. Inspect work before writing:
+
+   ```bash
+   git diff --stat
+   git diff --cached --stat
+   git log --oneline --decorate -10
+   ```
+
+   If unrelated files are present, list them and get approval before staging.
+
+4. Commit only after approval:
+
+   ```bash
+   git add <approved-paths>
+   git diff --staged --stat
+   git commit -m "<message>"
+   ```
+
+5. Build the PR body from evidence:
+   - Summary: what changed and why
+   - Changes: concise bullets grouped by behavior or subsystem
+   - Verification: exact checks run, or `Not run` with reason
+   - Risk: migrations, env vars, data changes, rollout notes
+   - Follow-ups: only real remaining work
+
+   Preserve useful existing body sections when updating an open PR.
+
+6. Find or create the PR:
+
+   ```bash
+   gh pr list --head <branch> --state open --json number,title,url,baseRefName
+   gh pr create --base <base> --head <branch> --draft --title "<title>" --body-file <body-file>
+   gh pr edit <number> --title "<title>" --body-file <body-file>
+   ```
+
+   Default to draft unless the user asked for ready review or the repo convention
+   clearly requires ready PRs.
+
+7. Push only after approval:
+
+   ```bash
+   git push -u origin <branch>
+   ```
+
+8. Report:
+   - PR URL
+   - Branch and base
+   - Draft/ready state
+   - Checks run
+   - Any required human action
+
+## PR Body Rules
+
+- Use real newlines via `--body-file`; do not pass escaped markdown inline.
+- Do not use `--fill` as the final body if the diff needs context.
+- Do not claim tests passed unless they were run in this session or clearly
+  visible from CI.
+- If the PR closes issues, include `Closes #123` only when the issue is truly
+  resolved by the PR.
+- If there is no meaningful body, write a short one; blank PR bodies rot.

--- a/bundles/github/skills/gh-pr-publish/plugin.json
+++ b/bundles/github/skills/gh-pr-publish/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-pr-publish",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Create or update GitHub pull requests with branch hygiene, PR body, checks, and safe push gates.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/gh-project-board/SKILL.md
+++ b/bundles/github/skills/gh-project-board/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: gh-project-board
+description: "Configure GitHub Projects v2 kanban boards with Ship Shit Dev defaults: Status columns, Human Review and Deferred lanes, and P0-P3 Priority. Use when setting up, copying, auditing, or normalizing GitHub project boards."
+compatibility: Requires GitHub CLI gh with project scope. The bundled normalizer script runs with Node.js or Bun.
+disable-model-invocation: true
+allowed-tools: Bash(gh *) Bash(node *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, projects, kanban, triage"
+---
+
+# GH Project Board
+
+Set up GitHub Projects v2 boards so issues and PRs use a consistent kanban
+shape.
+
+## Contract
+
+Inputs:
+
+- GitHub owner login and project number, or permission to process every open
+  project for an owner
+- Optional new board title when copying the reference board
+- Optional exact Status and Priority option names
+
+Outputs:
+
+- Project field audit summary
+- Field normalization plan or applied status
+- Board-layout verification result
+
+Creates/Modifies:
+
+- May create or update GitHub Projects v2 single-select fields
+- May copy a GitHub Project when creating a new board
+- Does not delete project items
+
+External Side Effects:
+
+- Reads GitHub Projects metadata
+- Writes GitHub Projects field configuration only after approval
+- May create a new GitHub Project only after approval
+
+Confirmation Required:
+
+- Before running field normalization with `--apply`
+- Before copying a project
+- Before processing every open project for an owner
+- Before using `--exact`, because removed single-select options can clear item
+  values that used those options
+
+Delegates To:
+
+- `task-prd-creator` when board setup reveals missing task structure
+- `gh-fix-ci` when project automation depends on failing GitHub Actions
+
+## Canonical Board Shape
+
+Use GitHub Projects v2.
+
+- Board view layout: `BOARD_LAYOUT`
+- Kanban column field: `Status`
+- Status options: `Backlog`, `Todo`, `In Progress`, `Human Review`, `Done`,
+  `Deferred`
+- Priority field: `Priority`
+- Priority options: `P0 🔥`, `P1`, `P2`, `P3`
+
+The Ship Shit Dev reference board is
+`https://github.com/orgs/shipshitdev/projects/1`. Treat `Human Review` as the
+added approval lane even if an older copied board does not have it yet.
+
+## Workflow
+
+1. Verify GitHub CLI auth and project scope:
+
+   ```bash
+   gh auth status -h github.com
+   gh project list --owner <owner>
+   ```
+
+2. Inspect the reference board or target board:
+
+   ```bash
+   gh project view 1 --owner shipshitdev --format json
+   gh project field-list 1 --owner shipshitdev --format json
+   gh project view <number> --owner <owner> --format json
+   gh project field-list <number> --owner <owner> --format json
+   ```
+
+3. For a new board, prefer copying the reference board so the kanban view is
+   preserved:
+
+   ```bash
+   gh project copy 1 \
+     --source-owner shipshitdev \
+     --target-owner <owner> \
+     --title "<project title>" \
+     --format json
+   ```
+
+   Then normalize the copied board to add any missing approval lane:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --project <number> \
+     --apply
+   ```
+
+4. For an existing board, audit first:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --project <number>
+   ```
+
+5. Show the audit summary and get approval before applying:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --project <number> \
+     --apply
+   ```
+
+6. To audit every open project for an owner:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --all-open
+   ```
+
+   Apply to every open project only when the user explicitly asks:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --all-open \
+     --apply
+   ```
+
+## Normalizer Options
+
+- `--status "Todo,In Progress,Human Review,Done,Deferred"` overrides the
+  Status option list.
+- `--priority "P0,P1,P2,P3"` uses ASCII-only priority names.
+- `--exact` removes non-canonical options after explicit approval.
+- `--include-closed` includes closed projects when used with `--all-open`.
+
+## Rules
+
+- Treat `Human Review` as a `Status` column, not a label.
+- Preserve unknown Status or Priority options unless the user explicitly asks
+  for exact normalization.
+- Preserve existing option IDs when renaming or recoloring options so existing
+  item values remain attached.
+- If no board view exists, report the blocker. GitHub exposes project field
+  mutations through the public API, but not public mutations for creating a
+  board view; copy the reference board or create the board view in GitHub, then
+  rerun verification.
+- Do not apply changes to closed projects unless the user explicitly asks.

--- a/bundles/github/skills/gh-project-board/plugin.json
+++ b/bundles/github/skills/gh-project-board/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-project-board",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Configure GitHub Projects kanban boards with Status columns and P0-P3 Priority fields.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/gh-project-board/scripts/setup-gh-project-board.mjs
+++ b/bundles/github/skills/gh-project-board/scripts/setup-gh-project-board.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const DEFAULT_STATUS_OPTIONS = [
+  {
+    name: 'Backlog',
+    color: 'GRAY',
+    description: 'Not ready or not scheduled yet',
+  },
+  {
+    name: 'Todo',
+    color: 'GREEN',
+    description: "This item hasn't been started",
+  },
+  {
+    name: 'In Progress',
+    color: 'YELLOW',
+    description: 'This is actively being worked on',
+  },
+  {
+    name: 'Human Review',
+    color: 'BLUE',
+    description: 'Waiting for human review or approval',
+  },
+  {
+    name: 'Done',
+    color: 'PURPLE',
+    description: 'This has been completed',
+  },
+  {
+    name: 'Deferred',
+    color: 'GRAY',
+    description: 'Parked for later',
+  },
+];
+
+const DEFAULT_PRIORITY_OPTIONS = [
+  {
+    name: 'P0 🔥',
+    color: 'RED',
+    description: 'Critical priority',
+  },
+  {
+    name: 'P1',
+    color: 'ORANGE',
+    description: 'High priority',
+  },
+  {
+    name: 'P2',
+    color: 'YELLOW',
+    description: 'Normal priority',
+  },
+  {
+    name: 'P3',
+    color: 'GRAY',
+    description: 'Low priority',
+  },
+];
+
+const PROJECT_QUERY = `
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      id
+      title
+      url
+      closed
+      views(first: 20) {
+        nodes {
+          id
+          name
+          layout
+        }
+      }
+      fields(first: 100) {
+        nodes {
+          ... on ProjectV2Field {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2IterationField {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options {
+              id
+              name
+              color
+              description
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    allOpen: false,
+    exact: false,
+    includeClosed: false,
+    owner: '',
+    priority: '',
+    project: '',
+    status: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--apply') {
+      args.apply = true;
+    } else if (arg === '--all-open') {
+      args.allOpen = true;
+    } else if (arg === '--exact') {
+      args.exact = true;
+    } else if (arg === '--include-closed') {
+      args.includeClosed = true;
+    } else if (arg === '--owner') {
+      args.owner = readValue(argv, (index += 1), arg);
+    } else if (arg === '--project') {
+      args.project = readValue(argv, (index += 1), arg);
+    } else if (arg === '--status') {
+      args.status = readValue(argv, (index += 1), arg);
+    } else if (arg === '--priority') {
+      args.priority = readValue(argv, (index += 1), arg);
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.owner) {
+    fail('Missing required --owner <login>.');
+  }
+
+  if (!args.project && !args.allOpen) {
+    fail('Pass --project <number> or --all-open.');
+  }
+
+  if (args.project && args.allOpen) {
+    fail('Use either --project <number> or --all-open, not both.');
+  }
+
+  return args;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    fail(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node setup-gh-project-board.mjs --owner <owner> --project <number> [--apply]
+  node setup-gh-project-board.mjs --owner <owner> --all-open [--apply]
+
+Options:
+  --status "Backlog,Todo,In Progress,Human Review,Done,Deferred"
+  --priority "P0 🔥,P1,P2,P3"
+  --exact             Remove non-canonical options after approval.
+  --include-closed    Include closed projects when processing all projects.
+
+Dry-run is the default. Use --apply to write GitHub Projects fields.
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function gh(args) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    const detail = stderr || error.message;
+    fail(`gh ${args.join(' ')} failed:\n${detail}`);
+  }
+}
+
+function ghJson(args) {
+  const output = gh(args);
+  return output ? JSON.parse(output) : {};
+}
+
+function graphql(query, variables = {}) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    args.push('-F', `${key}=${value}`);
+  }
+  return ghJson(args);
+}
+
+function listProjects(owner, includeClosed) {
+  const args = [
+    'project',
+    'list',
+    '--owner',
+    owner,
+    '--format',
+    'json',
+    '--limit',
+    '100',
+  ];
+
+  if (includeClosed) {
+    args.push('--closed');
+  }
+
+  const response = ghJson(args);
+  return response.projects ?? [];
+}
+
+function projectSummary(owner, number) {
+  return ghJson(['project', 'view', String(number), '--owner', owner, '--format', 'json']);
+}
+
+function projectDetails(projectId) {
+  const response = graphql(PROJECT_QUERY, { id: projectId });
+  const project = response.data?.node;
+  if (!project) {
+    fail(`Could not load project node ${projectId}.`);
+  }
+  return project;
+}
+
+function optionsFromCsv(value, defaults) {
+  if (!value) {
+    return defaults;
+  }
+
+  return value
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .map((name) => {
+      const fallback = defaults.find((option) => normalizeOptionName(option.name) === normalizeOptionName(name));
+      return {
+        name,
+        color: fallback?.color ?? 'GRAY',
+        description: fallback?.description ?? '',
+      };
+    });
+}
+
+function normalizeOptionName(name) {
+  return name
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function fieldByName(fields, name) {
+  return fields.find((field) => field.name === name);
+}
+
+function buildPlan(field, fieldName, desiredOptions, exact) {
+  if (!field) {
+    return {
+      action: 'create',
+      fieldName,
+      fieldId: '',
+      desiredOptions,
+      missingOptions: desiredOptions.map((option) => option.name),
+      renamedOptions: [],
+      preservedOptions: [],
+      changed: true,
+      error: '',
+    };
+  }
+
+  if (field.dataType !== 'SINGLE_SELECT') {
+    return {
+      action: 'blocked',
+      fieldName,
+      fieldId: field.id,
+      desiredOptions: [],
+      missingOptions: [],
+      renamedOptions: [],
+      preservedOptions: [],
+      changed: false,
+      error: `${fieldName} exists but is ${field.dataType}, not SINGLE_SELECT.`,
+    };
+  }
+
+  const existingOptions = field.options ?? [];
+  const usedOptionIndexes = new Set();
+  const mergedOptions = [];
+  const missingOptions = [];
+  const renamedOptions = [];
+
+  for (const desired of desiredOptions) {
+    const matchIndex = existingOptions.findIndex(
+      (option, index) =>
+        !usedOptionIndexes.has(index) &&
+        normalizeOptionName(option.name) === normalizeOptionName(desired.name)
+    );
+
+    if (matchIndex === -1) {
+      missingOptions.push(desired.name);
+      mergedOptions.push(desired);
+      continue;
+    }
+
+    usedOptionIndexes.add(matchIndex);
+    const existing = existingOptions[matchIndex];
+    if (existing.name !== desired.name) {
+      renamedOptions.push(`${existing.name} -> ${desired.name}`);
+    }
+
+    mergedOptions.push({
+      id: existing.id,
+      name: desired.name,
+      color: existing.color,
+      description: existing.description ?? '',
+    });
+  }
+
+  const preservedOptions = [];
+  if (!exact) {
+    for (const [index, option] of existingOptions.entries()) {
+      if (!usedOptionIndexes.has(index)) {
+        preservedOptions.push(option.name);
+        mergedOptions.push(option);
+      }
+    }
+  }
+
+  return {
+    action: 'update',
+    fieldName,
+    fieldId: field.id,
+    desiredOptions: mergedOptions,
+    missingOptions,
+    renamedOptions,
+    preservedOptions,
+    changed: optionsChanged(existingOptions, mergedOptions),
+    error: '',
+  };
+}
+
+function optionsChanged(existingOptions, desiredOptions) {
+  const serialize = (options) =>
+    options.map((option) => ({
+      id: option.id ?? '',
+      name: option.name,
+      color: option.color,
+      description: option.description ?? '',
+    }));
+
+  return JSON.stringify(serialize(existingOptions)) !== JSON.stringify(serialize(desiredOptions));
+}
+
+function graphQlString(value) {
+  return JSON.stringify(value);
+}
+
+function optionsInput(options) {
+  return `[${options
+    .map((option) => {
+      const id = option.id ? `id: ${graphQlString(option.id)}, ` : '';
+      return `{ ${id}name: ${graphQlString(option.name)}, color: ${option.color}, description: ${graphQlString(
+        option.description ?? ''
+      )} }`;
+    })
+    .join(', ')}]`;
+}
+
+function createSingleSelectField(projectId, plan) {
+  const mutation = `
+mutation {
+  createProjectV2Field(input: {
+    projectId: ${graphQlString(projectId)}
+    dataType: SINGLE_SELECT
+    name: ${graphQlString(plan.fieldName)}
+    singleSelectOptions: ${optionsInput(plan.desiredOptions)}
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+      }
+    }
+  }
+}`;
+
+  graphql(mutation);
+}
+
+function updateSingleSelectField(plan) {
+  const mutation = `
+mutation {
+  updateProjectV2Field(input: {
+    fieldId: ${graphQlString(plan.fieldId)}
+    singleSelectOptions: ${optionsInput(plan.desiredOptions)}
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+      }
+    }
+  }
+}`;
+
+  graphql(mutation);
+}
+
+function boardViewNames(project) {
+  return (project.views?.nodes ?? [])
+    .filter((view) => view.layout === 'BOARD_LAYOUT')
+    .map((view) => view.name);
+}
+
+function printPlan(plan) {
+  if (plan.error) {
+    process.stdout.write(`  ${plan.fieldName}: BLOCKED - ${plan.error}\n`);
+    return;
+  }
+
+  if (plan.action === 'create') {
+    process.stdout.write(`  ${plan.fieldName}: create with ${formatNames(plan.desiredOptions)}\n`);
+    return;
+  }
+
+  if (!plan.changed) {
+    process.stdout.write(`  ${plan.fieldName}: already matches\n`);
+    return;
+  }
+
+  process.stdout.write(`  ${plan.fieldName}: update to ${formatNames(plan.desiredOptions)}\n`);
+  if (plan.missingOptions.length > 0) {
+    process.stdout.write(`    add: ${plan.missingOptions.join(', ')}\n`);
+  }
+  if (plan.renamedOptions.length > 0) {
+    process.stdout.write(`    rename: ${plan.renamedOptions.join(', ')}\n`);
+  }
+  if (plan.preservedOptions.length > 0) {
+    process.stdout.write(`    preserve extra: ${plan.preservedOptions.join(', ')}\n`);
+  }
+}
+
+function formatNames(options) {
+  return options.map((option) => option.name).join(', ');
+}
+
+function normalizeProject(owner, number, options) {
+  const summary = projectSummary(owner, number);
+  const project = projectDetails(summary.id);
+  const fields = project.fields?.nodes ?? [];
+  const statusPlan = buildPlan(
+    fieldByName(fields, 'Status'),
+    'Status',
+    options.statusOptions,
+    options.exact
+  );
+  const priorityPlan = buildPlan(
+    fieldByName(fields, 'Priority'),
+    'Priority',
+    options.priorityOptions,
+    options.exact
+  );
+  const boardViews = boardViewNames(project);
+  const plans = [statusPlan, priorityPlan];
+  const blocked = plans.filter((plan) => plan.error);
+  const changed = plans.filter((plan) => !plan.error && plan.changed);
+
+  process.stdout.write(`\n${project.title} (#${number})\n`);
+  process.stdout.write(`${project.url}\n`);
+  process.stdout.write(
+    `  Board view: ${boardViews.length > 0 ? `yes (${boardViews.join(', ')})` : 'missing'}\n`
+  );
+
+  for (const plan of plans) {
+    printPlan(plan);
+  }
+
+  if (boardViews.length === 0) {
+    process.stdout.write(
+      '  warning: field normalization cannot create a board view through the public GitHub Projects API\n'
+    );
+  }
+
+  if (blocked.length > 0) {
+    process.exitCode = 2;
+    return;
+  }
+
+  if (!options.apply) {
+    if (changed.length > 0) {
+      process.stdout.write('  dry-run: rerun with --apply to write these field changes\n');
+    }
+    return;
+  }
+
+  for (const plan of changed) {
+    if (plan.action === 'create') {
+      createSingleSelectField(project.id, plan);
+    } else if (plan.action === 'update') {
+      updateSingleSelectField(plan);
+    }
+  }
+
+  process.stdout.write(`  applied: ${changed.length} field change(s)\n`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const statusOptions = optionsFromCsv(args.status, DEFAULT_STATUS_OPTIONS);
+const priorityOptions = optionsFromCsv(args.priority, DEFAULT_PRIORITY_OPTIONS);
+
+if (args.allOpen) {
+  const projects = listProjects(args.owner, args.includeClosed).filter(
+    (project) => args.includeClosed || !project.closed
+  );
+
+  for (const project of projects) {
+    normalizeProject(args.owner, project.number, {
+      apply: args.apply,
+      exact: args.exact,
+      priorityOptions,
+      statusOptions,
+    });
+  }
+} else {
+  normalizeProject(args.owner, args.project, {
+    apply: args.apply,
+    exact: args.exact,
+    priorityOptions,
+    statusOptions,
+  });
+}

--- a/bundles/github/skills/gh-review-suggestions/SKILL.md
+++ b/bundles/github/skills/gh-review-suggestions/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: gh-review-suggestions
+description: "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks. Use when asked to review a PR, leave actionable GitHub comments, propose applyable fixes, or submit review suggestions through gh."
+compatibility: Requires GitHub CLI gh access to the repository. The bundled diff-line helper runs with Node.js or Bun.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *) Bash(node *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, pull-requests, review, suggestions"
+---
+
+# GH Review Suggestions
+
+Review a GitHub PR and post inline comments only when the suggestion is safe,
+specific, and directly applyable.
+
+## Contract
+
+Inputs:
+
+- PR URL or number
+- Optional target files, review scope, and severity threshold
+
+Outputs:
+
+- Findings grouped by severity
+- Inline suggestion draft bodies
+- Posted review comment URLs after approval
+
+Creates/Modifies:
+
+- Does not modify local files by default
+- May post GitHub review comments after approval
+
+External Side Effects:
+
+- Reads PR metadata and diffs
+- Posts GitHub PR review comments only after approval
+
+Confirmation Required:
+
+- Before posting inline comments
+- Before submitting an approve/request-changes review
+- Before checking out or modifying the PR branch
+
+Delegates To:
+
+- `code-review` for local bug-focused review
+- `gh-address-comments` when addressing existing review feedback
+- `gh-fix-ci` when failing checks explain the review finding
+
+## Workflow
+
+1. Verify context:
+
+   ```bash
+   gh auth status -h github.com
+   gh pr view <pr> --json number,title,url,headRefOid,commits,files,reviewDecision
+   gh pr diff <pr> > /tmp/pr.diff
+   ```
+
+2. Review changed files, not the whole repository. Focus on:
+   - Bugs and behavioral regressions
+   - Security and data-isolation failures
+   - Broken tests or missing coverage for changed behavior
+   - Simple code corrections that GitHub suggestions can apply cleanly
+
+3. Use inline suggestions only for mechanical, local changes:
+
+   ````markdown
+   Explain why this concrete change is needed.
+
+   ```suggestion
+   replacement code
+   ```
+   ````
+
+   Use normal comments for architecture, product, design, or multi-file changes.
+
+4. Validate the target line is in the PR diff:
+
+   ```bash
+   node skills/gh-review-suggestions/scripts/diff-line-position.mjs \
+     --diff /tmp/pr.diff \
+     --path src/example.ts \
+     --line 42
+   ```
+
+5. Draft comments and get approval before posting.
+
+6. Prefer modern `line`/`side` API fields when posting comments:
+
+   ```bash
+   COMMIT_ID="$(gh pr view <pr> --json commits --jq '.commits[-1].oid')"
+   gh api \
+     --method POST \
+     /repos/<owner>/<repo>/pulls/<pr>/comments \
+     -f body="$(cat /tmp/comment.md)" \
+     -f commit_id="$COMMIT_ID" \
+     -f path="src/example.ts" \
+     -F line=42 \
+     -f side=RIGHT
+   ```
+
+   If targeting an older GitHub Enterprise instance that requires `position`,
+   use the helper output's `position` field.
+
+7. Summarize what was posted:
+   - Finding severity
+   - File and line
+   - Comment URL if returned
+   - Any findings intentionally left as summary-only comments
+
+## Rules
+
+- Do not post style-only comments unless the repo has an explicit style rule.
+- Do not post overlapping suggestions on the same lines.
+- Do not suggest generated lockfile or bundle changes unless the generated file
+  is the source of truth.
+- Do not request changes for speculative concerns. Ask a question or leave a
+  non-blocking comment instead.
+- If there are more than five comments, group low-priority notes into one
+  summary comment to avoid review noise.

--- a/bundles/github/skills/gh-review-suggestions/plugin.json
+++ b/bundles/github/skills/gh-review-suggestions/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-review-suggestions",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Review GitHub PRs and post precise inline suggested changes with safe GitHub suggestion blocks.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/gh-review-suggestions/scripts/diff-line-position.mjs
+++ b/bundles/github/skills/gh-review-suggestions/scripts/diff-line-position.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+function parseArgs(argv) {
+  const args = {
+    diff: '',
+    line: 0,
+    path: '',
+    side: 'RIGHT',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--diff') {
+      args.diff = readValue(argv, (index += 1), arg);
+    } else if (arg === '--line') {
+      args.line = Number.parseInt(readValue(argv, (index += 1), arg), 10);
+    } else if (arg === '--path') {
+      args.path = readValue(argv, (index += 1), arg);
+    } else if (arg === '--side') {
+      args.side = readValue(argv, (index += 1), arg).toUpperCase();
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.path) {
+    fail('Missing required --path <file>.');
+  }
+  if (!Number.isInteger(args.line) || args.line <= 0) {
+    fail('Missing required --line <positive-number>.');
+  }
+  if (args.side !== 'RIGHT' && args.side !== 'LEFT') {
+    fail('--side must be RIGHT or LEFT.');
+  }
+
+  return args;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    fail(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node diff-line-position.mjs --diff /tmp/pr.diff --path src/file.ts --line 42 [--side RIGHT]
+
+If --diff is omitted, reads the diff from stdin.
+Outputs JSON with path, line, side, and deprecated diff position.
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function readDiff(path) {
+  if (path) {
+    return readFileSync(path, 'utf8');
+  }
+  return readFileSync(0, 'utf8');
+}
+
+function normalizePath(path) {
+  return path.replace(/^["']|["']$/g, '').replace(/^[ab]\//, '');
+}
+
+function parseHunkHeader(line) {
+  const match = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+  if (!match) {
+    return null;
+  }
+  return {
+    oldLine: Number.parseInt(match[1], 10),
+    newLine: Number.parseInt(match[2], 10),
+  };
+}
+
+function findPosition(diff, targetPath, targetLine, targetSide) {
+  let currentPath = '';
+  let oldLine = 0;
+  let newLine = 0;
+  let position = 0;
+  let inTargetFile = false;
+  let inHunk = false;
+
+  for (const rawLine of diff.split(/\r?\n/)) {
+    if (rawLine.startsWith('diff --git ')) {
+      currentPath = '';
+      inTargetFile = false;
+      inHunk = false;
+      position = 0;
+      continue;
+    }
+
+    if (rawLine.startsWith('+++ ')) {
+      const filePath = normalizePath(rawLine.slice(4).trim());
+      if (filePath !== '/dev/null') {
+        currentPath = filePath;
+        inTargetFile = currentPath === targetPath;
+      }
+      continue;
+    }
+
+    const hunk = parseHunkHeader(rawLine);
+    if (hunk) {
+      oldLine = hunk.oldLine;
+      newLine = hunk.newLine;
+      inHunk = inTargetFile;
+      continue;
+    }
+
+    if (!inHunk) {
+      continue;
+    }
+
+    const marker = rawLine[0] ?? '';
+    if (marker !== '\\') {
+      position += 1;
+    }
+
+    if (marker === '+') {
+      if (targetSide === 'RIGHT' && newLine === targetLine) {
+        return position;
+      }
+      newLine += 1;
+    } else if (marker === '-') {
+      if (targetSide === 'LEFT' && oldLine === targetLine) {
+        return position;
+      }
+      oldLine += 1;
+    } else {
+      if (targetSide === 'RIGHT' && newLine === targetLine) {
+        return position;
+      }
+      if (targetSide === 'LEFT' && oldLine === targetLine) {
+        return position;
+      }
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return null;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const diff = readDiff(args.diff);
+const normalizedPath = normalizePath(args.path);
+const position = findPosition(diff, normalizedPath, args.line, args.side);
+
+if (position === null) {
+  fail(`Line ${args.line} on ${args.side} side of ${normalizedPath} was not found in the diff.`);
+}
+
+process.stdout.write(
+  `${JSON.stringify({
+    path: normalizedPath,
+    line: args.line,
+    side: args.side,
+    position,
+  })}\n`
+);

--- a/bundles/github/skills/github-actions-author/SKILL.md
+++ b/bundles/github/skills/github-actions-author/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: github-actions-author
+description: "Author, review, and harden GitHub Actions workflows using current official documentation, secure trigger patterns, least-privilege permissions, current action versions, and CI/CD validation. Use when creating, editing, debugging, or security-reviewing workflow YAML."
+compatibility: Requires access to GitHub Actions documentation for version-sensitive guidance. Uses git and gh when validating repository workflows.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, actions, ci-cd, workflows, security"
+---
+
+# GitHub Actions Author
+
+Create and review GitHub Actions workflows with current docs and secure
+defaults.
+
+## Contract
+
+Inputs:
+
+- Repository root or target workflow file
+- Desired workflow behavior, triggers, runtimes, and deployment target
+- Optional secrets, environments, runner constraints, and matrix strategy
+
+Outputs:
+
+- Workflow YAML or patch summary
+- Documentation-backed rationale for non-obvious choices
+- Security and validation checklist
+
+Creates/Modifies:
+
+- May create or edit `.github/workflows/*.yml`
+- Does not add secrets or deploy without approval
+
+External Side Effects:
+
+- Reads official GitHub documentation when syntax, permissions, or product
+  behavior may have changed
+- May query workflow metadata with GitHub CLI
+- Does not dispatch, rerun, or cancel workflows without approval
+
+Confirmation Required:
+
+- Before writing workflow files when requirements are unclear
+- Before adding deployment, release, publish, or secret-consuming behavior
+- Before dispatching or rerunning workflows
+
+Delegates To:
+
+- `testing-cicd-init` for first-pass TypeScript test infrastructure
+- `gh-fix-ci` when a workflow is failing on a PR
+- `git-safety` when workflows touch credentials, tokens, or publish steps
+
+## Workflow
+
+1. Discover existing CI shape:
+
+   ```bash
+   find .github/workflows -maxdepth 1 -type f 2>/dev/null
+   gh workflow list
+   git status -sb
+   ```
+
+2. Read relevant local context:
+   - Existing workflow files
+   - `package.json`, lockfiles, workspace config, test scripts
+   - Deployment docs or release conventions
+
+3. Ground version-sensitive choices in official GitHub docs:
+   - Workflow syntax, triggers, contexts, expressions
+   - `GITHUB_TOKEN` permissions
+   - `pull_request` vs `pull_request_target`
+   - OIDC, environments, deployment protection rules
+   - Cache, artifacts, reusable workflows, matrices, concurrency
+
+4. Check action versions before adding or bumping common actions:
+
+   ```bash
+   gh release view --repo actions/checkout --json tagName --jq '.tagName'
+   gh release view --repo actions/setup-node --json tagName --jq '.tagName'
+   gh release view --repo oven-sh/setup-bun --json tagName --jq '.tagName'
+   ```
+
+5. Author with safe defaults:
+   - Pin permissions at workflow or job level; default to `contents: read`.
+   - Use `pull_request` for untrusted code. Use `pull_request_target` only for
+     metadata/comment workflows that do not check out or execute fork code.
+   - Pass untrusted event data through environment variables before shell use.
+   - Use `concurrency` for expensive or deploy workflows.
+   - Use cache keys that include lockfile hashes.
+   - Avoid printing secrets or full tokens.
+   - Separate CI, release, and deployment workflows when permissions differ.
+
+6. Validate locally when possible:
+
+   ```bash
+   git diff -- .github/workflows
+   gh workflow view <workflow-name-or-id> --yaml
+   ```
+
+   Run `actionlint` if already installed. Do not install new global tools unless
+   the user asks.
+
+7. Final output:
+   - Files changed
+   - Trigger behavior
+   - Permissions and secret boundaries
+   - Validation performed
+   - Remaining manual setup such as secrets or environments
+
+## Security Review Checklist
+
+- No hardcoded secrets, tokens, credentials, or private URLs.
+- Job permissions are minimal and explicit.
+- Fork PRs cannot access secrets or execute trusted-token publish paths.
+- Shell steps quote variables and avoid direct interpolation of issue/PR text.
+- Third-party actions are current and reputable; pin to SHA for sensitive
+  workflows or untrusted supply-chain surfaces.
+- Deployment jobs use environments when human approval or environment-scoped
+  secrets are needed.
+- Release/publish jobs run only on trusted refs or signed/manual dispatch paths.

--- a/bundles/github/skills/github-actions-author/plugin.json
+++ b/bundles/github/skills/github-actions-author/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "github-actions-author",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Author and harden GitHub Actions workflows with secure triggers, permissions, and docs-backed guidance.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/release-pr-gates/SKILL.md
+++ b/bundles/github/skills/release-pr-gates/SKILL.md
@@ -1,0 +1,214 @@
+---
+name: release-pr-gates
+description: Promote releases through GitHub pull requests between develop, staging, and master/main branches, including branch discovery, target selection, PR creation, and waiting for required quality gates. Use when the user asks to release, promote develop, open a release PR, push to staging, promote staging to production, or wait for GitHub checks to go green.
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+metadata:
+  version: "1.0.0"
+  tags: "release, github, pull-request, ci-cd, quality-gates"
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+# Release PR Gates
+
+Promote code through protected branches with GitHub pull requests and wait for
+quality gates before reporting the release as ready.
+
+## Contract
+
+Inputs:
+
+- Repository root with git remote
+- Source branch and target branch, or permission to auto-detect release branches
+- Optional existing PR number
+
+Outputs:
+
+- PR URL or existing PR reused
+- Source/target branch summary
+- Quality gate status
+- Failing check summary when gates fail
+
+Creates/Modifies:
+
+- May create a GitHub release PR
+- May create a local PR body file
+- Does not merge unless explicitly confirmed
+
+External Side Effects:
+
+- Reads and writes GitHub pull request state
+- Watches GitHub checks
+- Reads GitHub Actions logs for failures
+
+Confirmation Required:
+
+- Before creating a PR unless the user explicitly asked to open a release PR
+- Before marking a PR ready when repository convention is unclear
+- Before merging into `master` or `main`
+- Before rerunning workflows
+
+Delegates To:
+
+- `gh-fix-ci` when checks fail
+- `changelog-generator` when a release body needs commit summaries
+- `deploy` after release gates pass and provider deployment is needed
+
+## Use Case
+
+Use this skill for release promotion flows such as:
+
+- `develop` -> `staging` -> `master`
+- `develop` -> `staging` -> `main`
+- `develop` -> `master` when no `staging` branch exists
+- `develop` -> `main` when no `staging` branch exists
+
+Always discover the repository's real branches before choosing the PR target.
+
+## Preconditions
+
+1. Verify GitHub CLI and auth:
+
+   ```bash
+   gh --version
+   gh auth status -h github.com
+   ```
+
+2. Verify clean release context:
+
+   ```bash
+   git status -sb
+   git remote -v
+   git fetch --all --prune
+   ```
+
+3. Identify the repository and default branch:
+
+   ```bash
+   gh repo view --json nameWithOwner,defaultBranchRef
+   ```
+
+4. List release branches on the remote:
+
+   ```bash
+   git branch -r --list 'origin/develop' 'origin/staging' 'origin/master' 'origin/main'
+   ```
+
+Stop and explain the blocker if `develop` does not exist. This release flow
+starts from `develop` by default.
+
+## Branch Target Rules
+
+Choose the PR base in this order:
+
+1. If the user explicitly names a base branch, use it after confirming it exists
+   on the remote.
+2. If `origin/staging` exists, open the release PR from `develop` to `staging`.
+3. If `origin/staging` does not exist, open the release PR from `develop` to
+   `master` when `origin/master` exists.
+4. If `origin/master` does not exist, open the release PR from `develop` to
+   `main` when `origin/main` exists.
+5. If none of these targets exist, stop and report the available remote branches.
+
+For a second production promotion after staging has gone green, use:
+
+- `staging` -> `master` when `master` exists
+- `staging` -> `main` when `master` does not exist and `main` exists
+
+Require explicit user confirmation before merging into `master` or `main`.
+
+## Release PR Workflow
+
+1. Run local quality gates before opening or updating the release PR. Format,
+   lint, and type-check are mandatory because they mirror GitHub Actions and are
+   cheap to run locally:
+
+   ```bash
+   bun run format || npm run format || npx biome check --write .
+   bun run lint || npm run lint || bunx turbo lint
+   bun run typecheck || bun run type-check || npm run typecheck || npm run type-check || npx tsc --noEmit
+   ```
+
+   Fix failures before pushing. Do not open a release PR with known local
+   format, lint, or type errors.
+
+2. Inspect branch divergence:
+
+   ```bash
+   git log --oneline origin/<base>..origin/<head>
+   git diff --stat origin/<base>...origin/<head>
+   ```
+
+3. Check for an existing open PR:
+
+   ```bash
+   gh pr list --head <head> --base <base> --state open --json number,title,url,headRefName,baseRefName
+   ```
+
+4. If no open PR exists, create one:
+
+   ```bash
+   gh pr create --head <head> --base <base> --title "Release: <head> to <base>" --body-file <body-file>
+   ```
+
+   The PR body should include:
+
+   - Source and target branches
+   - Commit summary from `<base>..<head>`
+   - Local checks already run, if any
+   - Release risk notes or migrations, if visible from commits
+
+5. If an open PR already exists, reuse it. Do not create duplicates.
+
+6. Mark the PR ready for review only if the user requested a non-draft PR or the
+   repository release convention requires ready PRs.
+
+## Waiting for Quality Gates
+
+After creating or finding the PR, wait for GitHub checks:
+
+```bash
+gh pr checks <number> --watch
+```
+
+If `--watch` is not available or fails, poll checks:
+
+```bash
+gh pr checks <number>
+```
+
+Quality gate outcomes:
+
+- `pass`: report the PR is green and ready for review or merge.
+- `fail`: fetch the failing workflow logs and summarize root cause.
+- `pending`: keep waiting unless the user asks for a status-only update.
+- `skipping` or no checks: report exactly what GitHub shows; do not call it green
+  unless required checks are passing or absent by repository policy.
+
+For failed GitHub Actions runs, inspect logs:
+
+```bash
+gh run view <run-id> --log
+```
+
+Do not rerun workflows unless the user asks.
+
+## Merge Policy
+
+- Do not merge production PRs without explicit confirmation.
+- Do not bypass failing required checks.
+- If staging exists, prefer a staged rollout: `develop` -> `staging`, then
+  `staging` -> production after gates are green.
+- If staging does not exist, use the direct `develop` -> production PR and make
+  the missing staging branch explicit in the final status.
+
+## Final Status
+
+Report:
+
+- Repository
+- PR URL
+- Source and target branches
+- Whether this was a staged or direct production release
+- Quality gate state
+- Any failing check names and root cause summary
+- Whether user confirmation is needed to merge

--- a/bundles/github/skills/release-pr-gates/plugin.json
+++ b/bundles/github/skills/release-pr-gates/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "release-pr-gates",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Promote release PRs through develop, staging, and production branches while waiting for CI gates",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/infrastructure/README.md
+++ b/bundles/infrastructure/README.md
@@ -19,5 +19,6 @@ DevOps, cloud, and infrastructure skills
 - `monitoring-setup`
 - `nestjs-queue-architect`
 - `performance-expert`
+- `redis-caching`
 - `security-expert`
 - `workflow-automation`

--- a/bundles/infrastructure/skills/redis-caching/SKILL.md
+++ b/bundles/infrastructure/skills/redis-caching/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: redis-caching
+description: "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications."
+metadata:
+  version: "1.0.0"
+  tags: "redis, caching, rate-limiting, sessions, prisma, nestjs, nextjs"
+---
+
+# Redis Caching
+
+Implement Redis as a production support layer, not as a second database.
+
+## When to Use
+
+- Add cache-aside or write-through caching around Prisma or API reads.
+- Protect expensive routes with rate limiting.
+- Store short-lived sessions, verification state, locks, or counters.
+- Add pub/sub or stream-backed event fanout.
+- Review Redis key design, TTLs, invalidation, or connection handling.
+
+For BullMQ job queue architecture, use `nestjs-queue-architect` instead of duplicating queue patterns here.
+
+## First Decisions
+
+1. Choose the runtime.
+   - Long-lived Node.js or NestJS process: use `ioredis`.
+   - Serverless or edge runtime: prefer the Upstash Redis SDK or REST API.
+   - Background jobs: use BullMQ guidance from `nestjs-queue-architect`.
+2. Define the cache contract before coding.
+   - Source of truth: Prisma/database, upstream API, computed result, or session authority.
+   - Freshness: hard TTL, stale-while-revalidate, explicit invalidation, or write-through.
+   - Failure mode: fail open for cache reads, fail closed for auth/session/rate-limit writes.
+3. Design keys and invalidation together.
+   - Namespace every key: `app:env:entity:id:variant`.
+   - Keep keys stable and inspectable.
+   - Add TTLs to every cache, lock, session, and rate-limit key.
+
+## Installation
+
+```bash
+bun add ioredis
+
+# Optional serverless Redis
+bun add @upstash/redis @upstash/ratelimit
+```
+
+Use one Redis client per process. Do not create a new TCP client per request.
+
+```typescript
+import Redis from "ioredis";
+
+declare global {
+  var redisClient: Redis | undefined;
+}
+
+export const redis =
+  globalThis.redisClient ??
+  new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+    enableReadyCheck: true,
+    lazyConnect: true,
+    maxRetriesPerRequest: 3,
+    retryStrategy(attempt) {
+      return Math.min(attempt * 50, 2_000);
+    },
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.redisClient = redis;
+}
+```
+
+Wire `error`, `connect`, and `reconnecting` events into the app logger or APM. Avoid logging credentials from connection URLs.
+
+## Cache-Aside With Prisma
+
+Use cache-aside for reads where brief staleness is acceptable.
+
+```typescript
+type CacheOptions = {
+  ttlSeconds: number;
+  jitterSeconds?: number;
+};
+
+const json = {
+  encode(value: unknown) {
+    return JSON.stringify(value);
+  },
+  decode<T>(value: string): T {
+    return JSON.parse(value) as T;
+  },
+};
+
+function withJitter(ttlSeconds: number, jitterSeconds = 30) {
+  return ttlSeconds + Math.floor(Math.random() * jitterSeconds);
+}
+
+export async function getCached<T>(
+  key: string,
+  load: () => Promise<T>,
+  options: CacheOptions,
+): Promise<T> {
+  const cached = await redis.get(key);
+  if (cached !== null) {
+    return json.decode<T>(cached);
+  }
+
+  const value = await load();
+  const ttl = withJitter(options.ttlSeconds, options.jitterSeconds);
+  await redis.set(key, json.encode(value), "EX", ttl);
+  return value;
+}
+```
+
+Example around Prisma:
+
+```typescript
+export async function getWorkspace(workspaceId: string) {
+  return getCached(
+    `app:prod:workspace:${workspaceId}`,
+    () =>
+      prisma.workspace.findUniqueOrThrow({
+        where: { id: workspaceId },
+        select: { id: true, name: true, plan: true, updatedAt: true },
+      }),
+    { ttlSeconds: 300, jitterSeconds: 60 },
+  );
+}
+```
+
+## Stampede Protection
+
+Protect hot keys with a short lock. Keep the lock TTL small and release it only if this process owns the token.
+
+```typescript
+import { randomUUID } from "node:crypto";
+
+const RELEASE_LOCK = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
+
+export async function getCachedWithLock<T>(
+  key: string,
+  load: () => Promise<T>,
+  options: CacheOptions,
+): Promise<T> {
+  const cached = await redis.get(key);
+  if (cached !== null) {
+    return json.decode<T>(cached);
+  }
+
+  const lockKey = `lock:${key}`;
+  const token = randomUUID();
+  const locked = await redis.set(lockKey, token, "EX", 10, "NX");
+
+  if (locked === "OK") {
+    try {
+      const value = await load();
+      await redis.set(key, json.encode(value), "EX", withJitter(options.ttlSeconds));
+      return value;
+    } finally {
+      await redis.eval(RELEASE_LOCK, 1, lockKey, token);
+    }
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 75));
+  const retry = await redis.get(key);
+  if (retry !== null) {
+    return json.decode<T>(retry);
+  }
+
+  return load();
+}
+```
+
+## Invalidation
+
+Prefer direct invalidation for known keys. Use tag sets when one mutation affects many keys.
+
+```typescript
+export async function cacheSetWithTags(
+  key: string,
+  value: unknown,
+  tags: string[],
+  ttlSeconds: number,
+) {
+  const pipeline = redis.pipeline();
+  pipeline.set(key, json.encode(value), "EX", ttlSeconds);
+
+  for (const tag of tags) {
+    const tagKey = `cachetag:${tag}`;
+    pipeline.sadd(tagKey, key);
+    pipeline.expire(tagKey, ttlSeconds + 60);
+  }
+
+  await pipeline.exec();
+}
+
+export async function invalidateTag(tag: string) {
+  const tagKey = `cachetag:${tag}`;
+  const keys = await redis.smembers(tagKey);
+  if (keys.length > 0) {
+    await redis.unlink(...keys);
+  }
+  await redis.del(tagKey);
+}
+```
+
+Use `SCAN` instead of `KEYS` for emergency pattern cleanup. Do not put pattern invalidation on hot request paths.
+
+## Rate Limiting
+
+Use sorted sets for sliding-window limits when exactness matters.
+
+```typescript
+import { randomUUID } from "node:crypto";
+
+type RateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: Date;
+};
+
+export async function slidingWindowRateLimit(
+  subject: string,
+  limit: number,
+  windowSeconds: number,
+): Promise<RateLimitResult> {
+  const key = `ratelimit:${subject}`;
+  const now = Date.now();
+  const windowStart = now - windowSeconds * 1_000;
+  const member = `${now}:${randomUUID()}`;
+
+  const results = await redis
+    .multi()
+    .zremrangebyscore(key, 0, windowStart)
+    .zadd(key, now, member)
+    .zcard(key)
+    .pexpire(key, windowSeconds * 1_000)
+    .exec();
+
+  const count = Number(results?.[2]?.[1] ?? 0);
+
+  return {
+    allowed: count <= limit,
+    limit,
+    remaining: Math.max(limit - count, 0),
+    resetAt: new Date(now + windowSeconds * 1_000),
+  };
+}
+```
+
+For public traffic, set response headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `Retry-After`.
+
+## Sessions And Verification State
+
+- Store opaque session IDs or token hashes, not raw JWTs or long-lived secrets.
+- Set TTL on every session key.
+- Regenerate sessions after privilege changes.
+- Delete sessions on logout, account deletion, and password reset.
+- Treat Redis write failure as auth failure for login, logout, MFA, and password reset flows.
+
+```typescript
+type SessionRecord = {
+  userId: string;
+  workspaceId: string;
+  issuedAt: string;
+};
+
+export async function createSession(sessionId: string, session: SessionRecord) {
+  await redis.set(
+    `session:${sessionId}`,
+    json.encode(session),
+    "EX",
+    60 * 60 * 24 * 7,
+  );
+}
+```
+
+## Pub/Sub And Streams
+
+- Use pub/sub for ephemeral fanout where missed messages are acceptable.
+- Use streams when consumers need replay, backpressure, or durable delivery.
+- Keep payloads small; store large objects elsewhere and publish IDs.
+- Add consumer observability: lag, dead letters, retries, and handler errors.
+
+## Production Checklist
+
+- [ ] All cache, lock, session, and rate-limit keys have TTLs.
+- [ ] Cache reads fail open where possible; auth and rate-limit writes fail closed.
+- [ ] Hot keys use TTL jitter or stampede protection.
+- [ ] No request path uses `KEYS`, unbounded `SMEMBERS`, or large `HGETALL`.
+- [ ] Invalidation is tested alongside the write path.
+- [ ] Redis metrics cover latency, hit rate, memory, evictions, blocked clients, and reconnects.
+- [ ] Local tests cover cache hit, cache miss, Redis down, invalidation, and rate-limit exceeded.

--- a/bundles/infrastructure/skills/redis-caching/plugin.json
+++ b/bundles/infrastructure/skills/redis-caching/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "redis-caching",
+  "version": "1.0.0",
+  "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "description": "100+ AI agent skills for indie developers - works with Claude Code, OpenAI Codex, and Cursor",
+  "description": "170 AI agent skills for indie developers - works with Claude Code, OpenAI Codex, and Cursor",
   "devDependencies": {
     "@biomejs/biome": "2.3.14",
     "husky": "9.1.7",

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -172,7 +172,17 @@
     },
     "github": {
       "description": "GitHub workflow and automation skills",
-      "skills": ["gh-address-comments", "gh-fix-ci", "git-safety"]
+      "skills": [
+        "gh-address-comments",
+        "gh-fix-ci",
+        "gh-inbox",
+        "gh-pr-publish",
+        "gh-project-board",
+        "gh-review-suggestions",
+        "github-actions-author",
+        "git-safety",
+        "release-pr-gates"
+      ]
     },
     "session": {
       "description": "Session management and documentation",

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -46,6 +46,7 @@
         "monitoring-setup",
         "nestjs-queue-architect",
         "performance-expert",
+        "redis-caching",
         "security-expert",
         "workflow-automation"
       ]

--- a/skills/commit-summary/SKILL.md
+++ b/skills/commit-summary/SKILL.md
@@ -1,69 +1,134 @@
 ---
 name: commit-summary
-description: "Commit message generation."
+description: "Generate Conventional Commit messages from staged or unstaged git changes, split unrelated changes into logical commits, detect breaking changes, and optionally create commits after approval. Use when writing commit messages, preparing commits, or committing local work."
+compatibility: Requires git.
+disable-model-invocation: true
+allowed-tools: Bash(git *)
 metadata:
   version: "1.0.0"
-  tags: git, workflow, commits, productivity
+  tags: "git, workflow, commits, productivity"
 ---
 
 # Commit Summary
 
-Generate meaningful commit messages based on staged changes.
+Generate accurate Conventional Commits from real git diffs.
+
+## Contract
+
+Inputs:
+
+- Repository root
+- Staged changes, unstaged changes, or approved paths to stage
+- Optional commit type, scope, and breaking-change context
+
+Outputs:
+
+- Commit message candidate
+- Logical commit grouping when changes are mixed
+- Created commit hash after approval, if requested
+
+Creates/Modifies:
+
+- No changes in message-only mode
+- May stage files and create commits after approval
+
+External Side Effects:
+
+- None unless another workflow pushes the commit later
+
+Confirmation Required:
+
+- Before staging files
+- Before creating a commit
+- Before amending or squashing existing commits
+
+Delegates To:
+
+- `gh-pr-publish` when the commit should be pushed and opened as a PR
+- `git-safety` when secrets or sensitive files appear in the diff
 
 ## Workflow
 
-### Step 1: Review Changes
+1. Inspect repository state:
 
-```bash
-git status
-git diff --staged
-git log --oneline -5
-```
+   ```bash
+   git status -sb
+   git log --oneline -5
+   git diff --stat
+   git diff --cached --stat
+   ```
 
-### Step 2: Analyze Changes
+2. Determine whether changes are already staged:
+   - If staged changes exist, generate the message from `git diff --staged`.
+   - If nothing is staged, inspect unstaged changes and propose logical groups.
+   - If unrelated changes are mixed, recommend separate commits.
 
-Categorize:
+3. Guard against unsafe commits:
+   - Do not stage secrets, `.env`, credentials, private keys, local databases,
+     build caches, or large generated artifacts.
+   - If sensitive files appear, stop and delegate to `git-safety`.
+   - Do not include unrelated formatting churn in a feature/fix commit unless
+     it is required by the change.
 
-- `feat:` New feature
-- `fix:` Bug fix
-- `refactor:` Code restructuring
-- `docs:` Documentation only
-- `test:` Adding/updating tests
-- `chore:` Maintenance tasks
+4. Choose the Conventional Commit type:
 
-### Step 3: Generate Message
+   - `feat`: user-visible feature or capability
+   - `fix`: bug fix
+   - `docs`: documentation only
+   - `style`: formatting only, no behavior change
+   - `refactor`: code restructuring without behavior change
+   - `perf`: performance improvement
+   - `test`: tests only
+   - `build`: build system, package manager, dependencies
+   - `ci`: CI/CD workflow changes
+   - `chore`: maintenance with no user-facing behavior
+   - `revert`: revert a previous commit
 
-Format: `type(scope): short description`
+5. Detect scope:
+   - Prefer package, app, domain, or subsystem names already used in history.
+   - Omit scope if it would be vague (`misc`, `stuff`, `changes`).
 
-- What changed
-- Why it changed (if not obvious)
+6. Detect breaking changes:
+   - Public API contract changes
+   - CLI flags or output changes
+   - Database/schema migrations requiring user action
+   - Removed config keys, env vars, routes, events, or exported symbols
 
-### Step 4: Review
+   Format as `type(scope)!: summary` and include a `BREAKING CHANGE:` footer.
 
-Ensure message:
+7. Generate the commit message:
 
-- Accurately describes changes
-- Follows project conventions
-- Is concise but complete
+   ```text
+   type(scope): imperative summary
 
-## Guidelines
+   Optional body explaining why and any non-obvious implementation detail.
 
-- Start with type (feat, fix, refactor, etc.)
-- Include scope if applicable
-- Use imperative mood ("Add" not "Added")
-- Keep first line under 72 chars
-- Explain why, not just what
+   Optional footer such as:
+   BREAKING CHANGE: migration required because ...
+   Refs: #123
+   ```
+
+8. If the user asked to commit, show the exact message and get approval:
+
+   ```bash
+   git add <approved-paths>
+   git diff --staged --stat
+   git commit -m "<subject>" -m "<body-or-footer>"
+   ```
+
+## Quality Bar
+
+- Subject is imperative and under 72 characters.
+- Body explains why when the diff alone is not enough.
+- Message does not overstate behavior.
+- Commit contains one logical change.
+- Verification commands are not placed in the commit message unless the repo
+  convention asks for them.
 
 ## Examples
 
 - `feat(auth): add password reset flow`
-- `fix(api): handle null response from external service`
-- `refactor(utils): extract date formatting to shared helper`
-- `docs: update API endpoint documentation`
-
-## What NOT to Do
-
-- Vague messages ("fix stuff", "update code")
-- Too long first lines
-- Missing context for non-obvious changes
-- Committing unrelated changes together
+- `fix(api): handle null provider response`
+- `ci(actions): restrict pull request token permissions`
+- `refactor(utils): extract date formatting helper`
+- `docs: update GitHub project board workflow`

--- a/skills/gh-inbox/SKILL.md
+++ b/skills/gh-inbox/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: gh-inbox
+description: "Collect and triage a GitHub work inbox from assigned issues, review requests, mentions, authored PRs with failing checks, and optional project filters. Use when checking what needs attention across GitHub or prioritizing GitHub tasks."
+compatibility: Requires GitHub CLI gh access. The bundled inbox report script runs with Node.js or Bun.
+disable-model-invocation: true
+allowed-tools: Bash(gh *) Bash(node *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, inbox, triage, issues, pull-requests"
+---
+
+# GH Inbox
+
+Turn scattered GitHub work into a small priority queue.
+
+## Contract
+
+Inputs:
+
+- Optional repository, owner, or project filter
+- Optional limit and priority rules
+
+Outputs:
+
+- Prioritized GitHub inbox summary
+- Recommended next actions
+- Commands for follow-up inspection
+
+Creates/Modifies:
+
+- None in report mode
+- May label, comment, assign, close, or move items only after approval
+
+External Side Effects:
+
+- Reads GitHub issues, PRs, reviews, checks, and project membership
+- Writes GitHub issue/PR/project state only after approval
+
+Confirmation Required:
+
+- Before editing labels, assignees, comments, project fields, or issue state
+- Before rerunning workflows
+- Before merging or closing anything
+
+Delegates To:
+
+- `gh-fix-ci` for failing PR checks
+- `gh-address-comments` for existing review comments
+- `gh-review-suggestions` when a PR needs inline review feedback
+- `gh-project-board` when board metadata is missing or inconsistent
+
+## Workflow
+
+1. Verify auth:
+
+   ```bash
+   gh auth status -h github.com
+   gh api user --jq .login
+   ```
+
+2. Generate the inbox:
+
+   ```bash
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs
+   ```
+
+   Common filters:
+
+   ```bash
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --owner shipshitdev
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --repo shipshitdev/shipcode
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --project shipshitdev/1
+   node skills/gh-inbox/scripts/gh-inbox-report.mjs --limit 50
+   ```
+
+3. Triage order:
+   - Review requests
+   - Authored PRs with failing checks
+   - Assigned P0/P1 or blocking issues
+   - Mentions needing a response
+   - Stale assigned issues
+   - Project-board items missing status or priority
+
+4. For each item, choose one next action:
+   - Inspect
+   - Fix
+   - Reply
+   - Defer
+   - Reassign
+   - Close
+
+5. Ask before applying any writes. When writing, use the smallest command:
+
+   ```bash
+   gh issue edit <number> --add-label "priority:P1"
+   gh issue comment <number> --body-file <file>
+   gh pr review <number> --comment --body-file <file>
+   ```
+
+## Rules
+
+- Prefer a short queue over a complete dump.
+- Keep review requests above authored work unless production is blocked.
+- Treat failing checks as actionable only after reading the failure.
+- Do not close or defer user-facing issues without leaving a reason.
+- If GitHub search results are noisy, narrow by `--repo`, `--owner`, or
+  `--project` before making recommendations.

--- a/skills/gh-inbox/plugin.json
+++ b/skills/gh-inbox/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-inbox",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Collect and triage assigned issues, review requests, mentions, failing PRs, and project-filtered GitHub work.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/gh-inbox/scripts/gh-inbox-report.mjs
+++ b/skills/gh-inbox/scripts/gh-inbox-report.mjs
@@ -1,0 +1,216 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const JSON_FIELDS = [
+  'assignees',
+  'author',
+  'commentsCount',
+  'createdAt',
+  'isDraft',
+  'labels',
+  'number',
+  'repository',
+  'state',
+  'title',
+  'updatedAt',
+  'url',
+].join(',');
+
+function parseArgs(argv) {
+  const args = {
+    limit: 20,
+    owner: '',
+    project: '',
+    repo: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--limit') {
+      args.limit = Number.parseInt(readValue(argv, (index += 1), arg), 10);
+    } else if (arg === '--owner') {
+      args.owner = readValue(argv, (index += 1), arg);
+    } else if (arg === '--project') {
+      args.project = readValue(argv, (index += 1), arg);
+    } else if (arg === '--repo') {
+      args.repo = readValue(argv, (index += 1), arg);
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!Number.isInteger(args.limit) || args.limit <= 0) {
+    fail('--limit must be a positive integer.');
+  }
+
+  return args;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    fail(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node gh-inbox-report.mjs [--repo owner/name] [--owner owner] [--project owner/number] [--limit 20]
+
+Report mode is read-only.
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function gh(args, allowFailure = false) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    if (allowFailure) {
+      return '';
+    }
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    fail(`gh ${args.join(' ')} failed:\n${stderr || error.message}`);
+  }
+}
+
+function ghJson(args, allowFailure = false) {
+  const output = gh(args, allowFailure);
+  return output ? JSON.parse(output) : [];
+}
+
+function scopeArgs(args) {
+  const scoped = [];
+  if (args.repo) {
+    scoped.push('--repo', args.repo);
+  }
+  if (args.owner) {
+    scoped.push('--owner', args.owner);
+  }
+  if (args.project) {
+    scoped.push('--project', args.project);
+  }
+  return scoped;
+}
+
+function searchIssues(args, bucket, extraArgs = []) {
+  return ghJson(
+    [
+      'search',
+      'issues',
+      '--state',
+      'open',
+      '--json',
+      JSON_FIELDS,
+      '--limit',
+      String(args.limit),
+      ...scopeArgs(args),
+      ...extraArgs,
+    ],
+    true
+  ).map((item) => ({ ...item, bucket }));
+}
+
+function searchPrs(args, bucket, extraArgs = []) {
+  return ghJson(
+    [
+      'search',
+      'prs',
+      '--state',
+      'open',
+      '--json',
+      JSON_FIELDS,
+      '--limit',
+      String(args.limit),
+      ...scopeArgs(args),
+      ...extraArgs,
+    ],
+    true
+  ).map((item) => ({ ...item, bucket }));
+}
+
+function repoName(item) {
+  if (typeof item.repository === 'string') {
+    return item.repository;
+  }
+  return item.repository?.fullName ?? item.repository?.nameWithOwner ?? item.repository?.name ?? '';
+}
+
+function labelNames(item) {
+  return (item.labels ?? []).map((label) => label.name ?? label).filter(Boolean);
+}
+
+function priorityScore(item) {
+  const labels = labelNames(item).join(' ').toLowerCase();
+  if (item.bucket === 'Review requested') return 0;
+  if (item.bucket === 'Failing authored PR') return 1;
+  if (labels.includes('p0') || labels.includes('critical') || labels.includes('blocking')) return 2;
+  if (labels.includes('p1') || labels.includes('high')) return 3;
+  if (item.bucket === 'Assigned issue') return 4;
+  if (item.bucket === 'Mention') return 5;
+  if (item.bucket === 'Project item') return 6;
+  return 10;
+}
+
+function mergeItems(items) {
+  const byUrl = new Map();
+  for (const item of items) {
+    const existing = byUrl.get(item.url);
+    if (!existing) {
+      byUrl.set(item.url, { ...item, buckets: [item.bucket] });
+    } else if (!existing.buckets.includes(item.bucket)) {
+      existing.buckets.push(item.bucket);
+    }
+  }
+  return [...byUrl.values()].sort((a, b) => {
+    const scoreDelta = priorityScore(a) - priorityScore(b);
+    if (scoreDelta !== 0) return scoreDelta;
+    return String(b.updatedAt).localeCompare(String(a.updatedAt));
+  });
+}
+
+function printItems(title, items) {
+  process.stdout.write(`\n## ${title} (${items.length})\n`);
+  if (items.length === 0) {
+    process.stdout.write('No matching items.\n');
+    return;
+  }
+
+  for (const item of items) {
+    const labels = labelNames(item);
+    const labelText = labels.length > 0 ? ` [${labels.join(', ')}]` : '';
+    const repo = repoName(item);
+    const buckets = item.buckets?.join(', ') ?? item.bucket;
+    process.stdout.write(`- ${buckets}: ${repo}#${item.number} ${item.title}${labelText}\n`);
+    process.stdout.write(`  ${item.url}\n`);
+  }
+}
+
+const args = parseArgs(process.argv.slice(2));
+const user = gh(['api', 'user', '--jq', '.login']);
+const items = mergeItems([
+  ...searchPrs(args, 'Review requested', ['--review-requested', '@me']),
+  ...searchPrs(args, 'Failing authored PR', ['--author', '@me', '--checks', 'failure']),
+  ...searchIssues(args, 'Assigned issue', ['--assignee', '@me']),
+  ...searchIssues(args, 'Mention', ['--mentions', user, '--include-prs']),
+  ...(args.project ? searchIssues(args, 'Project item', ['--include-prs']) : []),
+]);
+
+process.stdout.write(`# GitHub Inbox for ${user}\n`);
+const scope = [args.repo && `repo ${args.repo}`, args.owner && `owner ${args.owner}`, args.project && `project ${args.project}`]
+  .filter(Boolean)
+  .join(', ');
+process.stdout.write(`Scope: ${scope || 'all accessible repositories'}\n`);
+printItems('Priority Queue', items.slice(0, args.limit));

--- a/skills/gh-pr-publish/SKILL.md
+++ b/skills/gh-pr-publish/SKILL.md
@@ -1,0 +1,136 @@
+---
+name: gh-pr-publish
+description: "Create, update, and publish GitHub pull requests with a clean title, durable body, branch hygiene, validation notes, and safe push/PR gates. Use when opening a PR, updating a PR description, preparing a draft PR, or publishing local changes to GitHub."
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *)
+metadata:
+  version: "1.0.0"
+  tags: "github, pull-requests, publishing"
+---
+
+# GH PR Publish
+
+Create or update a GitHub pull request from local changes without losing context
+or pushing unsafe work.
+
+## Contract
+
+Inputs:
+
+- Repository root
+- Current branch, target branch, and optional existing PR number
+- Optional user preference: draft or ready PR
+
+Outputs:
+
+- PR URL
+- Title/body summary
+- Checks run or skipped
+- Any remaining approval gates
+
+Creates/Modifies:
+
+- May create a local branch, stage files, create commits, push, and create or
+  edit a GitHub PR after approval
+- May create a temporary PR body file
+
+External Side Effects:
+
+- Writes git history when committing
+- Pushes branches to GitHub
+- Creates or edits GitHub pull requests
+
+Confirmation Required:
+
+- Before staging broad/unrelated files
+- Before creating a commit
+- Before pushing
+- Before creating or editing a PR
+- Before marking a draft PR ready
+
+Delegates To:
+
+- `commit-summary` to create a Conventional Commit
+- `gh-fix-ci` when PR checks fail
+- `release-pr-gates` for develop/staging/production promotion PRs
+- `gh-project-board` when the PR must be added to a project board
+
+## Workflow
+
+1. Verify GitHub and git context:
+
+   ```bash
+   gh auth status -h github.com
+   gh repo view --json nameWithOwner,defaultBranchRef,url
+   git status -sb
+   git branch --show-current
+   git remote -v
+   ```
+
+2. Protect default branches:
+   - If on `main`, `master`, `develop`, or `staging`, create a feature branch
+     before committing unless the user explicitly requested a release PR.
+   - Use branch prefix `codex/` unless the repo has a stronger convention.
+   - Never rewrite shared branch history.
+
+3. Inspect work before writing:
+
+   ```bash
+   git diff --stat
+   git diff --cached --stat
+   git log --oneline --decorate -10
+   ```
+
+   If unrelated files are present, list them and get approval before staging.
+
+4. Commit only after approval:
+
+   ```bash
+   git add <approved-paths>
+   git diff --staged --stat
+   git commit -m "<message>"
+   ```
+
+5. Build the PR body from evidence:
+   - Summary: what changed and why
+   - Changes: concise bullets grouped by behavior or subsystem
+   - Verification: exact checks run, or `Not run` with reason
+   - Risk: migrations, env vars, data changes, rollout notes
+   - Follow-ups: only real remaining work
+
+   Preserve useful existing body sections when updating an open PR.
+
+6. Find or create the PR:
+
+   ```bash
+   gh pr list --head <branch> --state open --json number,title,url,baseRefName
+   gh pr create --base <base> --head <branch> --draft --title "<title>" --body-file <body-file>
+   gh pr edit <number> --title "<title>" --body-file <body-file>
+   ```
+
+   Default to draft unless the user asked for ready review or the repo convention
+   clearly requires ready PRs.
+
+7. Push only after approval:
+
+   ```bash
+   git push -u origin <branch>
+   ```
+
+8. Report:
+   - PR URL
+   - Branch and base
+   - Draft/ready state
+   - Checks run
+   - Any required human action
+
+## PR Body Rules
+
+- Use real newlines via `--body-file`; do not pass escaped markdown inline.
+- Do not use `--fill` as the final body if the diff needs context.
+- Do not claim tests passed unless they were run in this session or clearly
+  visible from CI.
+- If the PR closes issues, include `Closes #123` only when the issue is truly
+  resolved by the PR.
+- If there is no meaningful body, write a short one; blank PR bodies rot.

--- a/skills/gh-pr-publish/plugin.json
+++ b/skills/gh-pr-publish/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-pr-publish",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Create or update GitHub pull requests with branch hygiene, PR body, checks, and safe push gates.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/gh-project-board/SKILL.md
+++ b/skills/gh-project-board/SKILL.md
@@ -1,0 +1,163 @@
+---
+name: gh-project-board
+description: "Configure GitHub Projects v2 kanban boards with Ship Shit Dev defaults: Status columns, Human Review and Deferred lanes, and P0-P3 Priority. Use when setting up, copying, auditing, or normalizing GitHub project boards."
+compatibility: Requires GitHub CLI gh with project scope. The bundled normalizer script runs with Node.js or Bun.
+disable-model-invocation: true
+allowed-tools: Bash(gh *) Bash(node *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, projects, kanban, triage"
+---
+
+# GH Project Board
+
+Set up GitHub Projects v2 boards so issues and PRs use a consistent kanban
+shape.
+
+## Contract
+
+Inputs:
+
+- GitHub owner login and project number, or permission to process every open
+  project for an owner
+- Optional new board title when copying the reference board
+- Optional exact Status and Priority option names
+
+Outputs:
+
+- Project field audit summary
+- Field normalization plan or applied status
+- Board-layout verification result
+
+Creates/Modifies:
+
+- May create or update GitHub Projects v2 single-select fields
+- May copy a GitHub Project when creating a new board
+- Does not delete project items
+
+External Side Effects:
+
+- Reads GitHub Projects metadata
+- Writes GitHub Projects field configuration only after approval
+- May create a new GitHub Project only after approval
+
+Confirmation Required:
+
+- Before running field normalization with `--apply`
+- Before copying a project
+- Before processing every open project for an owner
+- Before using `--exact`, because removed single-select options can clear item
+  values that used those options
+
+Delegates To:
+
+- `task-prd-creator` when board setup reveals missing task structure
+- `gh-fix-ci` when project automation depends on failing GitHub Actions
+
+## Canonical Board Shape
+
+Use GitHub Projects v2.
+
+- Board view layout: `BOARD_LAYOUT`
+- Kanban column field: `Status`
+- Status options: `Backlog`, `Todo`, `In Progress`, `Human Review`, `Done`,
+  `Deferred`
+- Priority field: `Priority`
+- Priority options: `P0 🔥`, `P1`, `P2`, `P3`
+
+The Ship Shit Dev reference board is
+`https://github.com/orgs/shipshitdev/projects/1`. Treat `Human Review` as the
+added approval lane even if an older copied board does not have it yet.
+
+## Workflow
+
+1. Verify GitHub CLI auth and project scope:
+
+   ```bash
+   gh auth status -h github.com
+   gh project list --owner <owner>
+   ```
+
+2. Inspect the reference board or target board:
+
+   ```bash
+   gh project view 1 --owner shipshitdev --format json
+   gh project field-list 1 --owner shipshitdev --format json
+   gh project view <number> --owner <owner> --format json
+   gh project field-list <number> --owner <owner> --format json
+   ```
+
+3. For a new board, prefer copying the reference board so the kanban view is
+   preserved:
+
+   ```bash
+   gh project copy 1 \
+     --source-owner shipshitdev \
+     --target-owner <owner> \
+     --title "<project title>" \
+     --format json
+   ```
+
+   Then normalize the copied board to add any missing approval lane:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --project <number> \
+     --apply
+   ```
+
+4. For an existing board, audit first:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --project <number>
+   ```
+
+5. Show the audit summary and get approval before applying:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --project <number> \
+     --apply
+   ```
+
+6. To audit every open project for an owner:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --all-open
+   ```
+
+   Apply to every open project only when the user explicitly asks:
+
+   ```bash
+   node skills/gh-project-board/scripts/setup-gh-project-board.mjs \
+     --owner <owner> \
+     --all-open \
+     --apply
+   ```
+
+## Normalizer Options
+
+- `--status "Todo,In Progress,Human Review,Done,Deferred"` overrides the
+  Status option list.
+- `--priority "P0,P1,P2,P3"` uses ASCII-only priority names.
+- `--exact` removes non-canonical options after explicit approval.
+- `--include-closed` includes closed projects when used with `--all-open`.
+
+## Rules
+
+- Treat `Human Review` as a `Status` column, not a label.
+- Preserve unknown Status or Priority options unless the user explicitly asks
+  for exact normalization.
+- Preserve existing option IDs when renaming or recoloring options so existing
+  item values remain attached.
+- If no board view exists, report the blocker. GitHub exposes project field
+  mutations through the public API, but not public mutations for creating a
+  board view; copy the reference board or create the board view in GitHub, then
+  rerun verification.
+- Do not apply changes to closed projects unless the user explicitly asks.

--- a/skills/gh-project-board/plugin.json
+++ b/skills/gh-project-board/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-project-board",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Configure GitHub Projects kanban boards with Status columns and P0-P3 Priority fields.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/gh-project-board/scripts/setup-gh-project-board.mjs
+++ b/skills/gh-project-board/scripts/setup-gh-project-board.mjs
@@ -1,0 +1,550 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+
+const DEFAULT_STATUS_OPTIONS = [
+  {
+    name: 'Backlog',
+    color: 'GRAY',
+    description: 'Not ready or not scheduled yet',
+  },
+  {
+    name: 'Todo',
+    color: 'GREEN',
+    description: "This item hasn't been started",
+  },
+  {
+    name: 'In Progress',
+    color: 'YELLOW',
+    description: 'This is actively being worked on',
+  },
+  {
+    name: 'Human Review',
+    color: 'BLUE',
+    description: 'Waiting for human review or approval',
+  },
+  {
+    name: 'Done',
+    color: 'PURPLE',
+    description: 'This has been completed',
+  },
+  {
+    name: 'Deferred',
+    color: 'GRAY',
+    description: 'Parked for later',
+  },
+];
+
+const DEFAULT_PRIORITY_OPTIONS = [
+  {
+    name: 'P0 🔥',
+    color: 'RED',
+    description: 'Critical priority',
+  },
+  {
+    name: 'P1',
+    color: 'ORANGE',
+    description: 'High priority',
+  },
+  {
+    name: 'P2',
+    color: 'YELLOW',
+    description: 'Normal priority',
+  },
+  {
+    name: 'P3',
+    color: 'GRAY',
+    description: 'Low priority',
+  },
+];
+
+const PROJECT_QUERY = `
+query($id: ID!) {
+  node(id: $id) {
+    ... on ProjectV2 {
+      id
+      title
+      url
+      closed
+      views(first: 20) {
+        nodes {
+          id
+          name
+          layout
+        }
+      }
+      fields(first: 100) {
+        nodes {
+          ... on ProjectV2Field {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2IterationField {
+            id
+            name
+            dataType
+          }
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            dataType
+            options {
+              id
+              name
+              color
+              description
+            }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+function parseArgs(argv) {
+  const args = {
+    apply: false,
+    allOpen: false,
+    exact: false,
+    includeClosed: false,
+    owner: '',
+    priority: '',
+    project: '',
+    status: '',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+
+    if (arg === '--apply') {
+      args.apply = true;
+    } else if (arg === '--all-open') {
+      args.allOpen = true;
+    } else if (arg === '--exact') {
+      args.exact = true;
+    } else if (arg === '--include-closed') {
+      args.includeClosed = true;
+    } else if (arg === '--owner') {
+      args.owner = readValue(argv, (index += 1), arg);
+    } else if (arg === '--project') {
+      args.project = readValue(argv, (index += 1), arg);
+    } else if (arg === '--status') {
+      args.status = readValue(argv, (index += 1), arg);
+    } else if (arg === '--priority') {
+      args.priority = readValue(argv, (index += 1), arg);
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.owner) {
+    fail('Missing required --owner <login>.');
+  }
+
+  if (!args.project && !args.allOpen) {
+    fail('Pass --project <number> or --all-open.');
+  }
+
+  if (args.project && args.allOpen) {
+    fail('Use either --project <number> or --all-open, not both.');
+  }
+
+  return args;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    fail(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node setup-gh-project-board.mjs --owner <owner> --project <number> [--apply]
+  node setup-gh-project-board.mjs --owner <owner> --all-open [--apply]
+
+Options:
+  --status "Backlog,Todo,In Progress,Human Review,Done,Deferred"
+  --priority "P0 🔥,P1,P2,P3"
+  --exact             Remove non-canonical options after approval.
+  --include-closed    Include closed projects when processing all projects.
+
+Dry-run is the default. Use --apply to write GitHub Projects fields.
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function gh(args) {
+  try {
+    return execFileSync('gh', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const stderr = error.stderr ? String(error.stderr).trim() : '';
+    const detail = stderr || error.message;
+    fail(`gh ${args.join(' ')} failed:\n${detail}`);
+  }
+}
+
+function ghJson(args) {
+  const output = gh(args);
+  return output ? JSON.parse(output) : {};
+}
+
+function graphql(query, variables = {}) {
+  const args = ['api', 'graphql', '-f', `query=${query}`];
+  for (const [key, value] of Object.entries(variables)) {
+    args.push('-F', `${key}=${value}`);
+  }
+  return ghJson(args);
+}
+
+function listProjects(owner, includeClosed) {
+  const args = [
+    'project',
+    'list',
+    '--owner',
+    owner,
+    '--format',
+    'json',
+    '--limit',
+    '100',
+  ];
+
+  if (includeClosed) {
+    args.push('--closed');
+  }
+
+  const response = ghJson(args);
+  return response.projects ?? [];
+}
+
+function projectSummary(owner, number) {
+  return ghJson(['project', 'view', String(number), '--owner', owner, '--format', 'json']);
+}
+
+function projectDetails(projectId) {
+  const response = graphql(PROJECT_QUERY, { id: projectId });
+  const project = response.data?.node;
+  if (!project) {
+    fail(`Could not load project node ${projectId}.`);
+  }
+  return project;
+}
+
+function optionsFromCsv(value, defaults) {
+  if (!value) {
+    return defaults;
+  }
+
+  return value
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean)
+    .map((name) => {
+      const fallback = defaults.find((option) => normalizeOptionName(option.name) === normalizeOptionName(name));
+      return {
+        name,
+        color: fallback?.color ?? 'GRAY',
+        description: fallback?.description ?? '',
+      };
+    });
+}
+
+function normalizeOptionName(name) {
+  return name
+    .normalize('NFKD')
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, '');
+}
+
+function fieldByName(fields, name) {
+  return fields.find((field) => field.name === name);
+}
+
+function buildPlan(field, fieldName, desiredOptions, exact) {
+  if (!field) {
+    return {
+      action: 'create',
+      fieldName,
+      fieldId: '',
+      desiredOptions,
+      missingOptions: desiredOptions.map((option) => option.name),
+      renamedOptions: [],
+      preservedOptions: [],
+      changed: true,
+      error: '',
+    };
+  }
+
+  if (field.dataType !== 'SINGLE_SELECT') {
+    return {
+      action: 'blocked',
+      fieldName,
+      fieldId: field.id,
+      desiredOptions: [],
+      missingOptions: [],
+      renamedOptions: [],
+      preservedOptions: [],
+      changed: false,
+      error: `${fieldName} exists but is ${field.dataType}, not SINGLE_SELECT.`,
+    };
+  }
+
+  const existingOptions = field.options ?? [];
+  const usedOptionIndexes = new Set();
+  const mergedOptions = [];
+  const missingOptions = [];
+  const renamedOptions = [];
+
+  for (const desired of desiredOptions) {
+    const matchIndex = existingOptions.findIndex(
+      (option, index) =>
+        !usedOptionIndexes.has(index) &&
+        normalizeOptionName(option.name) === normalizeOptionName(desired.name)
+    );
+
+    if (matchIndex === -1) {
+      missingOptions.push(desired.name);
+      mergedOptions.push(desired);
+      continue;
+    }
+
+    usedOptionIndexes.add(matchIndex);
+    const existing = existingOptions[matchIndex];
+    if (existing.name !== desired.name) {
+      renamedOptions.push(`${existing.name} -> ${desired.name}`);
+    }
+
+    mergedOptions.push({
+      id: existing.id,
+      name: desired.name,
+      color: existing.color,
+      description: existing.description ?? '',
+    });
+  }
+
+  const preservedOptions = [];
+  if (!exact) {
+    for (const [index, option] of existingOptions.entries()) {
+      if (!usedOptionIndexes.has(index)) {
+        preservedOptions.push(option.name);
+        mergedOptions.push(option);
+      }
+    }
+  }
+
+  return {
+    action: 'update',
+    fieldName,
+    fieldId: field.id,
+    desiredOptions: mergedOptions,
+    missingOptions,
+    renamedOptions,
+    preservedOptions,
+    changed: optionsChanged(existingOptions, mergedOptions),
+    error: '',
+  };
+}
+
+function optionsChanged(existingOptions, desiredOptions) {
+  const serialize = (options) =>
+    options.map((option) => ({
+      id: option.id ?? '',
+      name: option.name,
+      color: option.color,
+      description: option.description ?? '',
+    }));
+
+  return JSON.stringify(serialize(existingOptions)) !== JSON.stringify(serialize(desiredOptions));
+}
+
+function graphQlString(value) {
+  return JSON.stringify(value);
+}
+
+function optionsInput(options) {
+  return `[${options
+    .map((option) => {
+      const id = option.id ? `id: ${graphQlString(option.id)}, ` : '';
+      return `{ ${id}name: ${graphQlString(option.name)}, color: ${option.color}, description: ${graphQlString(
+        option.description ?? ''
+      )} }`;
+    })
+    .join(', ')}]`;
+}
+
+function createSingleSelectField(projectId, plan) {
+  const mutation = `
+mutation {
+  createProjectV2Field(input: {
+    projectId: ${graphQlString(projectId)}
+    dataType: SINGLE_SELECT
+    name: ${graphQlString(plan.fieldName)}
+    singleSelectOptions: ${optionsInput(plan.desiredOptions)}
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+      }
+    }
+  }
+}`;
+
+  graphql(mutation);
+}
+
+function updateSingleSelectField(plan) {
+  const mutation = `
+mutation {
+  updateProjectV2Field(input: {
+    fieldId: ${graphQlString(plan.fieldId)}
+    singleSelectOptions: ${optionsInput(plan.desiredOptions)}
+  }) {
+    projectV2Field {
+      ... on ProjectV2SingleSelectField {
+        id
+        name
+      }
+    }
+  }
+}`;
+
+  graphql(mutation);
+}
+
+function boardViewNames(project) {
+  return (project.views?.nodes ?? [])
+    .filter((view) => view.layout === 'BOARD_LAYOUT')
+    .map((view) => view.name);
+}
+
+function printPlan(plan) {
+  if (plan.error) {
+    process.stdout.write(`  ${plan.fieldName}: BLOCKED - ${plan.error}\n`);
+    return;
+  }
+
+  if (plan.action === 'create') {
+    process.stdout.write(`  ${plan.fieldName}: create with ${formatNames(plan.desiredOptions)}\n`);
+    return;
+  }
+
+  if (!plan.changed) {
+    process.stdout.write(`  ${plan.fieldName}: already matches\n`);
+    return;
+  }
+
+  process.stdout.write(`  ${plan.fieldName}: update to ${formatNames(plan.desiredOptions)}\n`);
+  if (plan.missingOptions.length > 0) {
+    process.stdout.write(`    add: ${plan.missingOptions.join(', ')}\n`);
+  }
+  if (plan.renamedOptions.length > 0) {
+    process.stdout.write(`    rename: ${plan.renamedOptions.join(', ')}\n`);
+  }
+  if (plan.preservedOptions.length > 0) {
+    process.stdout.write(`    preserve extra: ${plan.preservedOptions.join(', ')}\n`);
+  }
+}
+
+function formatNames(options) {
+  return options.map((option) => option.name).join(', ');
+}
+
+function normalizeProject(owner, number, options) {
+  const summary = projectSummary(owner, number);
+  const project = projectDetails(summary.id);
+  const fields = project.fields?.nodes ?? [];
+  const statusPlan = buildPlan(
+    fieldByName(fields, 'Status'),
+    'Status',
+    options.statusOptions,
+    options.exact
+  );
+  const priorityPlan = buildPlan(
+    fieldByName(fields, 'Priority'),
+    'Priority',
+    options.priorityOptions,
+    options.exact
+  );
+  const boardViews = boardViewNames(project);
+  const plans = [statusPlan, priorityPlan];
+  const blocked = plans.filter((plan) => plan.error);
+  const changed = plans.filter((plan) => !plan.error && plan.changed);
+
+  process.stdout.write(`\n${project.title} (#${number})\n`);
+  process.stdout.write(`${project.url}\n`);
+  process.stdout.write(
+    `  Board view: ${boardViews.length > 0 ? `yes (${boardViews.join(', ')})` : 'missing'}\n`
+  );
+
+  for (const plan of plans) {
+    printPlan(plan);
+  }
+
+  if (boardViews.length === 0) {
+    process.stdout.write(
+      '  warning: field normalization cannot create a board view through the public GitHub Projects API\n'
+    );
+  }
+
+  if (blocked.length > 0) {
+    process.exitCode = 2;
+    return;
+  }
+
+  if (!options.apply) {
+    if (changed.length > 0) {
+      process.stdout.write('  dry-run: rerun with --apply to write these field changes\n');
+    }
+    return;
+  }
+
+  for (const plan of changed) {
+    if (plan.action === 'create') {
+      createSingleSelectField(project.id, plan);
+    } else if (plan.action === 'update') {
+      updateSingleSelectField(plan);
+    }
+  }
+
+  process.stdout.write(`  applied: ${changed.length} field change(s)\n`);
+}
+
+const args = parseArgs(process.argv.slice(2));
+const statusOptions = optionsFromCsv(args.status, DEFAULT_STATUS_OPTIONS);
+const priorityOptions = optionsFromCsv(args.priority, DEFAULT_PRIORITY_OPTIONS);
+
+if (args.allOpen) {
+  const projects = listProjects(args.owner, args.includeClosed).filter(
+    (project) => args.includeClosed || !project.closed
+  );
+
+  for (const project of projects) {
+    normalizeProject(args.owner, project.number, {
+      apply: args.apply,
+      exact: args.exact,
+      priorityOptions,
+      statusOptions,
+    });
+  }
+} else {
+  normalizeProject(args.owner, args.project, {
+    apply: args.apply,
+    exact: args.exact,
+    priorityOptions,
+    statusOptions,
+  });
+}

--- a/skills/gh-review-suggestions/SKILL.md
+++ b/skills/gh-review-suggestions/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: gh-review-suggestions
+description: "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks. Use when asked to review a PR, leave actionable GitHub comments, propose applyable fixes, or submit review suggestions through gh."
+compatibility: Requires GitHub CLI gh access to the repository. The bundled diff-line helper runs with Node.js or Bun.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *) Bash(node *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, pull-requests, review, suggestions"
+---
+
+# GH Review Suggestions
+
+Review a GitHub PR and post inline comments only when the suggestion is safe,
+specific, and directly applyable.
+
+## Contract
+
+Inputs:
+
+- PR URL or number
+- Optional target files, review scope, and severity threshold
+
+Outputs:
+
+- Findings grouped by severity
+- Inline suggestion draft bodies
+- Posted review comment URLs after approval
+
+Creates/Modifies:
+
+- Does not modify local files by default
+- May post GitHub review comments after approval
+
+External Side Effects:
+
+- Reads PR metadata and diffs
+- Posts GitHub PR review comments only after approval
+
+Confirmation Required:
+
+- Before posting inline comments
+- Before submitting an approve/request-changes review
+- Before checking out or modifying the PR branch
+
+Delegates To:
+
+- `code-review` for local bug-focused review
+- `gh-address-comments` when addressing existing review feedback
+- `gh-fix-ci` when failing checks explain the review finding
+
+## Workflow
+
+1. Verify context:
+
+   ```bash
+   gh auth status -h github.com
+   gh pr view <pr> --json number,title,url,headRefOid,commits,files,reviewDecision
+   gh pr diff <pr> > /tmp/pr.diff
+   ```
+
+2. Review changed files, not the whole repository. Focus on:
+   - Bugs and behavioral regressions
+   - Security and data-isolation failures
+   - Broken tests or missing coverage for changed behavior
+   - Simple code corrections that GitHub suggestions can apply cleanly
+
+3. Use inline suggestions only for mechanical, local changes:
+
+   ````markdown
+   Explain why this concrete change is needed.
+
+   ```suggestion
+   replacement code
+   ```
+   ````
+
+   Use normal comments for architecture, product, design, or multi-file changes.
+
+4. Validate the target line is in the PR diff:
+
+   ```bash
+   node skills/gh-review-suggestions/scripts/diff-line-position.mjs \
+     --diff /tmp/pr.diff \
+     --path src/example.ts \
+     --line 42
+   ```
+
+5. Draft comments and get approval before posting.
+
+6. Prefer modern `line`/`side` API fields when posting comments:
+
+   ```bash
+   COMMIT_ID="$(gh pr view <pr> --json commits --jq '.commits[-1].oid')"
+   gh api \
+     --method POST \
+     /repos/<owner>/<repo>/pulls/<pr>/comments \
+     -f body="$(cat /tmp/comment.md)" \
+     -f commit_id="$COMMIT_ID" \
+     -f path="src/example.ts" \
+     -F line=42 \
+     -f side=RIGHT
+   ```
+
+   If targeting an older GitHub Enterprise instance that requires `position`,
+   use the helper output's `position` field.
+
+7. Summarize what was posted:
+   - Finding severity
+   - File and line
+   - Comment URL if returned
+   - Any findings intentionally left as summary-only comments
+
+## Rules
+
+- Do not post style-only comments unless the repo has an explicit style rule.
+- Do not post overlapping suggestions on the same lines.
+- Do not suggest generated lockfile or bundle changes unless the generated file
+  is the source of truth.
+- Do not request changes for speculative concerns. Ask a question or leave a
+  non-blocking comment instead.
+- If there are more than five comments, group low-priority notes into one
+  summary comment to avoid review noise.

--- a/skills/gh-review-suggestions/plugin.json
+++ b/skills/gh-review-suggestions/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "gh-review-suggestions",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Review GitHub PRs and post precise inline suggested changes with safe GitHub suggestion blocks.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/gh-review-suggestions/scripts/diff-line-position.mjs
+++ b/skills/gh-review-suggestions/scripts/diff-line-position.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'node:fs';
+
+function parseArgs(argv) {
+  const args = {
+    diff: '',
+    line: 0,
+    path: '',
+    side: 'RIGHT',
+  };
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    if (arg === '--diff') {
+      args.diff = readValue(argv, (index += 1), arg);
+    } else if (arg === '--line') {
+      args.line = Number.parseInt(readValue(argv, (index += 1), arg), 10);
+    } else if (arg === '--path') {
+      args.path = readValue(argv, (index += 1), arg);
+    } else if (arg === '--side') {
+      args.side = readValue(argv, (index += 1), arg).toUpperCase();
+    } else if (arg === '--help' || arg === '-h') {
+      printHelp();
+      process.exit(0);
+    } else {
+      fail(`Unknown argument: ${arg}`);
+    }
+  }
+
+  if (!args.path) {
+    fail('Missing required --path <file>.');
+  }
+  if (!Number.isInteger(args.line) || args.line <= 0) {
+    fail('Missing required --line <positive-number>.');
+  }
+  if (args.side !== 'RIGHT' && args.side !== 'LEFT') {
+    fail('--side must be RIGHT or LEFT.');
+  }
+
+  return args;
+}
+
+function readValue(argv, index, flag) {
+  const value = argv[index];
+  if (!value || value.startsWith('--')) {
+    fail(`Missing value for ${flag}.`);
+  }
+  return value;
+}
+
+function printHelp() {
+  process.stdout.write(`Usage:
+  node diff-line-position.mjs --diff /tmp/pr.diff --path src/file.ts --line 42 [--side RIGHT]
+
+If --diff is omitted, reads the diff from stdin.
+Outputs JSON with path, line, side, and deprecated diff position.
+`);
+}
+
+function fail(message) {
+  process.stderr.write(`${message}\n`);
+  process.exit(1);
+}
+
+function readDiff(path) {
+  if (path) {
+    return readFileSync(path, 'utf8');
+  }
+  return readFileSync(0, 'utf8');
+}
+
+function normalizePath(path) {
+  return path.replace(/^["']|["']$/g, '').replace(/^[ab]\//, '');
+}
+
+function parseHunkHeader(line) {
+  const match = line.match(/^@@ -(\d+)(?:,\d+)? \+(\d+)(?:,\d+)? @@/);
+  if (!match) {
+    return null;
+  }
+  return {
+    oldLine: Number.parseInt(match[1], 10),
+    newLine: Number.parseInt(match[2], 10),
+  };
+}
+
+function findPosition(diff, targetPath, targetLine, targetSide) {
+  let currentPath = '';
+  let oldLine = 0;
+  let newLine = 0;
+  let position = 0;
+  let inTargetFile = false;
+  let inHunk = false;
+
+  for (const rawLine of diff.split(/\r?\n/)) {
+    if (rawLine.startsWith('diff --git ')) {
+      currentPath = '';
+      inTargetFile = false;
+      inHunk = false;
+      position = 0;
+      continue;
+    }
+
+    if (rawLine.startsWith('+++ ')) {
+      const filePath = normalizePath(rawLine.slice(4).trim());
+      if (filePath !== '/dev/null') {
+        currentPath = filePath;
+        inTargetFile = currentPath === targetPath;
+      }
+      continue;
+    }
+
+    const hunk = parseHunkHeader(rawLine);
+    if (hunk) {
+      oldLine = hunk.oldLine;
+      newLine = hunk.newLine;
+      inHunk = inTargetFile;
+      continue;
+    }
+
+    if (!inHunk) {
+      continue;
+    }
+
+    const marker = rawLine[0] ?? '';
+    if (marker !== '\\') {
+      position += 1;
+    }
+
+    if (marker === '+') {
+      if (targetSide === 'RIGHT' && newLine === targetLine) {
+        return position;
+      }
+      newLine += 1;
+    } else if (marker === '-') {
+      if (targetSide === 'LEFT' && oldLine === targetLine) {
+        return position;
+      }
+      oldLine += 1;
+    } else {
+      if (targetSide === 'RIGHT' && newLine === targetLine) {
+        return position;
+      }
+      if (targetSide === 'LEFT' && oldLine === targetLine) {
+        return position;
+      }
+      oldLine += 1;
+      newLine += 1;
+    }
+  }
+
+  return null;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const diff = readDiff(args.diff);
+const normalizedPath = normalizePath(args.path);
+const position = findPosition(diff, normalizedPath, args.line, args.side);
+
+if (position === null) {
+  fail(`Line ${args.line} on ${args.side} side of ${normalizedPath} was not found in the diff.`);
+}
+
+process.stdout.write(
+  `${JSON.stringify({
+    path: normalizedPath,
+    line: args.line,
+    side: args.side,
+    position,
+  })}\n`
+);

--- a/skills/github-actions-author/SKILL.md
+++ b/skills/github-actions-author/SKILL.md
@@ -1,0 +1,122 @@
+---
+name: github-actions-author
+description: "Author, review, and harden GitHub Actions workflows using current official documentation, secure trigger patterns, least-privilege permissions, current action versions, and CI/CD validation. Use when creating, editing, debugging, or security-reviewing workflow YAML."
+compatibility: Requires access to GitHub Actions documentation for version-sensitive guidance. Uses git and gh when validating repository workflows.
+disable-model-invocation: true
+allowed-tools: Bash(git *) Bash(gh *) Bash(bun *)
+metadata:
+  version: "1.0.0"
+  tags: "github, actions, ci-cd, workflows, security"
+---
+
+# GitHub Actions Author
+
+Create and review GitHub Actions workflows with current docs and secure
+defaults.
+
+## Contract
+
+Inputs:
+
+- Repository root or target workflow file
+- Desired workflow behavior, triggers, runtimes, and deployment target
+- Optional secrets, environments, runner constraints, and matrix strategy
+
+Outputs:
+
+- Workflow YAML or patch summary
+- Documentation-backed rationale for non-obvious choices
+- Security and validation checklist
+
+Creates/Modifies:
+
+- May create or edit `.github/workflows/*.yml`
+- Does not add secrets or deploy without approval
+
+External Side Effects:
+
+- Reads official GitHub documentation when syntax, permissions, or product
+  behavior may have changed
+- May query workflow metadata with GitHub CLI
+- Does not dispatch, rerun, or cancel workflows without approval
+
+Confirmation Required:
+
+- Before writing workflow files when requirements are unclear
+- Before adding deployment, release, publish, or secret-consuming behavior
+- Before dispatching or rerunning workflows
+
+Delegates To:
+
+- `testing-cicd-init` for first-pass TypeScript test infrastructure
+- `gh-fix-ci` when a workflow is failing on a PR
+- `git-safety` when workflows touch credentials, tokens, or publish steps
+
+## Workflow
+
+1. Discover existing CI shape:
+
+   ```bash
+   find .github/workflows -maxdepth 1 -type f 2>/dev/null
+   gh workflow list
+   git status -sb
+   ```
+
+2. Read relevant local context:
+   - Existing workflow files
+   - `package.json`, lockfiles, workspace config, test scripts
+   - Deployment docs or release conventions
+
+3. Ground version-sensitive choices in official GitHub docs:
+   - Workflow syntax, triggers, contexts, expressions
+   - `GITHUB_TOKEN` permissions
+   - `pull_request` vs `pull_request_target`
+   - OIDC, environments, deployment protection rules
+   - Cache, artifacts, reusable workflows, matrices, concurrency
+
+4. Check action versions before adding or bumping common actions:
+
+   ```bash
+   gh release view --repo actions/checkout --json tagName --jq '.tagName'
+   gh release view --repo actions/setup-node --json tagName --jq '.tagName'
+   gh release view --repo oven-sh/setup-bun --json tagName --jq '.tagName'
+   ```
+
+5. Author with safe defaults:
+   - Pin permissions at workflow or job level; default to `contents: read`.
+   - Use `pull_request` for untrusted code. Use `pull_request_target` only for
+     metadata/comment workflows that do not check out or execute fork code.
+   - Pass untrusted event data through environment variables before shell use.
+   - Use `concurrency` for expensive or deploy workflows.
+   - Use cache keys that include lockfile hashes.
+   - Avoid printing secrets or full tokens.
+   - Separate CI, release, and deployment workflows when permissions differ.
+
+6. Validate locally when possible:
+
+   ```bash
+   git diff -- .github/workflows
+   gh workflow view <workflow-name-or-id> --yaml
+   ```
+
+   Run `actionlint` if already installed. Do not install new global tools unless
+   the user asks.
+
+7. Final output:
+   - Files changed
+   - Trigger behavior
+   - Permissions and secret boundaries
+   - Validation performed
+   - Remaining manual setup such as secrets or environments
+
+## Security Review Checklist
+
+- No hardcoded secrets, tokens, credentials, or private URLs.
+- Job permissions are minimal and explicit.
+- Fork PRs cannot access secrets or execute trusted-token publish paths.
+- Shell steps quote variables and avoid direct interpolation of issue/PR text.
+- Third-party actions are current and reputable; pin to SHA for sensitive
+  workflows or untrusted supply-chain surfaces.
+- Deployment jobs use environments when human approval or environment-scoped
+  secrets are needed.
+- Release/publish jobs run only on trusted refs or signed/manual dispatch paths.

--- a/skills/github-actions-author/plugin.json
+++ b/skills/github-actions-author/plugin.json
@@ -1,7 +1,7 @@
 {
-  "name": "commit-summary",
+  "name": "github-actions-author",
   "version": "1.0.0",
-  "description": "Generate Conventional Commit messages, split logical changes, and create commits after approval.",
+  "description": "Author and harden GitHub Actions workflows with secure triggers, permissions, and docs-backed guidance.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/redis-caching/SKILL.md
+++ b/skills/redis-caching/SKILL.md
@@ -1,0 +1,298 @@
+---
+name: redis-caching
+description: "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications."
+metadata:
+  version: "1.0.0"
+  tags: "redis, caching, rate-limiting, sessions, prisma, nestjs, nextjs"
+---
+
+# Redis Caching
+
+Implement Redis as a production support layer, not as a second database.
+
+## When to Use
+
+- Add cache-aside or write-through caching around Prisma or API reads.
+- Protect expensive routes with rate limiting.
+- Store short-lived sessions, verification state, locks, or counters.
+- Add pub/sub or stream-backed event fanout.
+- Review Redis key design, TTLs, invalidation, or connection handling.
+
+For BullMQ job queue architecture, use `nestjs-queue-architect` instead of duplicating queue patterns here.
+
+## First Decisions
+
+1. Choose the runtime.
+   - Long-lived Node.js or NestJS process: use `ioredis`.
+   - Serverless or edge runtime: prefer the Upstash Redis SDK or REST API.
+   - Background jobs: use BullMQ guidance from `nestjs-queue-architect`.
+2. Define the cache contract before coding.
+   - Source of truth: Prisma/database, upstream API, computed result, or session authority.
+   - Freshness: hard TTL, stale-while-revalidate, explicit invalidation, or write-through.
+   - Failure mode: fail open for cache reads, fail closed for auth/session/rate-limit writes.
+3. Design keys and invalidation together.
+   - Namespace every key: `app:env:entity:id:variant`.
+   - Keep keys stable and inspectable.
+   - Add TTLs to every cache, lock, session, and rate-limit key.
+
+## Installation
+
+```bash
+bun add ioredis
+
+# Optional serverless Redis
+bun add @upstash/redis @upstash/ratelimit
+```
+
+Use one Redis client per process. Do not create a new TCP client per request.
+
+```typescript
+import Redis from "ioredis";
+
+declare global {
+  var redisClient: Redis | undefined;
+}
+
+export const redis =
+  globalThis.redisClient ??
+  new Redis(process.env.REDIS_URL ?? "redis://localhost:6379", {
+    enableReadyCheck: true,
+    lazyConnect: true,
+    maxRetriesPerRequest: 3,
+    retryStrategy(attempt) {
+      return Math.min(attempt * 50, 2_000);
+    },
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalThis.redisClient = redis;
+}
+```
+
+Wire `error`, `connect`, and `reconnecting` events into the app logger or APM. Avoid logging credentials from connection URLs.
+
+## Cache-Aside With Prisma
+
+Use cache-aside for reads where brief staleness is acceptable.
+
+```typescript
+type CacheOptions = {
+  ttlSeconds: number;
+  jitterSeconds?: number;
+};
+
+const json = {
+  encode(value: unknown) {
+    return JSON.stringify(value);
+  },
+  decode<T>(value: string): T {
+    return JSON.parse(value) as T;
+  },
+};
+
+function withJitter(ttlSeconds: number, jitterSeconds = 30) {
+  return ttlSeconds + Math.floor(Math.random() * jitterSeconds);
+}
+
+export async function getCached<T>(
+  key: string,
+  load: () => Promise<T>,
+  options: CacheOptions,
+): Promise<T> {
+  const cached = await redis.get(key);
+  if (cached !== null) {
+    return json.decode<T>(cached);
+  }
+
+  const value = await load();
+  const ttl = withJitter(options.ttlSeconds, options.jitterSeconds);
+  await redis.set(key, json.encode(value), "EX", ttl);
+  return value;
+}
+```
+
+Example around Prisma:
+
+```typescript
+export async function getWorkspace(workspaceId: string) {
+  return getCached(
+    `app:prod:workspace:${workspaceId}`,
+    () =>
+      prisma.workspace.findUniqueOrThrow({
+        where: { id: workspaceId },
+        select: { id: true, name: true, plan: true, updatedAt: true },
+      }),
+    { ttlSeconds: 300, jitterSeconds: 60 },
+  );
+}
+```
+
+## Stampede Protection
+
+Protect hot keys with a short lock. Keep the lock TTL small and release it only if this process owns the token.
+
+```typescript
+import { randomUUID } from "node:crypto";
+
+const RELEASE_LOCK = `
+if redis.call("GET", KEYS[1]) == ARGV[1] then
+  return redis.call("DEL", KEYS[1])
+end
+return 0
+`;
+
+export async function getCachedWithLock<T>(
+  key: string,
+  load: () => Promise<T>,
+  options: CacheOptions,
+): Promise<T> {
+  const cached = await redis.get(key);
+  if (cached !== null) {
+    return json.decode<T>(cached);
+  }
+
+  const lockKey = `lock:${key}`;
+  const token = randomUUID();
+  const locked = await redis.set(lockKey, token, "EX", 10, "NX");
+
+  if (locked === "OK") {
+    try {
+      const value = await load();
+      await redis.set(key, json.encode(value), "EX", withJitter(options.ttlSeconds));
+      return value;
+    } finally {
+      await redis.eval(RELEASE_LOCK, 1, lockKey, token);
+    }
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, 75));
+  const retry = await redis.get(key);
+  if (retry !== null) {
+    return json.decode<T>(retry);
+  }
+
+  return load();
+}
+```
+
+## Invalidation
+
+Prefer direct invalidation for known keys. Use tag sets when one mutation affects many keys.
+
+```typescript
+export async function cacheSetWithTags(
+  key: string,
+  value: unknown,
+  tags: string[],
+  ttlSeconds: number,
+) {
+  const pipeline = redis.pipeline();
+  pipeline.set(key, json.encode(value), "EX", ttlSeconds);
+
+  for (const tag of tags) {
+    const tagKey = `cachetag:${tag}`;
+    pipeline.sadd(tagKey, key);
+    pipeline.expire(tagKey, ttlSeconds + 60);
+  }
+
+  await pipeline.exec();
+}
+
+export async function invalidateTag(tag: string) {
+  const tagKey = `cachetag:${tag}`;
+  const keys = await redis.smembers(tagKey);
+  if (keys.length > 0) {
+    await redis.unlink(...keys);
+  }
+  await redis.del(tagKey);
+}
+```
+
+Use `SCAN` instead of `KEYS` for emergency pattern cleanup. Do not put pattern invalidation on hot request paths.
+
+## Rate Limiting
+
+Use sorted sets for sliding-window limits when exactness matters.
+
+```typescript
+import { randomUUID } from "node:crypto";
+
+type RateLimitResult = {
+  allowed: boolean;
+  limit: number;
+  remaining: number;
+  resetAt: Date;
+};
+
+export async function slidingWindowRateLimit(
+  subject: string,
+  limit: number,
+  windowSeconds: number,
+): Promise<RateLimitResult> {
+  const key = `ratelimit:${subject}`;
+  const now = Date.now();
+  const windowStart = now - windowSeconds * 1_000;
+  const member = `${now}:${randomUUID()}`;
+
+  const results = await redis
+    .multi()
+    .zremrangebyscore(key, 0, windowStart)
+    .zadd(key, now, member)
+    .zcard(key)
+    .pexpire(key, windowSeconds * 1_000)
+    .exec();
+
+  const count = Number(results?.[2]?.[1] ?? 0);
+
+  return {
+    allowed: count <= limit,
+    limit,
+    remaining: Math.max(limit - count, 0),
+    resetAt: new Date(now + windowSeconds * 1_000),
+  };
+}
+```
+
+For public traffic, set response headers: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `Retry-After`.
+
+## Sessions And Verification State
+
+- Store opaque session IDs or token hashes, not raw JWTs or long-lived secrets.
+- Set TTL on every session key.
+- Regenerate sessions after privilege changes.
+- Delete sessions on logout, account deletion, and password reset.
+- Treat Redis write failure as auth failure for login, logout, MFA, and password reset flows.
+
+```typescript
+type SessionRecord = {
+  userId: string;
+  workspaceId: string;
+  issuedAt: string;
+};
+
+export async function createSession(sessionId: string, session: SessionRecord) {
+  await redis.set(
+    `session:${sessionId}`,
+    json.encode(session),
+    "EX",
+    60 * 60 * 24 * 7,
+  );
+}
+```
+
+## Pub/Sub And Streams
+
+- Use pub/sub for ephemeral fanout where missed messages are acceptable.
+- Use streams when consumers need replay, backpressure, or durable delivery.
+- Keep payloads small; store large objects elsewhere and publish IDs.
+- Add consumer observability: lag, dead letters, retries, and handler errors.
+
+## Production Checklist
+
+- [ ] All cache, lock, session, and rate-limit keys have TTLs.
+- [ ] Cache reads fail open where possible; auth and rate-limit writes fail closed.
+- [ ] Hot keys use TTL jitter or stampede protection.
+- [ ] No request path uses `KEYS`, unbounded `SMEMBERS`, or large `HGETALL`.
+- [ ] Invalidation is tested alongside the write path.
+- [ ] Redis metrics cover latency, hit rate, memory, evictions, blocked clients, and reconnects.
+- [ ] Local tests cover cache hit, cache miss, Redis down, invalidation, and rate-limit exceeded.

--- a/skills/redis-caching/plugin.json
+++ b/skills/redis-caching/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "redis-caching",
+  "version": "1.0.0",
+  "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}


### PR DESCRIPTION
Adds a production-focused Redis caching skill after checking current skills.sh Redis and Upstash coverage.\n\nIncludes:\n- Redis cache-aside, stampede lock, tag invalidation, rate limiting, session, pub/sub, and stream guidance\n- Infrastructure bundle and marketplace wiring\n- Skill count updates to 170\n\nCloses #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added 6 new GitHub workflow skills: inbox management, pull request publishing, project board configuration, pull request review suggestions, GitHub Actions authoring, and release gating.
  * Added Redis caching skill with patterns for cache-aside, rate limiting, sessions, and pub/sub for production applications.
  * Enhanced commit summarization with Conventional Commits message generation.
  * Skill library expanded to 170 total skills.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->