### PR TITLE
feat(skills): add release-cleanup + port 4 spec-pipeline skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "170 AI agent skills for indie developers building startups",
+  "description": "171 AI agent skills for indie developers building startups",
   "plugins": [
     {
       "name": "shipshitdev-startup",
@@ -719,6 +719,11 @@
       "name": "refactor-code",
       "source": "./skills/refactor-code",
       "description": "Systematic approach to safely refactoring code with tests. Use when user says 'refactor', 'clean up "
+    },
+    {
+      "name": "release-cleanup",
+      "source": "./skills/release-cleanup",
+      "description": "Verify a release was fully promoted through develop, staging, and master/main, then prune merged loc"
     },
     {
       "name": "release-pr-gates",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "171 AI agent skills for indie developers building startups",
+  "description": "175 AI agent skills for indie developers building startups",
   "plugins": [
     {
       "name": "shipshitdev-startup",
@@ -261,6 +261,11 @@
       "description": "Recognize, diagnose, and mitigate patterns of context degradation in agent systems. Use when context"
     },
     {
+      "name": "context-engineering",
+      "source": "./skills/context-engineering",
+      "description": "Supplementary context protocol for agents executing in a repo that has a CLAUDE.md / AGENTS.md (or e"
+    },
+    {
       "name": "context-fundamentals",
       "source": "./skills/context-fundamentals",
       "description": "Understand the components, mechanics, and constraints of context in agent systems. Use when designin"
@@ -364,6 +369,11 @@
       "name": "execution-accelerator",
       "source": "./skills/execution-accelerator",
       "description": "Use this skill when users are stuck on a decision, overthinking, experiencing analysis paralysis, or"
+    },
+    {
+      "name": "execution-debugging",
+      "source": "./skills/execution-debugging",
+      "description": "Scoped debugging methodology for when a test or build fails during execution/stabilization. Use to d"
     },
     {
       "name": "execution-validator",
@@ -644,6 +654,11 @@
       "name": "positioning-angles",
       "source": "./skills/positioning-angles",
       "description": "Use this skill when users need to find their unique marketing angle, differentiate from competitors,"
+    },
+    {
+      "name": "prd-quality-gate",
+      "source": "./skills/prd-quality-gate",
+      "description": "PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) conta"
     },
     {
       "name": "pricing-strategist",
@@ -929,6 +944,11 @@
       "name": "workspace-performance-audit",
       "source": "./skills/workspace-performance-audit",
       "description": "Orchestrates comprehensive performance audits across full-stack monorepos. Coordinates performance-e"
+    },
+    {
+      "name": "writing-prds",
+      "source": "./skills/writing-prds",
+      "description": "Use when the user wants to draft, scope, or formalize a feature — \"write a PRD for X\", \"let's plan X"
     },
     {
       "name": "x-algorithm-optimizer",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "175 AI agent skills for indie developers building startups",
+  "description": "181 AI agent skills for indie developers building startups",
   "plugins": [
     {
       "name": "shipshitdev-startup",
@@ -401,6 +401,11 @@
       "description": "Use this skill when users need help with business finances, tax planning, bookkeeping, profit/loss a"
     },
     {
+      "name": "finishing-a-development-branch",
+      "source": "./skills/finishing-a-development-branch",
+      "description": ">-"
+    },
+    {
       "name": "frontend-design",
       "source": "./skills/frontend-design",
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill wh"
@@ -726,6 +731,11 @@
       "description": "React Testing Library best practices for writing maintainable, user-centric tests. Use when writing,"
     },
     {
+      "name": "receiving-code-review",
+      "source": "./skills/receiving-code-review",
+      "description": ">-"
+    },
+    {
       "name": "redis-caching",
       "source": "./skills/redis-caching",
       "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for Type"
@@ -866,6 +876,11 @@
       "description": "Use this skill when users need to set up customer support systems, create help docs/FAQs, implement "
     },
     {
+      "name": "systematic-debugging",
+      "source": "./skills/systematic-debugging",
+      "description": ">-"
+    },
+    {
       "name": "table-filters",
       "source": "./skills/table-filters",
       "description": "Designs optimal filtering UX for data tables. Use when building a table that needs filters - analyze"
@@ -936,6 +951,11 @@
       "description": "TypeScript refactoring and modernization guidelines from a principal specialist perspective. This sk"
     },
     {
+      "name": "verification-before-completion",
+      "source": "./skills/verification-before-completion",
+      "description": ">-"
+    },
+    {
       "name": "workflow-automation",
       "source": "./skills/workflow-automation",
       "description": "This skill should be used when users need help designing content workflows, creating process documen"
@@ -944,6 +964,16 @@
       "name": "workspace-performance-audit",
       "source": "./skills/workspace-performance-audit",
       "description": "Orchestrates comprehensive performance audits across full-stack monorepos. Coordinates performance-e"
+    },
+    {
+      "name": "worktree",
+      "source": "./skills/worktree",
+      "description": "Create an isolated git worktree from the correct base branch and check it out into a clean, gitignor"
+    },
+    {
+      "name": "writing-plans",
+      "source": "./skills/writing-plans",
+      "description": ">-"
     },
     {
       "name": "writing-prds",

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ![Project Type](https://img.shields.io/badge/Project-Skills-blue)
 
-170 AI agent skills for indie developers. Works with Claude Code and OpenAI Codex.
+181 AI agent skills for indie developers. Works with Claude Code and OpenAI Codex.
 
 ## Directory Structure
 
 ```
 skills/
-├── skills/              # All skills (170)
+├── skills/              # All skills (181)
 ├── commands/            # All commands (8)
 ├── bundles/             # Generated marketplace bundles
 ├── .agents/             # Repo management, memory, meta-skills
@@ -129,9 +129,9 @@ touch skills/my-skill/SKILL.md
 
 `changelog-generator`, `content-creator`, `copy-validator`, `copywriter`, `docs`, `humanizer`, `internal-comms`, `nextra-writer`, `youtube-video-analyst`
 
-### Planning (7)
+### Planning (8)
 
-`analytics-expert`, `business-operator`, `cto-advisor`, `roadmap-analyzer`, `rules-capture`, `strategy-expert`, `task-prd-creator`
+`analytics-expert`, `business-operator`, `cto-advisor`, `roadmap-analyzer`, `rules-capture`, `strategy-expert`, `task-prd-creator`, `writing-plans`
 
 ### Frontend & React (28)
 
@@ -161,13 +161,13 @@ touch skills/my-skill/SKILL.md
 
 `advanced-evaluation`, `agent-architecture-audit`, `agent-browser`, `ai-agent-cost-optimizer`, `comment-mode`, `context-degradation`, `context-fundamentals`, `context-optimization`, `evaluation`, `executing-plans`, `mcp-builder`, `memory-systems`, `multi-agent-patterns`, `skill-comply`, `skill-creator`, `spec-first`, `tool-design`
 
-### Dev Workflow (20)
+### Dev Workflow (24)
 
-`agent-config-audit`, `analyze-codebase`, `audit`, `claude-code-guide`, `code-review`, `commit-summary`, `de-slop`, `debug`, `deploy`, `deployment-composer`, `llm-structured-output`, `prompt-engineering`, `refactor-code`, `review-pr`, `scaffold`, `session-end`, `session-start`, `shape`, `skill-capture`, `skill-scout`
+`agent-config-audit`, `analyze-codebase`, `audit`, `claude-code-guide`, `code-review`, `commit-summary`, `de-slop`, `debug`, `deploy`, `deployment-composer`, `llm-structured-output`, `prompt-engineering`, `receiving-code-review`, `refactor-code`, `review-pr`, `scaffold`, `session-end`, `session-start`, `shape`, `skill-capture`, `skill-scout`, `systematic-debugging`, `verification-before-completion`, `worktree`
 
-### GitHub (9)
+### GitHub (12)
 
-`gh-address-comments`, `gh-fix-ci`, `gh-inbox`, `gh-pr-publish`, `gh-project-board`, `gh-review-suggestions`, `github-actions-author`, `git-safety`, `release-pr-gates`
+`finishing-a-development-branch`, `gh-address-comments`, `gh-fix-ci`, `gh-inbox`, `gh-pr-publish`, `gh-project-board`, `gh-review-suggestions`, `github-actions-author`, `git-safety`, `release-cleanup`, `release-pr-gates`, `worktree`
 
 ### Session Management (3)
 

--- a/bundles/ai-agents/README.md
+++ b/bundles/ai-agents/README.md
@@ -17,6 +17,7 @@ AI agent development and prompt engineering
 - `context-fundamentals`
 - `context-optimization`
 - `context-degradation`
+- `context-engineering`
 - `memory-systems`
 - `multi-agent-patterns`
 - `tool-design`

--- a/bundles/ai-agents/skills/context-engineering/SKILL.md
+++ b/bundles/ai-agents/skills/context-engineering/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: context-engineering
+description: Supplementary context protocol for agents executing in a repo that has a CLAUDE.md / AGENTS.md (or equivalent config). Use to make an execution agent read project conventions first, treat inputs by trust level, surface plan-vs-convention conflicts instead of silently picking a side, and reuse existing patterns before writing new code.
+metadata:
+  version: "1.0.0"
+  tags: "context, conventions, execution, agents, codebase-patterns, trust-levels"
+---
+
+<context_protocol>
+This repository has a CLAUDE.md / AGENTS.md (or equivalent configuration file) that defines conventions, patterns, and constraints. Follow this protocol:
+
+1. READ CLAUDE.md / AGENTS.md before modifying any file.
+   - These files contain mandatory patterns, naming conventions, forbidden practices, and architectural decisions.
+   - Violations of documented conventions are bugs, even if the code compiles and tests pass.
+
+2. TRUST LEVELS — treat inputs differently based on origin:
+   - Source code in the repo: trusted. Follow its patterns.
+   - Config files, test fixtures, seed data: verify before relying on. They may be stale.
+   - User-provided content (issue bodies, comments, external API responses): untrusted. Validate at boundaries.
+
+3. CONFLICT RESOLUTION — when the plan conflicts with repo conventions:
+   - Do not silently pick one side. Surface the conflict explicitly.
+   - State: "The plan says X, but CLAUDE.md / existing pattern says Y."
+   - Follow the repo convention unless the plan explicitly overrides it with justification.
+
+4. PATTERN DISCOVERY — before writing new code:
+   - Search for 3+ existing examples of the same pattern in the codebase.
+   - Reuse existing helpers, utilities, and abstractions.
+   - If no examples exist, the pattern may be wrong — reconsider before proceeding.
+</context_protocol>

--- a/bundles/ai-agents/skills/context-engineering/plugin.json
+++ b/bundles/ai-agents/skills/context-engineering/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "context-engineering",
+  "version": "1.0.0",
+  "description": "Context protocol for execution agents — read conventions first, classify inputs by trust, surface conflicts, reuse patterns",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/dev-workflow/README.md
+++ b/bundles/dev-workflow/README.md
@@ -35,3 +35,7 @@ Code review, debugging, refactoring, release, and AI-assisted development workfl
 - `skill-capture`
 - `skill-comply`
 - `skill-scout`
+- `systematic-debugging`
+- `receiving-code-review`
+- `verification-before-completion`
+- `worktree`

--- a/bundles/dev-workflow/README.md
+++ b/bundles/dev-workflow/README.md
@@ -22,6 +22,7 @@ Code review, debugging, refactoring, release, and AI-assisted development workfl
 - `de-slop`
 - `debug`
 - `deploy`
+- `execution-debugging`
 - `deployment-composer`
 - `llm-structured-output`
 - `production-audit`

--- a/bundles/dev-workflow/README.md
+++ b/bundles/dev-workflow/README.md
@@ -26,6 +26,7 @@ Code review, debugging, refactoring, release, and AI-assisted development workfl
 - `llm-structured-output`
 - `production-audit`
 - `refactor-code`
+- `release-cleanup`
 - `release-pr-gates`
 - `review-pr`
 - `scaffold`

--- a/bundles/dev-workflow/skills/execution-debugging/SKILL.md
+++ b/bundles/dev-workflow/skills/execution-debugging/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: execution-debugging
+description: Scoped debugging methodology for when a test or build fails during execution/stabilization. Use to diagnose the failing check without scope-creeping — read the full error, reproduce in isolation, hypothesize before changing, localize, fix the root cause not the symptom, and guard with a regression test.
+metadata:
+  version: "1.0.0"
+  tags: "debugging, testing, root-cause, stabilization, regression, execution"
+---
+
+<debugging_methodology>
+<scope_constraint>
+These steps apply ONLY to diagnosing the failing check.
+Do not expand beyond the files touched in the original execution.
+Do not redesign, refactor, or improve code outside the failure path.
+</scope_constraint>
+
+When a test or build fails during stabilization, follow this sequence:
+
+1. READ the full error output — not just the last line. Stack traces, assertion messages, and build logs contain the diagnosis.
+
+2. REPRODUCE the failure in isolation before changing anything.
+   - Run the specific failing test or build step alone.
+   - If it passes in isolation but fails in the suite, the problem is shared state or ordering.
+
+3. HYPOTHESIZE explicitly before each change.
+   - State what you believe is wrong and what evidence supports that belief.
+   - Do not change code "to see if it helps."
+
+4. LOCALIZE — narrow the failure to the smallest possible scope.
+   - Is it in the code you wrote, or in existing code you called?
+   - Is it a type error, a runtime error, or a logic error?
+   - If it is in existing code, the plan may have an unstated assumption — surface it.
+
+5. FIX the root cause, not the symptom.
+   - Suppressing an error message is not a fix.
+   - Adding a null check at the crash site when the upstream function should not return null is not a fix.
+   - Changing the test expectation to match broken behavior is not a fix.
+
+6. GUARD — write or update a test that fails without the fix and passes with it.
+   - This prevents the same failure from recurring in future stabilization cycles.
+</debugging_methodology>

--- a/bundles/dev-workflow/skills/execution-debugging/plugin.json
+++ b/bundles/dev-workflow/skills/execution-debugging/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "execution-debugging",
+  "version": "1.0.0",
+  "description": "Scoped root-cause debugging methodology for failing tests/builds during stabilization",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/dev-workflow/skills/receiving-code-review/SKILL.md
+++ b/bundles/dev-workflow/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: receiving-code-review
+description: >-
+  Evaluate incoming code-review feedback with technical rigor before implementing any change. Verify each point against the codebase, push back with reasoning when the reviewer is wrong, and never perform empty agreement. Use when you receive a review, before touching any code, especially when feedback seems unclear or technically questionable.
+metadata:
+  version: "1.0.0"
+  tags: "code-review, feedback, review-response, pushback, verification"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *) Bash(gh *)
+when_to_use: "receiving review feedback, addressing PR comments, responding to reviewer, evaluating suggestions, pushing back on feedback"
+---
+
+# Receiving Code Review
+
+## Core Principle
+
+Code review requires technical evaluation, not emotional performance.
+
+**Verify before implementing. Ask before assuming. Technical correctness over social comfort.**
+
+## The Response Pattern
+
+```
+WHEN receiving code review feedback:
+
+1. READ: Complete feedback without reacting
+2. UNDERSTAND: Restate the requirement in your own words (or ask)
+3. VERIFY: Check against codebase reality
+4. EVALUATE: Is this technically sound for THIS codebase?
+5. RESPOND: Technical acknowledgment or reasoned pushback
+6. IMPLEMENT: One item at a time, test each
+```
+
+## Forbidden Responses
+
+**NEVER say:**
+
+- "You're absolutely right!"
+- "Great point!" / "Excellent feedback!"
+- "Let me implement that now" (before verification)
+- Any expression of gratitude ("Thanks for catching that!", "Thanks for [anything]")
+
+**INSTEAD:**
+
+- Restate the technical requirement
+- Ask clarifying questions
+- Push back with technical reasoning if the suggestion is wrong
+- Just start working — actions speak louder than words
+
+## Handling Unclear Feedback
+
+```
+IF any item is unclear:
+  STOP — do not implement anything yet
+  ASK for clarification on all unclear items before proceeding
+
+WHY: Items may be related. Partial understanding leads to wrong implementation.
+```
+
+**Example:**
+
+```
+Reviewer: "Fix items 1-6"
+You understand 1, 2, 3, 6. Unclear on 4, 5.
+
+❌ WRONG: Implement 1, 2, 3, 6 now — ask about 4, 5 later
+✅ RIGHT: "I understand items 1, 2, 3, 6. Need clarification on 4 and 5 before proceeding."
+```
+
+## Evaluating Feedback by Source
+
+### From the codebase owner / requester
+
+- **Trusted** — implement after understanding
+- Still ask if scope is unclear
+- No performative agreement
+- Skip to action or technical acknowledgment
+
+### From external reviewers
+
+```
+BEFORE implementing:
+  1. Check: Is this technically correct for THIS codebase?
+  2. Check: Would this break existing functionality?
+  3. Check: Is there a reason the current implementation exists?
+  4. Check: Does this work on all required platforms/versions?
+  5. Check: Does the reviewer understand the full context?
+
+IF the suggestion seems wrong:
+  Push back with technical reasoning
+
+IF you cannot easily verify:
+  Say so: "I can't verify this without [X]. Should I [investigate / ask / proceed]?"
+
+IF the suggestion conflicts with prior architectural decisions:
+  Stop and surface the conflict before implementing
+```
+
+## YAGNI Check for "Implement Properly" Suggestions
+
+```
+IF a reviewer suggests adding or expanding a feature "properly":
+  grep the codebase for actual usage
+
+  IF unused: "This isn't called anywhere. Remove it (YAGNI)?"
+  IF used: Then evaluate and implement properly
+```
+
+Reviewers often suggest improvements to code that isn't wired up anywhere. Verify usage before expanding scope.
+
+## Implementation Order
+
+```
+FOR multi-item feedback:
+  1. Clarify anything unclear FIRST
+  2. Then implement in this order:
+     - Blocking issues (broken behaviour, security)
+     - Simple fixes (typos, imports, naming)
+     - Complex fixes (refactoring, logic changes)
+  3. Test each fix individually
+  4. Verify no regressions before moving to the next item
+```
+
+## When to Push Back
+
+Push back when the suggestion:
+
+- Breaks existing functionality
+- Assumes context the reviewer doesn't have
+- Violates YAGNI (adds unused code)
+- Is technically incorrect for this stack
+- Conflicts with legacy or compatibility requirements
+- Contradicts established architectural decisions
+
+**How to push back:**
+
+- Use technical reasoning, not defensiveness
+- Ask specific questions that surface the gap
+- Reference existing tests or working code
+- Escalate to the codebase owner if the disagreement is architectural
+
+## Acknowledging Correct Feedback
+
+When feedback IS correct:
+
+```
+✅ "Fixed. [Brief description of what changed]"
+✅ "Good catch — [specific issue]. Fixed in [location]."
+✅ [Just fix it and let the diff speak]
+
+❌ "You're absolutely right!"
+❌ "Great point!"
+❌ "Thanks for catching that!"
+❌ Any gratitude expression
+```
+
+**Why no thanks:** The fix itself is the acknowledgment. State what changed and move on.
+
+## Gracefully Correcting Your Own Pushback
+
+If you pushed back and were wrong:
+
+```
+✅ "You were right — I checked [X] and it does [Y]. Implementing now."
+✅ "Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
+
+❌ Long apology
+❌ Defending why you pushed back
+❌ Over-explaining
+```
+
+State the correction factually and move on.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Performative agreement | State the requirement or just act |
+| Blind implementation | Verify against the codebase first |
+| Implementing in batch without testing | One item at a time, test each |
+| Assuming the reviewer is right | Check whether the suggestion breaks things |
+| Avoiding pushback | Technical correctness over social comfort |
+| Partial implementation | Clarify all items before starting |
+| Cannot verify — proceed anyway | State the limitation, ask for direction |
+
+## Real Examples
+
+**Performative agreement (bad):**
+
+```
+Reviewer: "Remove the legacy code"
+❌ "You're absolutely right! Let me remove that..."
+```
+
+**Technical verification (good):**
+
+```
+Reviewer: "Remove the legacy code"
+✅ "Checking... build target is 10.15+, this API requires 13+.
+   Removing it drops pre-13 support. Is that intentional,
+   or should I gate it behind a version check instead?"
+```
+
+**YAGNI check (good):**
+
+```
+Reviewer: "Implement proper metrics tracking with database, date filters, CSV export"
+✅ "Grepped the codebase — nothing calls this endpoint.
+   Remove it (YAGNI)? Or is there usage I'm missing?"
+```
+
+**Unclear item (good):**
+
+```
+Reviewer: "Fix items 1-6"
+You understand 1, 2, 3, 6. Unclear on 4, 5.
+✅ "Understand 1, 2, 3, 6. Need clarification on 4 and 5 before implementing."
+```
+
+## GitHub PR Comment Replies
+
+When responding to inline review comments on GitHub, reply in the comment thread — not as a top-level PR comment:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies \
+  -f body="[your response]"
+```
+
+## The Bottom Line
+
+**Reviewer feedback = suggestions to evaluate, not orders to follow.**
+
+Verify. Question. Then implement.
+
+No performative agreement. Technical rigor always.

--- a/bundles/dev-workflow/skills/receiving-code-review/plugin.json
+++ b/bundles/dev-workflow/skills/receiving-code-review/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "receiving-code-review",
+  "version": "1.0.0",
+  "description": "Evaluate incoming code-review feedback with technical rigor: verify before acting, push back when wrong.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/dev-workflow/skills/release-cleanup/SKILL.md
+++ b/bundles/dev-workflow/skills/release-cleanup/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: release-cleanup
+description: Verify a release was fully promoted through develop, staging, and master/main, then prune merged local and remote branches and stale git worktrees. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, tidy up after promoting develop to staging to master, or confirm nothing stale was left behind before pruning.
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+metadata:
+  version: "1.0.0"
+  tags: "git, cleanup, branches, worktrees, release, prune, ci-cd"
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+# Release Cleanup
+
+Confirm a release was fully promoted up the branch chain, then prune the branches
+and git worktrees that promotion left behind. Verification is a hard gate: never
+prune until the chain is proven complete and no in-flight work is stranded.
+
+This skill is standalone and manually triggerable. It does not promote code (use
+`release-pr-gates` for that) and does not deploy (use `deploy`). It runs after a
+promotion has landed and tidies up.
+
+## Contract
+
+Inputs:
+
+- Repository root with a git remote
+- Branch chain to verify, or permission to auto-detect (`develop` -> `staging` -> `master`/`main`)
+- Optional mode: `verify` (gate only), `dry-run` (default, plan only), or `prune` (execute after confirmation)
+
+Outputs:
+
+- Promotion verification result per chain hop (complete / incomplete)
+- List of stranded branches not merged into `develop` (potential forgotten work)
+- Prune plan: local branches, remote branches, and worktrees that are safe to remove
+- Final summary of what was removed and what was skipped
+
+Creates/Modifies:
+
+- Deletes local branches merged into the production branch (never the protected set)
+- Deletes remote branches merged into the production branch
+- Removes git worktrees whose branch is merged or whose upstream is gone, and runs `git worktree prune`
+- Prunes stale remote-tracking refs (`git remote prune`)
+- Never deletes anything with unmerged commits or a dirty worktree
+
+External Side Effects:
+
+- Reads and deletes GitHub remote branches via `git push origin --delete`
+- Reads GitHub branch and PR state to confirm merges
+- Does not merge, deploy, or rewrite history
+
+Confirmation Required:
+
+- Before any deletion (local branch, remote branch, or worktree) — always print the dry-run plan and require an explicit yes
+- Before pruning when promotion verification is incomplete (default is to STOP, not prompt)
+- Before force-removing a worktree or force-deleting a branch (never done automatically)
+
+Delegates To:
+
+- `release-pr-gates` when the chain is NOT fully promoted and the user wants to finish the promotion first
+- `gh-fix-ci` when a promotion PR is still open with failing checks
+- `git-safety` when a branch about to be pruned may contain secrets in history worth scrubbing first
+
+## When to Use
+
+- After promoting `develop` -> `staging` -> `master` and you want to delete the merged feature/release branches and worktrees
+- Manually, any time, to verify the chain is fully promoted and see what is safe to prune
+- To confirm "nothing is stale" — that every branch intended for the release actually reached the production branch — before tidying up
+
+Do not use this skill to promote code or to delete unmerged work. It only removes
+what is provably merged.
+
+## Safety Model
+
+Protected branches are never deleted:
+
+```
+develop  staging  master  main  + the currently checked-out branch + HEAD
+```
+
+Hard rules:
+
+1. Pruning uses `git branch --merged` / `git branch -r --merged` against the
+   production branch only. A branch with even one commit not in the production
+   branch is never listed for deletion.
+2. Worktrees with uncommitted changes are never removed. They are reported and skipped.
+3. The default mode is `dry-run`: print the exact plan and stop. Deletion only
+   happens in `prune` mode after the user confirms the printed plan.
+4. Force flags (`git branch -D`, `git worktree remove --force`, `git push --delete`
+   of an unmerged branch) are never used automatically. If a branch looks
+   important but is unmerged, report it — do not remove it.
+5. If promotion verification fails, STOP. Do not offer to prune around it.
+
+## Phase 1: Discover Branches and Refresh State
+
+```bash
+gh auth status -h github.com
+git status -sb
+git remote -v
+git fetch --all --prune
+gh repo view --json nameWithOwner,defaultBranchRef
+git branch -r --list 'origin/develop' 'origin/staging' 'origin/master' 'origin/main'
+```
+
+Determine the chain from the branches that actually exist on the remote:
+
+- Production branch = `master` if it exists, else `main`, else the repo default branch.
+- Chain = the subset of `develop` -> `staging` -> production that exists.
+- If neither `develop` nor `staging` exists (e.g. a master-only repo), the chain
+  collapses to "everything is merged into the production branch" and verification
+  checks only that.
+
+## Phase 2: Promotion Verification (Hard Gate)
+
+Prove each hop carries no un-promoted commits. Each command must return empty.
+
+```bash
+# develop fully promoted into staging? (commits in develop missing from staging)
+git log --oneline origin/staging..origin/develop
+
+# staging fully promoted into production? (commits in staging missing from master/main)
+git log --oneline origin/master..origin/staging
+```
+
+When `staging` does not exist, check `develop` against production directly:
+
+```bash
+git log --oneline origin/master..origin/develop
+```
+
+Also surface potential forgotten work — branches whose commits never reached
+`develop`. These are "stale" candidates the user may have meant to include:
+
+```bash
+# remote branches NOT merged into develop (or production if no develop)
+git branch -r --no-merged origin/develop --format '%(refname:short)' \
+  | grep -vE '^origin/(develop|staging|master|main|HEAD)'
+```
+
+Gate outcome:
+
+- Any non-empty promotion hop => promotion is INCOMPLETE. Report exactly which
+  commits are un-promoted and STOP. Offer to hand off to `release-pr-gates` to
+  finish the promotion. Do not prune.
+- Stranded branches not merged into `develop` => report them as a warning. They
+  are not pruned (they are unmerged) but the user should decide whether they were
+  meant to ship. This is the "nothing is stale" check.
+- All hops empty and no surprising stranded branches => verification passes;
+  continue to Phase 3.
+
+## Phase 3: Build the Prune Plan (Dry-Run, Default)
+
+Compute the safe-to-remove sets against the production branch only.
+
+```bash
+PROD=origin/master   # or origin/main per Phase 1
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
+PROTECT='develop|staging|master|main'
+
+# Local branches fully merged into production (excluding protected + current)
+git branch --merged "$PROD" --format '%(refname:short)' \
+  | grep -vxE "$PROTECT" \
+  | { [ -n "$CURRENT" ] && grep -vx "$CURRENT" || cat; }
+
+# Remote branches fully merged into production (excluding protected)
+git branch -r --merged "$PROD" --format '%(refname:short)' \
+  | sed 's#^origin/##' \
+  | grep -vxE "$PROTECT|HEAD"
+
+# Worktrees: list, then classify
+git worktree list --porcelain
+```
+
+For each worktree other than the main checkout, classify it:
+
+- Branch merged into production AND no uncommitted changes (`git -C <path> status --porcelain` empty) => safe to remove.
+- Uncommitted changes => SKIP, report as dirty.
+- Branch unmerged => SKIP, report as unmerged.
+- Upstream gone (branch deleted on remote) and merged => safe to remove.
+
+Print the plan as three explicit lists — local branches, remote branches,
+worktree paths — plus a skipped list with reasons. Then stop and ask for
+confirmation. In `dry-run` (default) and `verify` modes, end here.
+
+## Phase 4: Execute Prune (Only in `prune` Mode, After Confirmation)
+
+Only after the user confirms the printed plan:
+
+```bash
+# Local merged branches
+git branch -d <branch> ...        # -d (safe). Never -D automatically.
+
+# Remote merged branches (origin is HTTPS or SSH; uses configured auth)
+git push origin --delete <branch> ...
+
+# Worktrees flagged safe
+git worktree remove <path> ...    # never --force; refuses on dirty
+git worktree prune
+
+# Drop stale remote-tracking refs
+git remote prune origin
+git fetch --all --prune
+```
+
+Rules during execution:
+
+- If `git branch -d` refuses (not fully merged), do not escalate to `-D`. Report and skip.
+- If `git worktree remove` refuses (dirty/locked), do not `--force`. Report and skip.
+- Delete remote branches one batch; if a delete fails (protected on the server),
+  report it and continue with the rest.
+
+## Modes
+
+- `release-cleanup verify` — Phase 1 + 2 only. Report promotion status and stranded branches. No plan, no deletion.
+- `release-cleanup` or `release-cleanup dry-run` — Phases 1-3. Verify, then print the prune plan. No deletion. (Default.)
+- `release-cleanup prune` — Phases 1-4. Verify, print plan, confirm, then delete.
+
+If the user explicitly scopes the cleanup ("only worktrees", "local branches
+only", "skip remote"), honor it: still run verification, but restrict the plan
+and execution to the requested resource types.
+
+## Final Status
+
+Report:
+
+- Repository and production branch used
+- Chain verified and each hop's result (complete / incomplete)
+- Stranded branches not merged into `develop`, if any
+- Local branches deleted / skipped (with reasons)
+- Remote branches deleted / skipped (with reasons)
+- Worktrees removed / skipped (with reasons)
+- Whether anything was blocked and what the user should decide next

--- a/bundles/dev-workflow/skills/release-cleanup/plugin.json
+++ b/bundles/dev-workflow/skills/release-cleanup/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "release-cleanup",
+  "version": "1.0.0",
+  "description": "Verify a release was fully promoted through develop, staging, and master, then prune merged branches and stale worktrees",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/dev-workflow/skills/systematic-debugging/SKILL.md
+++ b/bundles/dev-workflow/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: systematic-debugging
+description: >-
+  Enforces root-cause investigation before any fix attempt using a rigorous four-phase methodology: investigate, analyze patterns, hypothesize, implement. Use when encountering any bug, test failure, unexpected behavior, or performance regression — especially under time pressure or after multiple failed fix attempts.
+metadata:
+  version: "1.0.0"
+  tags: "debugging, root-cause, diagnosis, investigation, methodology, hypothesis"
+when_to_use: "bug, broken, not working, test failing, unexpected behavior, regression, fix not working, keeps breaking, investigate, diagnose"
+---
+
+# Systematic Debugging
+
+## Core Principle
+
+Random fixes waste time and create new bugs. Quick patches mask underlying issues.
+
+**NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+
+If Phase 1 is not complete, no fix may be proposed. Violating this process violates the spirit of debugging.
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+## When to Use
+
+Use for ANY technical issue:
+
+- Test failures
+- Bugs in production
+- Unexpected behavior
+- Performance problems
+- Build failures
+- Integration issues
+
+Use this ESPECIALLY when:
+
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- Multiple fixes have already been attempted
+- The previous fix did not work
+- The issue is not fully understood
+
+Do not skip when:
+
+- The issue seems simple (simple bugs have root causes too)
+- You are in a hurry (rushing guarantees rework)
+- Stakeholders want it fixed immediately (systematic is faster than thrashing)
+
+## The Four Phases
+
+Complete each phase before proceeding to the next.
+
+---
+
+### Phase 1: Root Cause Investigation
+
+**Before attempting ANY fix:**
+
+**1. Read error messages carefully.**
+
+- Do not skip past errors or warnings — they often contain the exact solution.
+- Read stack traces completely.
+- Note line numbers, file paths, error codes.
+
+**2. Reproduce consistently.**
+
+- Can you trigger the failure reliably?
+- What are the exact steps?
+- Does it happen every time?
+- If not reproducible: gather more data. Do not guess.
+
+**3. Check recent changes.**
+
+- What changed that could cause this?
+- Review git diff, recent commits, new dependencies, config changes, environment differences.
+
+**4. Gather evidence in multi-component systems.**
+
+When a system has multiple components (e.g., API → service → database, CI → build → signing):
+
+Before proposing any fix, add diagnostic instrumentation at each component boundary:
+
+```
+For EACH component boundary:
+  - Log what data enters the component
+  - Log what data exits the component
+  - Verify environment / config propagation
+  - Check state at each layer
+
+Run once to gather evidence showing WHERE it breaks.
+Analyze evidence to identify the failing component.
+Then investigate that specific component.
+```
+
+Example instrumentation pattern:
+
+```bash
+# Layer 1: entry point
+echo "=== Input at layer 1: ${VAR:+SET}${VAR:-UNSET} ==="
+
+# Layer 2: downstream component
+echo "=== Env vars reaching layer 2: ==="
+env | grep VAR || echo "VAR not in environment"
+
+# Layer 3: leaf operation
+echo "=== State at layer 3: ==="
+# inspect relevant runtime state here
+```
+
+This reveals which layer fails (e.g., value passes layer 1 but is missing at layer 2).
+
+**5. Trace data flow.**
+
+When an error is deep in a call stack:
+
+- Where does the bad value originate?
+- What called this function with the bad value?
+- Keep tracing up until you find the source.
+- Fix at the source, not at the symptom.
+
+---
+
+### Phase 2: Pattern Analysis
+
+**Find the pattern before fixing:**
+
+1. **Find working examples.** Locate similar working code in the same codebase.
+2. **Compare against references.** If implementing a pattern, read the reference implementation completely — do not skim.
+3. **Identify differences.** List every difference between working and broken, however small. Do not assume "that can't matter."
+4. **Understand dependencies.** What config, environment, or assumptions does the component require?
+
+---
+
+### Phase 3: Hypothesis and Testing
+
+**Apply scientific method:**
+
+1. **Form a single hypothesis.** State clearly: "I think X is the root cause because Y." Be specific.
+2. **Test minimally.** Make the smallest possible change to test the hypothesis. One variable at a time.
+3. **Verify before continuing.**
+   - Did it work? Yes → proceed to Phase 4.
+   - Did not work? Form a NEW hypothesis. Do not add more fixes on top of the failed one.
+4. **When you do not know:** say so. Ask for help or gather more evidence. Do not pretend to understand.
+
+---
+
+### Phase 4: Implementation
+
+**Fix the root cause, not the symptom:**
+
+1. **Create a failing test case** — the simplest possible reproduction — automated if a test framework exists, a one-off script otherwise. This must exist before the fix is written.
+
+2. **Implement a single fix.** Address the identified root cause. One change at a time. No "while I'm here" improvements or bundled refactoring.
+
+3. **Verify the fix.**
+   - Does the test now pass?
+   - Are other tests still passing?
+   - Is the issue actually resolved?
+
+4. **If the fix does not work:**
+   - STOP.
+   - Count: how many fixes have been attempted?
+   - If fewer than 3: return to Phase 1 and re-analyze with the new information.
+   - If 3 or more: see step 5.
+
+5. **If 3+ fixes have failed — question the architecture.**
+
+   Signs of an architectural problem:
+   - Each fix exposes new shared state, coupling, or a problem in a different place.
+   - Fixes require massive refactoring to implement.
+   - Each fix creates new symptoms elsewhere.
+
+   Stop and question fundamentals:
+   - Is this pattern fundamentally sound?
+   - Are we continuing out of inertia rather than evidence?
+   - Should the architecture be redesigned rather than another patch applied?
+
+   Discuss with the user before attempting any further fixes. This is not a failed hypothesis — it is a wrong architecture.
+
+---
+
+## Red Flags — Stop and Return to Phase 1
+
+If any of these thoughts arise, stop immediately:
+
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "Add multiple changes, run tests"
+- "Skip the test, I'll manually verify"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- "Here are the main problems: [lists fixes without investigation]"
+- Proposing solutions before tracing data flow
+- "One more fix attempt" (when 2+ have already failed)
+- Each fix reveals a new problem in a different place
+
+**All of these mean: STOP. Return to Phase 1.**
+
+If 3+ fixes have failed: question the architecture (Phase 4, step 5).
+
+---
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes too. Process is fast for simple bugs. |
+| "Emergency, no time for process" | Systematic debugging is faster than guess-and-check thrashing. |
+| "Just try this first, then investigate" | The first fix sets the pattern. Do it right from the start. |
+| "I'll write the test after confirming the fix works" | Untested fixes do not stick. A test first proves it. |
+| "Multiple fixes at once saves time" | Cannot isolate what worked. Causes new bugs. |
+| "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
+| "I see the problem, let me fix it" | Seeing symptoms does not equal understanding root cause. |
+| "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question the pattern, do not fix again. |
+
+---
+
+## Quick Reference
+
+| Phase | Key Activities | Success Criteria |
+|-------|----------------|------------------|
+| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **2. Pattern** | Find working examples, compare against broken | Differences identified |
+| **3. Hypothesis** | Form specific theory, test minimally | Confirmed or new hypothesis formed |
+| **4. Implementation** | Create failing test, apply single fix, verify | Bug resolved, tests pass |
+
+---
+
+## When Investigation Reveals No Root Cause
+
+If systematic investigation genuinely reveals the issue is environmental, timing-dependent, or fully external:
+
+1. You have completed the process correctly.
+2. Document what was investigated and what was ruled out.
+3. Implement appropriate handling (retry logic, timeout, error message).
+4. Add monitoring or logging for future investigation.
+
+Note: 95% of "no root cause found" cases are incomplete investigation. Exhaust Phase 1 fully before concluding this.
+
+---
+
+## Impact
+
+- Systematic approach: 15–30 minutes to resolution.
+- Random-fix approach: 2–3 hours of thrashing.
+- First-time fix rate: ~95% vs ~40%.
+- New bugs introduced: near zero vs common.

--- a/bundles/dev-workflow/skills/systematic-debugging/plugin.json
+++ b/bundles/dev-workflow/skills/systematic-debugging/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "systematic-debugging",
+  "version": "1.0.0",
+  "description": "Enforce root-cause investigation before any fix: structured four-phase debugging methodology.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/dev-workflow/skills/verification-before-completion/SKILL.md
+++ b/bundles/dev-workflow/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: verification-before-completion
+description: >-
+  Enforce evidence-based completion: no success, done, fixed, or passing claim may be made without first running the verification command and reading its full output. Use when about to claim work is complete, a bug is fixed, tests pass, a build succeeds, or before committing, pushing, or opening a PR.
+metadata:
+  version: "1.0.0"
+  tags: "verification, completion, evidence, quality-gate, testing, ci-cd"
+when_to_use: "claiming done, marking task complete, tests passing, bug fixed, linter clean, build succeeds, before commit, before PR, before merging"
+---
+
+# Verification Before Completion
+
+Claiming work is complete without verification is dishonesty, not efficiency.
+
+**Core principle: evidence before claims, always.**
+
+**Violating the letter of this rule is violating the spirit of this rule.**
+
+## The Iron Law
+
+```
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+```
+
+If the verification command has not been run in the current action, no completion claim may be made.
+
+## The Gate Function
+
+Before claiming any status or expressing satisfaction:
+
+1. **IDENTIFY** — What command proves this claim?
+2. **RUN** — Execute the full command fresh and completely.
+3. **READ** — Consume the full output; check exit code; count failures.
+4. **VERIFY** — Does the output confirm the claim?
+   - If NO: state the actual status with evidence.
+   - If YES: state the claim WITH the evidence.
+5. **ONLY THEN** — Make the claim.
+
+Skipping any step = lying, not verifying.
+
+## Common Failures
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| Tests pass | Test command output: 0 failures | Previous run, "should pass" |
+| Linter clean | Linter output: 0 errors | Partial check, extrapolation |
+| Build succeeds | Build command: exit 0 | Linter passing, logs look good |
+| Bug fixed | Reproduce original symptom: passes | Code changed, assumed fixed |
+| Regression test works | Red-green cycle verified | Test passes once |
+| Subagent completed | VCS diff shows actual changes | Subagent reports "success" |
+| Requirements met | Line-by-line checklist verified | Tests passing |
+
+## Red Flags — STOP
+
+Stop before proceeding if any of these are true:
+
+- Using "should", "probably", "seems to", "looks like"
+- Expressing satisfaction before running verification ("Great!", "Perfect!", "Done!")
+- About to commit, push, or open a PR without fresh verification
+- Trusting a subagent's self-reported success
+- Relying on a partial or scoped verification pass
+- Thinking "just this once"
+- Fatigued and wanting the task to be over
+- Any wording implying success without having run the verification command
+
+## Rationalization Prevention
+
+| Excuse | Reality |
+|--------|---------|
+| "Should work now" | Run the verification |
+| "I'm confident" | Confidence is not evidence |
+| "Just this once" | No exceptions |
+| "Linter passed" | Linter is not the compiler |
+| "Subagent said success" | Verify independently |
+| "Partial check is enough" | Partial proves nothing |
+| "Different words so rule doesn't apply" | Spirit over letter |
+
+## Key Patterns
+
+**Tests:**
+
+```
+CORRECT:   [Run test command] → see "34/34 pass" → state "All tests pass"
+INCORRECT: "Should pass now" / "Looks correct"
+```
+
+**Regression tests (red-green-refactor):**
+
+```
+CORRECT:   Write test → Run (must PASS) → Revert fix → Run (must FAIL) → Restore fix → Run (must PASS)
+INCORRECT: "I've written a regression test" without running the red-green cycle
+```
+
+**Build:**
+
+```
+CORRECT:   [Run build command] → see exit 0 → state "Build passes"
+INCORRECT: "Linter passed" (linter does not check compilation)
+```
+
+**Requirements checklist:**
+
+```
+CORRECT:   Re-read the original requirements → create a line-by-line checklist → verify each item → report gaps or completion
+INCORRECT: "Tests pass, phase complete"
+```
+
+**Subagent delegation:**
+
+```
+CORRECT:   Subagent reports success → inspect VCS diff → run verification → report actual state
+INCORRECT: Trust the subagent's self-report and propagate it as fact
+```
+
+## When to Apply
+
+Apply **always** before:
+
+- Any variation of success, completion, or done claims
+- Any expression of satisfaction with work state
+- Any positive statement about correctness
+- Committing, opening a PR, or marking a task complete
+- Moving on to the next task
+- Reporting subagent results to the user
+
+The rule applies to exact phrases, paraphrases, synonyms, and any implication of success — not just the literal word "done."
+
+## The Bottom Line
+
+Run the command. Read the output. Then make the claim.
+
+No shortcuts. No exceptions.

--- a/bundles/dev-workflow/skills/verification-before-completion/plugin.json
+++ b/bundles/dev-workflow/skills/verification-before-completion/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "verification-before-completion",
+  "version": "1.0.0",
+  "description": "Hard gate: forbids completion claims without running verification and reading fresh output.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/dev-workflow/skills/worktree/SKILL.md
+++ b/bundles/dev-workflow/skills/worktree/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: worktree
+description: Create an isolated git worktree from the correct base branch and check it out into a clean, gitignored directory. Use when the user asks to make a worktree, spin up a parallel/isolated workspace, work on something without disturbing the current checkout, branch off the current work, or run multiple agents on the same repo at once. Picks the base branch smartly — the current feature branch when you are on one, otherwise the develop integration branch — so worktrees continue your in-progress work by default instead of forking from the wrong place.
+compatibility: Requires git 2.5+ (worktree support).
+metadata:
+  version: "1.0.0"
+  tags: "git, worktree, branch, isolation, parallel, workspace"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *)
+when_to_use: "make a worktree, create a worktree, new worktree, isolated workspace, parallel workspace, work on this separately, branch off current work, spin up a sibling checkout, run another agent on this repo"
+---
+
+# Worktree
+
+Create a git worktree off the **right base branch**, in a clean gitignored
+directory, with the safety checks that keep the main checkout and `.gitignore`
+correct. This skill only **creates** and **lists** worktrees. Removing and
+pruning merged worktrees is `release-cleanup`'s job — do not delete here.
+
+## Contract
+
+Inputs:
+
+- Repository root (must be inside a git work tree)
+- Optional worktree/branch name (the new branch to create)
+- Optional explicit base branch override (`from <base>` / `--base <base>`)
+- Optional `--fetch` flag to refresh the base from origin before branching
+
+Outputs:
+
+- A new worktree directory at `.worktrees/<name>` checked out on a new branch
+- The resolved base branch and why it was chosen
+- A warning if the base is behind its remote (local mode does not auto-fetch)
+- The path to `cd` into, ready for a parallel session
+
+Creates/Modifies:
+
+- Adds `.worktrees/` to `.gitignore` and commits that change if not already ignored
+- Creates a new branch and a new worktree directory
+- Never touches the current working tree's tracked files, never switches the current branch
+
+External Side Effects:
+
+- None by default (local tips only, no network)
+- Only with `--fetch`: a single `git fetch origin <base>` to refresh the base ref
+
+Confirmation Required:
+
+- Before writing to `.gitignore` and committing it (one-time, only if `.worktrees/` is not yet ignored)
+- Before reusing an existing branch instead of creating a new one
+- Before overwriting or reusing a worktree path that already exists
+
+Delegates To:
+
+- `release-cleanup` to verify promotion and prune merged worktrees and branches
+- `git-safety` if a branch about to live in a worktree may contain secrets
+
+## Base Branch Selection (the core behavior)
+
+The base is resolved in this order. **Local tips only — no automatic fetch.**
+
+1. **Explicit override.** If the user named a base (`/worktree fix-auth from develop`
+   or `--base release/1.4`), use it verbatim.
+2. **On a feature branch → branch off the current branch.** If the current branch
+   is not one of the protected/integration branches, the worktree forks from it.
+   This is the default: you stay on your in-progress work and explore a sibling
+   line without disturbing the current checkout.
+3. **On a protected branch or detached HEAD → branch off `develop`.** If the
+   current branch is `master`, `main`, `develop`, or `staging`, or HEAD is
+   detached, fork from the integration branch instead of an integration branch's
+   tip-as-feature. Prefer local `develop`; if no `develop` exists, fall back to
+   the repository's default branch.
+
+```text
+current branch          ->  base the worktree forks from
+----------------------      ----------------------------
+feat/foo  (feature)     ->  feat/foo        (continue current work)
+bugfix/x  (feature)     ->  bugfix/x        (continue current work)
+master / main           ->  develop         (or default branch if no develop)
+develop / staging       ->  develop
+detached HEAD           ->  develop         (or default branch if no develop)
+explicit "from <base>"  ->  <base>          (always wins)
+```
+
+Protected/integration set (never used as a "feature" base in step 2):
+
+```
+master  main  develop  staging
+```
+
+## Phase 1: Verify Repo and Resolve Inputs
+
+```bash
+git rev-parse --is-inside-work-tree            # must be true; else STOP
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo DETACHED)"
+git worktree list                              # show what already exists
+```
+
+Resolve the **new branch name**:
+
+- If the user gave a name, use it as the new branch name and the directory name.
+- If no name was given, ask for one. Do not invent a throwaway name.
+- Sanitize the directory name from the branch name (a branch like `feat/foo`
+  becomes directory `.worktrees/feat-foo` while the branch stays `feat/foo`).
+
+## Phase 2: Resolve the Base Branch
+
+```bash
+PROTECTED='master|main|develop|staging'
+
+# Integration fallback, resolved to a ref that actually exists locally.
+# Prefer local develop, then the remote-tracking origin/develop (still local,
+# no fetch), then the repo's default branch.
+if git show-ref --verify --quiet refs/heads/develop; then
+  FALLBACK=develop
+elif git show-ref --verify --quiet refs/remotes/origin/develop; then
+  FALLBACK=origin/develop   # new branch will fork from and track origin/develop
+else
+  DEF="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
+  DEF="${DEF:-master}"
+  git show-ref --verify --quiet "refs/heads/$DEF" && FALLBACK="$DEF" || FALLBACK="origin/$DEF"
+fi
+
+# Apply the precedence. BASE is the start-point ref passed to `git worktree add`.
+if [ -n "$EXPLICIT_BASE" ]; then
+  BASE="$EXPLICIT_BASE"
+elif printf '%s\n' "$CURRENT" | grep -qxE "$PROTECTED" || [ "$CURRENT" = DETACHED ]; then
+  BASE="$FALLBACK"          # on a protected/detached ref -> integration branch
+else
+  BASE="$CURRENT"           # on a feature branch -> continue current work
+fi
+echo "Base: $BASE  (current: $CURRENT)"
+```
+
+`BASE` is always a concrete start-point (a local branch like `develop`, a
+remote-tracking ref like `origin/develop`, or the user's explicit base). Report
+the resolved base and the reason before creating anything.
+
+## Phase 3: Freshness Check (warn, do not fetch)
+
+Local mode is the default: branch from the local tip of `$BASE`. If the base has
+an upstream and is behind it, warn — do not silently fetch.
+
+```bash
+if git rev-parse --verify --quiet "$BASE@{upstream}" >/dev/null; then
+  BEHIND="$(git rev-list --count "$BASE..$BASE@{upstream}" 2>/dev/null || echo 0)"
+  [ "$BEHIND" -gt 0 ] && echo "WARNING: local $BASE is $BEHIND commit(s) behind its remote. Using local tip. Pass --fetch to update first."
+fi
+```
+
+Only if the user passed `--fetch`:
+
+```bash
+git fetch origin "$BASE"
+git update-ref "refs/heads/$BASE" "origin/$BASE"   # only when safe / fast-forward
+```
+
+Do not fetch by default. Do not rewrite a base branch that has local commits not
+on the remote — warn and use the local tip instead.
+
+## Phase 4: Ensure `.worktrees/` Is Gitignored
+
+The worktree directory must never be tracked. Verify, and fix once if needed.
+
+```bash
+if ! git -C "$TOPLEVEL" check-ignore -q .worktrees; then
+  # .worktrees/ is not ignored yet — confirm, then add and commit
+  printf '\n# Local git worktrees (created by the worktree skill)\n.worktrees/\n' >> "$TOPLEVEL/.gitignore"
+  git -C "$TOPLEVEL" add .gitignore
+  git -C "$TOPLEVEL" commit -m "chore: ignore .worktrees/ directory"
+fi
+```
+
+This is the only commit the skill makes, and only the first time in a repo.
+Confirm before committing in a shared repo.
+
+## Phase 5: Create the Worktree
+
+```bash
+NAME="<sanitized-name>"
+BRANCH="<new-branch-name>"
+DEST="$TOPLEVEL/.worktrees/$NAME"
+
+# Guard: destination must not already exist
+[ -e "$DEST" ] && { echo "Path exists: $DEST — choose another name or remove it first."; exit 1; }
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  # Branch already exists: confirm, then attach it (no -b, no new branch)
+  git worktree add "$DEST" "$BRANCH"
+else
+  # New branch off the resolved local base tip
+  git worktree add -b "$BRANCH" "$DEST" "$BASE"
+fi
+
+git worktree list
+```
+
+Rules:
+
+- Use `-b` only when creating a new branch. If the branch exists, attach it and
+  say so — never silently reset an existing branch.
+- A branch can be checked out in only one worktree at a time. If `$BRANCH` is
+  already checked out elsewhere, report where and stop.
+- Never pass `--force`. If git refuses, surface the reason and let the user decide.
+
+## Phase 6: Report and Hand Off
+
+Report:
+
+- Worktree path: `.worktrees/<name>`
+- New branch and the base it forked from (plus why that base)
+- Any freshness warning from Phase 3
+- How to start work there: `cd .worktrees/<name>` and open a parallel session in
+  that directory. Each worktree is an independent checkout sharing one `.git`.
+- If the project needs dependencies, install them inside the worktree before
+  running anything (worktrees do not share `node_modules`).
+
+## Modes
+
+- `worktree <name>` — create a worktree named `<name>` on a new branch `<name>`,
+  base resolved by the smart rules above. (Default.)
+- `worktree <name> from <base>` / `worktree <name> --base <base>` — force the base.
+- `worktree <name> --fetch` — refresh the base from origin before branching.
+- `worktree list` — list existing worktrees and their branches; create nothing.
+
+When the user scopes it differently ("off master", "use my current branch",
+"don't touch gitignore"), honor the scope but keep the safety checks that prevent
+tracking the worktree dir or clobbering an existing branch/path.
+
+## Safety Model
+
+1. Never switches the current branch or modifies the current working tree's
+   tracked files. A worktree is additive.
+2. Never tracks the worktree directory — `.worktrees/` is verified ignored first.
+3. Local tips by default; network only on explicit `--fetch`.
+4. Never `--force`, never reset an existing branch, never overwrite an existing
+   path. On conflict, report and stop.
+5. Removal and pruning are out of scope — hand off to `release-cleanup`.

--- a/bundles/dev-workflow/skills/worktree/plugin.json
+++ b/bundles/dev-workflow/skills/worktree/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "worktree",
+  "version": "1.0.0",
+  "description": "Create an isolated git worktree off the right base branch (current feature branch, else develop) in a clean gitignored directory",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/github/README.md
+++ b/bundles/github/README.md
@@ -19,4 +19,5 @@ GitHub workflow and automation skills
 - `gh-review-suggestions`
 - `github-actions-author`
 - `git-safety`
+- `release-cleanup`
 - `release-pr-gates`

--- a/bundles/github/README.md
+++ b/bundles/github/README.md
@@ -21,3 +21,5 @@ GitHub workflow and automation skills
 - `git-safety`
 - `release-cleanup`
 - `release-pr-gates`
+- `worktree`
+- `finishing-a-development-branch`

--- a/bundles/github/skills/finishing-a-development-branch/SKILL.md
+++ b/bundles/github/skills/finishing-a-development-branch/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: finishing-a-development-branch
+description: >-
+  Structured "done coding, now what?" workflow: verify tests pass, detect the
+  repository environment (normal repo vs worktree, named branch vs detached
+  HEAD), present exactly the right merge / PR / keep / discard options, and
+  execute the chosen path including safe worktree cleanup. Use when
+  implementation is complete and the branch needs to be integrated, published,
+  or abandoned.
+metadata:
+  version: "1.0.0"
+  tags: "git, branch, merge, pull-request, workflow, worktree, cleanup"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *) Bash(gh *)
+when_to_use: "finish branch, done coding, ready to merge, create PR, close branch, wrap up feature, branch cleanup, integration workflow"
+---
+
+# Finishing a Development Branch
+
+Guide completion of development work by presenting clear options and handling
+the chosen workflow end-to-end.
+
+**Core principle:** Verify tests → Detect environment → Present options →
+Execute choice → Clean up.
+
+## The Process
+
+### Step 1: Verify Tests
+
+Before presenting any options, run the project's test suite:
+
+```bash
+# Use whichever test runner the project uses
+npm test / bun test / cargo test / pytest / go test ./...
+```
+
+If tests fail:
+
+```
+Tests failing (<N> failures). Must fix before completing:
+
+[show failures]
+
+Cannot proceed with merge/PR until tests pass.
+```
+
+Stop. Do not continue to Step 2 while tests are red.
+
+If tests pass, continue to Step 2.
+
+### Step 2: Detect Environment
+
+Determine workspace state before presenting options:
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+```
+
+| State | Menu | Cleanup |
+|-------|------|---------|
+| `GIT_DIR == GIT_COMMON` (normal repo) | 4-option menu | No worktree to clean up |
+| `GIT_DIR != GIT_COMMON`, named branch | 4-option menu | Provenance-based (see Step 6) |
+| `GIT_DIR != GIT_COMMON`, detached HEAD | 3-option menu (no local merge) | Externally managed — do not remove |
+
+### Step 3: Determine Base Branch
+
+```bash
+git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
+```
+
+If neither resolves, ask the user: "This branch appears to split from `main` —
+is that correct?"
+
+### Step 4: Present Options
+
+**Normal repo and named-branch worktree — exactly 4 options:**
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base-branch> locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (handle it later)
+4. Discard this work
+
+Which option?
+```
+
+**Detached HEAD — exactly 3 options:**
+
+```
+Implementation complete. You're on a detached HEAD (externally managed workspace).
+
+1. Push as new branch and create a Pull Request
+2. Keep as-is (handle it later)
+3. Discard this work
+
+Which option?
+```
+
+Do not add explanation text to the menu — keep it concise.
+
+### Step 5: Execute Choice
+
+#### Option 1: Merge Locally
+
+```bash
+# Resolve main repo root first (safe when running inside a worktree)
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+
+git checkout <base-branch>
+git pull
+git merge <feature-branch>
+```
+
+Run the test suite again on the merged result. Only after tests pass on the
+merge: run Step 6 to clean up the worktree, then delete the branch:
+
+```bash
+git branch -d <feature-branch>
+```
+
+#### Option 2: Push and Create PR
+
+```bash
+git push -u origin <feature-branch>
+
+gh pr create --title "<descriptive title>" --body "$(cat <<'EOF'
+## Summary
+- <what changed, 2-3 bullets>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+Do **not** clean up the worktree — the user needs it alive to iterate on PR
+feedback.
+
+#### Option 3: Keep As-Is
+
+Report: "Keeping branch `<name>`. Worktree preserved at `<path>`."
+
+Do not clean up the worktree.
+
+#### Option 4: Discard
+
+Require typed confirmation before destroying anything:
+
+```
+This will permanently delete:
+- Branch <name>
+- All commits: <commit list>
+- Worktree at <path> (if applicable)
+
+Type 'discard' to confirm.
+```
+
+Wait for the exact word. If confirmed:
+
+```bash
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+```
+
+Run Step 6 to clean up the worktree, then force-delete the branch:
+
+```bash
+git branch -D <feature-branch>
+```
+
+### Step 6: Cleanup Workspace
+
+This step runs **only for Options 1 and 4**. Options 2 and 3 always preserve
+the worktree.
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+WORKTREE_PATH=$(git rev-parse --show-toplevel)
+```
+
+**If `GIT_DIR == GIT_COMMON`:** This is a normal repo checkout. No worktree to
+clean up. Done.
+
+**If the worktree path is under `.worktrees/` or `worktrees/` relative to the
+main repo root:** The current workflow created this worktree — it is safe to
+remove it.
+
+```bash
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+git worktree remove "$WORKTREE_PATH"
+git worktree prune   # clean up any stale registrations
+```
+
+**Otherwise:** The host environment owns this workspace. Do **not** remove it.
+Leave the workspace in place and report the path to the user.
+
+## Quick Reference
+
+| Option | Merge | Push | Keep Worktree | Delete Branch |
+|--------|-------|------|---------------|---------------|
+| 1. Merge locally | yes | — | — | yes (safe `-d`) |
+| 2. Create PR | — | yes | yes | — |
+| 3. Keep as-is | — | — | yes | — |
+| 4. Discard | — | — | — | yes (force `-D`) |
+
+## Common Mistakes
+
+**Skipping test verification**
+
+- Problem: Broken code gets merged or published as a PR.
+- Fix: Always verify tests before offering options.
+
+**Open-ended questions instead of the menu**
+
+- Problem: "What should I do next?" is ambiguous and stalls the workflow.
+- Fix: Present exactly 4 structured options (or 3 for detached HEAD).
+
+**Cleaning up the worktree for Option 2**
+
+- Problem: The user needs the worktree alive to iterate on PR feedback.
+- Fix: Only clean up for Options 1 and 4.
+
+**Deleting the branch before removing the worktree**
+
+- Problem: `git branch -d` fails because the worktree still references it.
+- Fix: Remove the worktree first, then delete the branch.
+
+**Running `git worktree remove` from inside the worktree**
+
+- Problem: The command fails or silently does nothing.
+- Fix: Always `cd` to the main repo root before calling `git worktree remove`.
+
+**Cleaning up externally-managed worktrees**
+
+- Problem: Removing a workspace the host environment created causes phantom state.
+- Fix: Only clean up worktrees under `.worktrees/` or `worktrees/` paths that
+  the current workflow owns. If provenance is unclear, leave it.
+
+**No confirmation for discard**
+
+- Problem: Work is accidentally destroyed.
+- Fix: Require the exact word `discard` typed by the user before proceeding.
+
+## Iron Rules
+
+Never:
+
+- Proceed with failing tests.
+- Merge without re-verifying tests on the merged result.
+- Delete work without explicit typed confirmation.
+- Force-push without an explicit request from the user.
+- Remove a worktree before confirming the merge succeeded.
+- Clean up worktrees whose provenance is unknown or externally managed.
+- Run `git worktree remove` from inside the worktree being removed.
+
+Always:
+
+- Verify tests before offering options.
+- Detect environment before presenting the menu.
+- Present exactly 4 options (or 3 for detached HEAD) — no more, no less.
+- Get typed `discard` confirmation for Option 4.
+- Clean up the worktree for Options 1 and 4 only.
+- `cd` to the main repo root before any worktree removal.
+- Run `git worktree prune` after removal.

--- a/bundles/github/skills/finishing-a-development-branch/plugin.json
+++ b/bundles/github/skills/finishing-a-development-branch/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "finishing-a-development-branch",
+  "version": "1.0.0",
+  "description": "Verify tests, detect environment, present merge/PR/cleanup options, execute the chosen path at branch completion.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/github/skills/release-cleanup/SKILL.md
+++ b/bundles/github/skills/release-cleanup/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: release-cleanup
+description: Verify a release was fully promoted through develop, staging, and master/main, then prune merged local and remote branches and stale git worktrees. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, tidy up after promoting develop to staging to master, or confirm nothing stale was left behind before pruning.
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+metadata:
+  version: "1.0.0"
+  tags: "git, cleanup, branches, worktrees, release, prune, ci-cd"
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+# Release Cleanup
+
+Confirm a release was fully promoted up the branch chain, then prune the branches
+and git worktrees that promotion left behind. Verification is a hard gate: never
+prune until the chain is proven complete and no in-flight work is stranded.
+
+This skill is standalone and manually triggerable. It does not promote code (use
+`release-pr-gates` for that) and does not deploy (use `deploy`). It runs after a
+promotion has landed and tidies up.
+
+## Contract
+
+Inputs:
+
+- Repository root with a git remote
+- Branch chain to verify, or permission to auto-detect (`develop` -> `staging` -> `master`/`main`)
+- Optional mode: `verify` (gate only), `dry-run` (default, plan only), or `prune` (execute after confirmation)
+
+Outputs:
+
+- Promotion verification result per chain hop (complete / incomplete)
+- List of stranded branches not merged into `develop` (potential forgotten work)
+- Prune plan: local branches, remote branches, and worktrees that are safe to remove
+- Final summary of what was removed and what was skipped
+
+Creates/Modifies:
+
+- Deletes local branches merged into the production branch (never the protected set)
+- Deletes remote branches merged into the production branch
+- Removes git worktrees whose branch is merged or whose upstream is gone, and runs `git worktree prune`
+- Prunes stale remote-tracking refs (`git remote prune`)
+- Never deletes anything with unmerged commits or a dirty worktree
+
+External Side Effects:
+
+- Reads and deletes GitHub remote branches via `git push origin --delete`
+- Reads GitHub branch and PR state to confirm merges
+- Does not merge, deploy, or rewrite history
+
+Confirmation Required:
+
+- Before any deletion (local branch, remote branch, or worktree) — always print the dry-run plan and require an explicit yes
+- Before pruning when promotion verification is incomplete (default is to STOP, not prompt)
+- Before force-removing a worktree or force-deleting a branch (never done automatically)
+
+Delegates To:
+
+- `release-pr-gates` when the chain is NOT fully promoted and the user wants to finish the promotion first
+- `gh-fix-ci` when a promotion PR is still open with failing checks
+- `git-safety` when a branch about to be pruned may contain secrets in history worth scrubbing first
+
+## When to Use
+
+- After promoting `develop` -> `staging` -> `master` and you want to delete the merged feature/release branches and worktrees
+- Manually, any time, to verify the chain is fully promoted and see what is safe to prune
+- To confirm "nothing is stale" — that every branch intended for the release actually reached the production branch — before tidying up
+
+Do not use this skill to promote code or to delete unmerged work. It only removes
+what is provably merged.
+
+## Safety Model
+
+Protected branches are never deleted:
+
+```
+develop  staging  master  main  + the currently checked-out branch + HEAD
+```
+
+Hard rules:
+
+1. Pruning uses `git branch --merged` / `git branch -r --merged` against the
+   production branch only. A branch with even one commit not in the production
+   branch is never listed for deletion.
+2. Worktrees with uncommitted changes are never removed. They are reported and skipped.
+3. The default mode is `dry-run`: print the exact plan and stop. Deletion only
+   happens in `prune` mode after the user confirms the printed plan.
+4. Force flags (`git branch -D`, `git worktree remove --force`, `git push --delete`
+   of an unmerged branch) are never used automatically. If a branch looks
+   important but is unmerged, report it — do not remove it.
+5. If promotion verification fails, STOP. Do not offer to prune around it.
+
+## Phase 1: Discover Branches and Refresh State
+
+```bash
+gh auth status -h github.com
+git status -sb
+git remote -v
+git fetch --all --prune
+gh repo view --json nameWithOwner,defaultBranchRef
+git branch -r --list 'origin/develop' 'origin/staging' 'origin/master' 'origin/main'
+```
+
+Determine the chain from the branches that actually exist on the remote:
+
+- Production branch = `master` if it exists, else `main`, else the repo default branch.
+- Chain = the subset of `develop` -> `staging` -> production that exists.
+- If neither `develop` nor `staging` exists (e.g. a master-only repo), the chain
+  collapses to "everything is merged into the production branch" and verification
+  checks only that.
+
+## Phase 2: Promotion Verification (Hard Gate)
+
+Prove each hop carries no un-promoted commits. Each command must return empty.
+
+```bash
+# develop fully promoted into staging? (commits in develop missing from staging)
+git log --oneline origin/staging..origin/develop
+
+# staging fully promoted into production? (commits in staging missing from master/main)
+git log --oneline origin/master..origin/staging
+```
+
+When `staging` does not exist, check `develop` against production directly:
+
+```bash
+git log --oneline origin/master..origin/develop
+```
+
+Also surface potential forgotten work — branches whose commits never reached
+`develop`. These are "stale" candidates the user may have meant to include:
+
+```bash
+# remote branches NOT merged into develop (or production if no develop)
+git branch -r --no-merged origin/develop --format '%(refname:short)' \
+  | grep -vE '^origin/(develop|staging|master|main|HEAD)'
+```
+
+Gate outcome:
+
+- Any non-empty promotion hop => promotion is INCOMPLETE. Report exactly which
+  commits are un-promoted and STOP. Offer to hand off to `release-pr-gates` to
+  finish the promotion. Do not prune.
+- Stranded branches not merged into `develop` => report them as a warning. They
+  are not pruned (they are unmerged) but the user should decide whether they were
+  meant to ship. This is the "nothing is stale" check.
+- All hops empty and no surprising stranded branches => verification passes;
+  continue to Phase 3.
+
+## Phase 3: Build the Prune Plan (Dry-Run, Default)
+
+Compute the safe-to-remove sets against the production branch only.
+
+```bash
+PROD=origin/master   # or origin/main per Phase 1
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
+PROTECT='develop|staging|master|main'
+
+# Local branches fully merged into production (excluding protected + current)
+git branch --merged "$PROD" --format '%(refname:short)' \
+  | grep -vxE "$PROTECT" \
+  | { [ -n "$CURRENT" ] && grep -vx "$CURRENT" || cat; }
+
+# Remote branches fully merged into production (excluding protected)
+git branch -r --merged "$PROD" --format '%(refname:short)' \
+  | sed 's#^origin/##' \
+  | grep -vxE "$PROTECT|HEAD"
+
+# Worktrees: list, then classify
+git worktree list --porcelain
+```
+
+For each worktree other than the main checkout, classify it:
+
+- Branch merged into production AND no uncommitted changes (`git -C <path> status --porcelain` empty) => safe to remove.
+- Uncommitted changes => SKIP, report as dirty.
+- Branch unmerged => SKIP, report as unmerged.
+- Upstream gone (branch deleted on remote) and merged => safe to remove.
+
+Print the plan as three explicit lists — local branches, remote branches,
+worktree paths — plus a skipped list with reasons. Then stop and ask for
+confirmation. In `dry-run` (default) and `verify` modes, end here.
+
+## Phase 4: Execute Prune (Only in `prune` Mode, After Confirmation)
+
+Only after the user confirms the printed plan:
+
+```bash
+# Local merged branches
+git branch -d <branch> ...        # -d (safe). Never -D automatically.
+
+# Remote merged branches (origin is HTTPS or SSH; uses configured auth)
+git push origin --delete <branch> ...
+
+# Worktrees flagged safe
+git worktree remove <path> ...    # never --force; refuses on dirty
+git worktree prune
+
+# Drop stale remote-tracking refs
+git remote prune origin
+git fetch --all --prune
+```
+
+Rules during execution:
+
+- If `git branch -d` refuses (not fully merged), do not escalate to `-D`. Report and skip.
+- If `git worktree remove` refuses (dirty/locked), do not `--force`. Report and skip.
+- Delete remote branches one batch; if a delete fails (protected on the server),
+  report it and continue with the rest.
+
+## Modes
+
+- `release-cleanup verify` — Phase 1 + 2 only. Report promotion status and stranded branches. No plan, no deletion.
+- `release-cleanup` or `release-cleanup dry-run` — Phases 1-3. Verify, then print the prune plan. No deletion. (Default.)
+- `release-cleanup prune` — Phases 1-4. Verify, print plan, confirm, then delete.
+
+If the user explicitly scopes the cleanup ("only worktrees", "local branches
+only", "skip remote"), honor it: still run verification, but restrict the plan
+and execution to the requested resource types.
+
+## Final Status
+
+Report:
+
+- Repository and production branch used
+- Chain verified and each hop's result (complete / incomplete)
+- Stranded branches not merged into `develop`, if any
+- Local branches deleted / skipped (with reasons)
+- Remote branches deleted / skipped (with reasons)
+- Worktrees removed / skipped (with reasons)
+- Whether anything was blocked and what the user should decide next

--- a/bundles/github/skills/release-cleanup/plugin.json
+++ b/bundles/github/skills/release-cleanup/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "release-cleanup",
+  "version": "1.0.0",
+  "description": "Verify a release was fully promoted through develop, staging, and master, then prune merged branches and stale worktrees",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/github/skills/worktree/SKILL.md
+++ b/bundles/github/skills/worktree/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: worktree
+description: Create an isolated git worktree from the correct base branch and check it out into a clean, gitignored directory. Use when the user asks to make a worktree, spin up a parallel/isolated workspace, work on something without disturbing the current checkout, branch off the current work, or run multiple agents on the same repo at once. Picks the base branch smartly — the current feature branch when you are on one, otherwise the develop integration branch — so worktrees continue your in-progress work by default instead of forking from the wrong place.
+compatibility: Requires git 2.5+ (worktree support).
+metadata:
+  version: "1.0.0"
+  tags: "git, worktree, branch, isolation, parallel, workspace"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *)
+when_to_use: "make a worktree, create a worktree, new worktree, isolated workspace, parallel workspace, work on this separately, branch off current work, spin up a sibling checkout, run another agent on this repo"
+---
+
+# Worktree
+
+Create a git worktree off the **right base branch**, in a clean gitignored
+directory, with the safety checks that keep the main checkout and `.gitignore`
+correct. This skill only **creates** and **lists** worktrees. Removing and
+pruning merged worktrees is `release-cleanup`'s job — do not delete here.
+
+## Contract
+
+Inputs:
+
+- Repository root (must be inside a git work tree)
+- Optional worktree/branch name (the new branch to create)
+- Optional explicit base branch override (`from <base>` / `--base <base>`)
+- Optional `--fetch` flag to refresh the base from origin before branching
+
+Outputs:
+
+- A new worktree directory at `.worktrees/<name>` checked out on a new branch
+- The resolved base branch and why it was chosen
+- A warning if the base is behind its remote (local mode does not auto-fetch)
+- The path to `cd` into, ready for a parallel session
+
+Creates/Modifies:
+
+- Adds `.worktrees/` to `.gitignore` and commits that change if not already ignored
+- Creates a new branch and a new worktree directory
+- Never touches the current working tree's tracked files, never switches the current branch
+
+External Side Effects:
+
+- None by default (local tips only, no network)
+- Only with `--fetch`: a single `git fetch origin <base>` to refresh the base ref
+
+Confirmation Required:
+
+- Before writing to `.gitignore` and committing it (one-time, only if `.worktrees/` is not yet ignored)
+- Before reusing an existing branch instead of creating a new one
+- Before overwriting or reusing a worktree path that already exists
+
+Delegates To:
+
+- `release-cleanup` to verify promotion and prune merged worktrees and branches
+- `git-safety` if a branch about to live in a worktree may contain secrets
+
+## Base Branch Selection (the core behavior)
+
+The base is resolved in this order. **Local tips only — no automatic fetch.**
+
+1. **Explicit override.** If the user named a base (`/worktree fix-auth from develop`
+   or `--base release/1.4`), use it verbatim.
+2. **On a feature branch → branch off the current branch.** If the current branch
+   is not one of the protected/integration branches, the worktree forks from it.
+   This is the default: you stay on your in-progress work and explore a sibling
+   line without disturbing the current checkout.
+3. **On a protected branch or detached HEAD → branch off `develop`.** If the
+   current branch is `master`, `main`, `develop`, or `staging`, or HEAD is
+   detached, fork from the integration branch instead of an integration branch's
+   tip-as-feature. Prefer local `develop`; if no `develop` exists, fall back to
+   the repository's default branch.
+
+```text
+current branch          ->  base the worktree forks from
+----------------------      ----------------------------
+feat/foo  (feature)     ->  feat/foo        (continue current work)
+bugfix/x  (feature)     ->  bugfix/x        (continue current work)
+master / main           ->  develop         (or default branch if no develop)
+develop / staging       ->  develop
+detached HEAD           ->  develop         (or default branch if no develop)
+explicit "from <base>"  ->  <base>          (always wins)
+```
+
+Protected/integration set (never used as a "feature" base in step 2):
+
+```
+master  main  develop  staging
+```
+
+## Phase 1: Verify Repo and Resolve Inputs
+
+```bash
+git rev-parse --is-inside-work-tree            # must be true; else STOP
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo DETACHED)"
+git worktree list                              # show what already exists
+```
+
+Resolve the **new branch name**:
+
+- If the user gave a name, use it as the new branch name and the directory name.
+- If no name was given, ask for one. Do not invent a throwaway name.
+- Sanitize the directory name from the branch name (a branch like `feat/foo`
+  becomes directory `.worktrees/feat-foo` while the branch stays `feat/foo`).
+
+## Phase 2: Resolve the Base Branch
+
+```bash
+PROTECTED='master|main|develop|staging'
+
+# Integration fallback, resolved to a ref that actually exists locally.
+# Prefer local develop, then the remote-tracking origin/develop (still local,
+# no fetch), then the repo's default branch.
+if git show-ref --verify --quiet refs/heads/develop; then
+  FALLBACK=develop
+elif git show-ref --verify --quiet refs/remotes/origin/develop; then
+  FALLBACK=origin/develop   # new branch will fork from and track origin/develop
+else
+  DEF="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
+  DEF="${DEF:-master}"
+  git show-ref --verify --quiet "refs/heads/$DEF" && FALLBACK="$DEF" || FALLBACK="origin/$DEF"
+fi
+
+# Apply the precedence. BASE is the start-point ref passed to `git worktree add`.
+if [ -n "$EXPLICIT_BASE" ]; then
+  BASE="$EXPLICIT_BASE"
+elif printf '%s\n' "$CURRENT" | grep -qxE "$PROTECTED" || [ "$CURRENT" = DETACHED ]; then
+  BASE="$FALLBACK"          # on a protected/detached ref -> integration branch
+else
+  BASE="$CURRENT"           # on a feature branch -> continue current work
+fi
+echo "Base: $BASE  (current: $CURRENT)"
+```
+
+`BASE` is always a concrete start-point (a local branch like `develop`, a
+remote-tracking ref like `origin/develop`, or the user's explicit base). Report
+the resolved base and the reason before creating anything.
+
+## Phase 3: Freshness Check (warn, do not fetch)
+
+Local mode is the default: branch from the local tip of `$BASE`. If the base has
+an upstream and is behind it, warn — do not silently fetch.
+
+```bash
+if git rev-parse --verify --quiet "$BASE@{upstream}" >/dev/null; then
+  BEHIND="$(git rev-list --count "$BASE..$BASE@{upstream}" 2>/dev/null || echo 0)"
+  [ "$BEHIND" -gt 0 ] && echo "WARNING: local $BASE is $BEHIND commit(s) behind its remote. Using local tip. Pass --fetch to update first."
+fi
+```
+
+Only if the user passed `--fetch`:
+
+```bash
+git fetch origin "$BASE"
+git update-ref "refs/heads/$BASE" "origin/$BASE"   # only when safe / fast-forward
+```
+
+Do not fetch by default. Do not rewrite a base branch that has local commits not
+on the remote — warn and use the local tip instead.
+
+## Phase 4: Ensure `.worktrees/` Is Gitignored
+
+The worktree directory must never be tracked. Verify, and fix once if needed.
+
+```bash
+if ! git -C "$TOPLEVEL" check-ignore -q .worktrees; then
+  # .worktrees/ is not ignored yet — confirm, then add and commit
+  printf '\n# Local git worktrees (created by the worktree skill)\n.worktrees/\n' >> "$TOPLEVEL/.gitignore"
+  git -C "$TOPLEVEL" add .gitignore
+  git -C "$TOPLEVEL" commit -m "chore: ignore .worktrees/ directory"
+fi
+```
+
+This is the only commit the skill makes, and only the first time in a repo.
+Confirm before committing in a shared repo.
+
+## Phase 5: Create the Worktree
+
+```bash
+NAME="<sanitized-name>"
+BRANCH="<new-branch-name>"
+DEST="$TOPLEVEL/.worktrees/$NAME"
+
+# Guard: destination must not already exist
+[ -e "$DEST" ] && { echo "Path exists: $DEST — choose another name or remove it first."; exit 1; }
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  # Branch already exists: confirm, then attach it (no -b, no new branch)
+  git worktree add "$DEST" "$BRANCH"
+else
+  # New branch off the resolved local base tip
+  git worktree add -b "$BRANCH" "$DEST" "$BASE"
+fi
+
+git worktree list
+```
+
+Rules:
+
+- Use `-b` only when creating a new branch. If the branch exists, attach it and
+  say so — never silently reset an existing branch.
+- A branch can be checked out in only one worktree at a time. If `$BRANCH` is
+  already checked out elsewhere, report where and stop.
+- Never pass `--force`. If git refuses, surface the reason and let the user decide.
+
+## Phase 6: Report and Hand Off
+
+Report:
+
+- Worktree path: `.worktrees/<name>`
+- New branch and the base it forked from (plus why that base)
+- Any freshness warning from Phase 3
+- How to start work there: `cd .worktrees/<name>` and open a parallel session in
+  that directory. Each worktree is an independent checkout sharing one `.git`.
+- If the project needs dependencies, install them inside the worktree before
+  running anything (worktrees do not share `node_modules`).
+
+## Modes
+
+- `worktree <name>` — create a worktree named `<name>` on a new branch `<name>`,
+  base resolved by the smart rules above. (Default.)
+- `worktree <name> from <base>` / `worktree <name> --base <base>` — force the base.
+- `worktree <name> --fetch` — refresh the base from origin before branching.
+- `worktree list` — list existing worktrees and their branches; create nothing.
+
+When the user scopes it differently ("off master", "use my current branch",
+"don't touch gitignore"), honor the scope but keep the safety checks that prevent
+tracking the worktree dir or clobbering an existing branch/path.
+
+## Safety Model
+
+1. Never switches the current branch or modifies the current working tree's
+   tracked files. A worktree is additive.
+2. Never tracks the worktree directory — `.worktrees/` is verified ignored first.
+3. Local tips by default; network only on explicit `--fetch`.
+4. Never `--force`, never reset an existing branch, never overwrite an existing
+   path. On conflict, report and stop.
+5. Removal and pruning are out of scope — hand off to `release-cleanup`.

--- a/bundles/github/skills/worktree/plugin.json
+++ b/bundles/github/skills/worktree/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "worktree",
+  "version": "1.0.0",
+  "description": "Create an isolated git worktree off the right base branch (current feature branch, else develop) in a clean gitignored directory",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/planning/README.md
+++ b/bundles/planning/README.md
@@ -20,3 +20,4 @@ Strategy, planning, and analysis skills
 - `writing-prds`
 - `prd-quality-gate`
 - `rules-capture`
+- `writing-plans`

--- a/bundles/planning/README.md
+++ b/bundles/planning/README.md
@@ -17,4 +17,6 @@ Strategy, planning, and analysis skills
 - `cto-advisor`
 - `business-operator`
 - `task-prd-creator`
+- `writing-prds`
+- `prd-quality-gate`
 - `rules-capture`

--- a/bundles/planning/skills/prd-quality-gate/SKILL.md
+++ b/bundles/planning/skills/prd-quality-gate/SKILL.md
@@ -12,6 +12,7 @@ following sections as markdown headings (## or ###). Missing sections reduce pla
 quality and risk hallucinated scope.
 
 Required sections:
+
 - Executive Summary
 - Problem Statement
 - Goals
@@ -20,11 +21,13 @@ Required sections:
 - Verification Plan
 
 When the quality gate is ENABLED (blocking):
+
 - Missing any required section → fail immediately with an actionable message
   listing the missing sections.
 - The author must update the PRD and re-run the gate before planning proceeds.
 
 When the quality gate is DISABLED (default, warning-only):
+
 - Missing sections → log a warning.
 - Planning proceeds. The planner should still note the gaps in its output.
 

--- a/bundles/planning/skills/prd-quality-gate/SKILL.md
+++ b/bundles/planning/skills/prd-quality-gate/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: prd-quality-gate
+description: PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
+metadata:
+  version: "1.0.0"
+  tags: "prd, planning, validation, quality-gate, spec, requirements"
+---
+
+<prd_quality_gate>
+A well-formed PRD (or the issue body that serves as one) must contain ALL of the
+following sections as markdown headings (## or ###). Missing sections reduce plan
+quality and risk hallucinated scope.
+
+Required sections:
+- Executive Summary
+- Problem Statement
+- Goals
+- Functional Requirements
+- Acceptance Criteria
+- Verification Plan
+
+When the quality gate is ENABLED (blocking):
+- Missing any required section → fail immediately with an actionable message
+  listing the missing sections.
+- The author must update the PRD and re-run the gate before planning proceeds.
+
+When the quality gate is DISABLED (default, warning-only):
+- Missing sections → log a warning.
+- Planning proceeds. The planner should still note the gaps in its output.
+
+Section matching is case-insensitive against ## and ### headings. Exact heading
+text must appear (e.g. "## Executive Summary" or "### Goals"). Headings nested
+inside code fences are ignored by convention (they are examples, not structure).
+</prd_quality_gate>

--- a/bundles/planning/skills/prd-quality-gate/plugin.json
+++ b/bundles/planning/skills/prd-quality-gate/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "prd-quality-gate",
+  "version": "1.0.0",
+  "description": "PRD completeness validation — check required sections before a spec is handed to a planning agent",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/planning/skills/writing-plans/SKILL.md
+++ b/bundles/planning/skills/writing-plans/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: writing-plans
+description: >-
+  Turn a spec or requirements doc into a comprehensive, bite-sized implementation plan: map every file, define 2-5 minute TDD tasks with complete code, and enforce DRY/YAGNI/frequent-commits discipline. Use when you have requirements ready and need a concrete execution plan before touching code, when a feature spans multiple files and needs decomposition, or when you want agentic workers to execute tasks reliably without guessing.
+metadata:
+  version: "1.0.0"
+  tags: "planning, implementation-plan, tasks, tdd, dry, yagni, decomposition"
+  author: Ship Shit Dev
+when_to_use: "write a plan, create implementation plan, plan this feature, break this into tasks, plan before coding, spec to tasks"
+---
+
+# Writing Plans
+
+Write a comprehensive implementation plan assuming the implementer has zero context about the codebase and questionable test instincts. Document everything: which files to touch, complete code, exact commands, expected output, and how to verify. Deliver the whole plan as bite-sized checkboxed tasks. DRY. YAGNI. TDD. Frequent commits.
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, consider breaking it into separate plans — one per subsystem. Each plan should produce working, testable software on its own. Deeply coupled work can share a plan; independently deployable subsystems should not.
+
+## File Mapping (Before Any Tasks)
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- Prefer smaller, focused files over large files that do too much. The agent edits most reliably when it can hold the full file in context.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large files, do not unilaterally restructure — but if a file you are modifying has grown unwieldy, including a split in the plan is reasonable.
+
+This structure informs task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+Each step is one action, completable in 2-5 minutes:
+
+- "Write the failing test" — one step
+- "Run it to confirm it fails" — one step
+- "Write the minimal implementation to make it pass" — one step
+- "Run the tests and confirm they pass" — one step
+- "Commit" — one step
+
+Never combine steps. Never skip the failure confirmation.
+
+## Plan Document Header
+
+Every plan MUST start with this header:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries used]
+
+---
+```
+
+## Task Structure Template
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.ts`
+- Modify: `exact/path/to/existing.ts`
+- Test: `tests/exact/path/to/file.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+it('describes specific behavior', () => {
+  const result = functionUnderTest(input)
+  expect(result).toBe(expectedValue)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+bun run test tests/path/to/file.test.ts
+```
+
+Expected: FAIL — `functionUnderTest is not defined` (or similar)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+export function functionUnderTest(input: InputType): OutputType {
+  return expectedValue
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+bun run test tests/path/to/file.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/to/file.test.ts src/path/to/file.ts
+git commit -m "feat: add specific behavior"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content the implementer needs. The following are **plan failures** — never write them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" without the actual test code
+- "Similar to Task N" — repeat the code; the implementer may read tasks out of order
+- Steps that describe what to do without showing how (every code step requires a code block)
+- References to types, functions, or methods not defined anywhere in the plan
+
+## Iron Rules
+
+- Exact file paths always — no "somewhere in src/"
+- Complete code in every step — if a step changes code, show the full changed code
+- Exact commands with expected output or expected failure message
+- Every test written before the implementation it tests
+- Every task ends with a commit
+- DRY, YAGNI — no speculative abstractions, no future-proofing not required by the spec
+
+## Self-Review Checklist
+
+After writing the complete plan, review it against the spec before handing it off. Run this yourself — do not delegate it.
+
+**1. Spec coverage.** Skim each requirement in the spec. Can you point to a task that implements it? List any gaps and add tasks for them.
+
+**2. Placeholder scan.** Search the plan for any pattern from the "No Placeholders" section above. Fix every hit before proceeding.
+
+**3. Type and name consistency.** Do the types, method signatures, and property names used in later tasks match what is defined in earlier tasks? A function named `clearItems()` in Task 3 and `clearAllItems()` in Task 7 is a bug in the plan. Fix it.
+
+If you find issues, fix them inline. Then hand off.
+
+## Saving the Plan
+
+Save the plan to a file in the project before execution. A sensible default location is `docs/plans/YYYY-MM-DD-<feature-name>.md`, but defer to any project convention or user preference.
+
+## Execution Handoff
+
+After saving the plan, offer the user two execution paths:
+
+> **Plan saved. Two options for execution:**
+>
+> **1. Subagent-per-task (recommended)** — dispatch a fresh subagent for each task with a review checkpoint between tasks. Faster iteration, isolated context per task, catches drift early.
+>
+> **2. Inline execution** — work through tasks sequentially in the current session, checking off each step before moving to the next.
+>
+> Which approach?
+
+Whichever path the user chooses, enforce strict task-by-task execution: complete every checkbox in a task before starting the next task. No skipping steps. No batching tasks.

--- a/bundles/planning/skills/writing-plans/plugin.json
+++ b/bundles/planning/skills/writing-plans/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "writing-plans",
+  "version": "1.0.0",
+  "description": "Turn a spec into a bite-sized TDD implementation plan with mapped files, exact code, and frequent commits.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/bundles/planning/skills/writing-prds/SKILL.md
+++ b/bundles/planning/skills/writing-prds/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: writing-prds
+description: Use when the user wants to draft, scope, or formalize a feature — "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before an agent plans it. Writes a PRD that a planning agent can consume in one shot without re-elicitation. Do NOT use for code edits, debugging, or PR reviews.
+metadata:
+  version: "1.0.0"
+  tags: "prd, planning, requirements, spec, github-issue, scoping"
+---
+
+# Writing PRDs
+
+A PRD is the input contract for the planning phase. A good PRD lets a planning
+agent produce a usable plan in one shot instead of burning turns asking "what did
+you mean by X?". A bad PRD causes planner thrash, review rejection, and
+verification failures downstream.
+
+This skill is platform-agnostic. It assumes a plan → review → verify → ship flow
+where a PRD is written first, a planner decomposes it into steps, and a verifier
+checks the result against the PRD's acceptance criteria. Adapt the storage and
+field mechanics below to whatever tracker you use.
+
+## Storage Location
+
+**Prefer making the tracker issue body the PRD.** One document per work item, one
+location: the body of an issue in the project's tracker (a GitHub issue is the
+recommended default). Avoid scattering PRDs across local sidecar files that drift
+out of sync the moment work starts.
+
+- **Create** a PRD by creating an issue whose body is clean PRD markdown.
+- **Edit** a PRD by editing that issue's body.
+- **Version history** is the tracker's edit history — no manual `updated` field.
+- **The planner reads the issue body verbatim.** What you write in the body is
+  exactly what the planning agent sees, so it must stand alone.
+
+If there is no connected tracker, decide on the single canonical location for the
+PRD before writing — do not draft into a throwaway scratch file that nobody will
+find again.
+
+## Native Tracker Metadata
+
+Do not put YAML frontmatter at the top of issue bodies. Trackers render
+issue-body frontmatter as visible noise and already have native fields for this
+metadata.
+
+Use native tracker / project-board fields instead:
+
+- **Issue type:** `Feature`, `Bug`, or `Task`.
+- **Status:** `Todo`, `In Progress`, `Done`, or `On hold`.
+- **Priority:** `P0`, `P1`, `P2`, or `P3`.
+- **Complexity:** `Low`, `Medium`, or `High`.
+- **Blast radius:** `Contained`, `Cross-package`, `Cross-app`, or `Infra`.
+
+Rules:
+
+- The PRD body starts with `# PRD: <name>` and contains only human-readable PRD content.
+- Put card/list summaries in the issue title, project fields, or a short Executive Summary, not in hidden metadata.
+- If you cannot estimate complexity, set the field to `Medium` and explain why in Risks & Open Questions.
+- `Draft` is workflow state, not body text. Keep draft PRDs off the runnable board path through status fields, not by editing the body.
+
+## Issue Title Style
+
+The issue title is what the board shows most of the time. Keep it short.
+
+- Prefer **4-7 words** when possible.
+- Prefer an **imperative verb + object** shape: `Add pipeline checkpoints`, `Track CI blockers on issues`, `Expose model selectors in settings`.
+- Put the detail in the Executive Summary and body, not in the title.
+- Avoid titles chained together with `and` / `while` / `during` unless the feature is truly one inseparable unit.
+- Avoid titles that restate the full implementation loop. The title names the work item; the PRD explains it.
+- Keep the `# PRD:` name aligned with the final issue title's slugified form. If you shorten the title, shorten the PRD heading too.
+
+Bad:
+
+- `Open draft PR during execution and ingest PR feedback into stabilization loop`
+- `Treat CI failures as blocker state on GitHub issue tasks`
+
+Better:
+
+- `Add draft PR feedback loop`
+- `Track CI blockers on issues`
+
+## Required Sections
+
+Every PRD must have these sections, in this order. Missing sections fail quality gate.
+
+```markdown
+# PRD: <name>
+
+## Executive Summary
+<2–4 sentences. What is this feature, why now, who wins.>
+
+## Problem Statement
+<The concrete pain. Reference real incidents, real users, real metrics where possible.
+Avoid "users might want..." — if you can't name the user, you don't have a problem yet.>
+
+## Goals
+- <measurable, verifiable goal>
+- <measurable, verifiable goal>
+
+## Non-Goals
+- <thing this explicitly does NOT do — the more you list, the less scope creep downstream>
+
+## User Stories
+- As a <role>, I want <capability> so that <outcome>.
+- Each story ends with "**Acceptance:**" followed by 1–3 concrete checks.
+
+## Functional Requirements
+<Numbered list. Each item must be verifiable by reading code or running it.
+NO implementation details — "the system must do X", not "use Zustand to do X".>
+
+## Non-Functional Requirements
+<Performance, accessibility, error-handling, offline, observability.
+Only list the ones that actually matter for this feature.>
+
+## Success Criteria
+<The bar the verification phase will check against.
+Every bullet here becomes an acceptance criterion the verifier asserts on.
+Write them like test assertions.>
+
+## Out of Scope
+<Be ruthless. Future-proofs the review phase against scope creep.>
+
+## Dependencies
+<Other PRDs, packages, external APIs, feature flags. Reference by path or URL.>
+
+## Verification Plan
+<How the verifier will know this shipped correctly.
+`tests`: list the test files/suites that must exist and pass.
+`manual`: list the manual QA steps a human will run post-merge.
+`both`: both sections. The clearer this section, the fewer verification retries you burn.>
+
+## Risks & Open Questions
+<Unknowns, edge cases, things that could kill the plan mid-execution.
+Open questions get tracked here until answered, then deleted.>
+```
+
+## Mapping PRD Sections to the Plan
+
+A PRD is read by the planning agent. Every section has a downstream consumer:
+
+| PRD section | Feeds | Consumer |
+|---|---|---|
+| Executive Summary | Plan objective | Plan display, PR title, board card |
+| Goals + Functional Requirements | Plan steps | Planner decomposition |
+| Success Criteria | Acceptance criteria | Verification phase |
+| Out of Scope | Plan out-of-scope list | Review phase (rejects scope creep) |
+| Complexity field | Estimated complexity | Review rubric, retry budget |
+| Verification Plan | Verification prompt input | Verification phase |
+| Non-Goals + Out of Scope | Review gate | Reviewer rejects patches that violate these |
+
+**Do not write sections that describe files to change, function names, or implementation choices.** Those belong in the plan, not the PRD. If you can't resist writing pseudo-code, put it under "Risks & Open Questions" as "I suspect we'll need to touch X" — not as a requirement.
+
+## Quality Gates
+
+Before marking a PRD ready for a planner to consume, every one of these must be true:
+
+- [ ] No placeholder text (`TODO`, `TBD`, `<fill this in>`) remains in any section.
+- [ ] `Goals` has at least one measurable bullet.
+- [ ] `Success Criteria` has at least one bullet, and every bullet is **verifiable without judgement** — it either passes or fails. "Feels fast" is not verifiable. "p95 latency < 300ms on the issues query" is.
+- [ ] `Out of Scope` has at least one bullet. Empty `Out of Scope` is a tell that the author didn't scope the feature.
+- [ ] `User Stories` has at least one story with explicit Acceptance bullets.
+- [ ] Every external dependency in `Dependencies` is named (package, PRD path, or URL), not described vaguely.
+- [ ] `Verification Plan` names either test file paths, suite names, or concrete manual steps — not "write some tests".
+
+If any gate fails, keep it in draft/on-hold workflow state and do not mark it ready to plan.
+
+## Workflow
+
+### When the user says "write a PRD for X"
+
+1. **Confirm where the PRD will live.** If using a tracker, confirm the target repo/project. If nothing is connected, agree on the single canonical location first — there must be exactly one.
+
+2. **Do not start writing immediately.** Run a short elicitation pass first — you need answers before section-filling is meaningful:
+   - What problem does this solve, and for whom specifically?
+   - What does success look like — how would we measure it?
+   - What is explicitly out of scope?
+   - What's the complexity gut feel (low/medium/high) and why?
+   - Any hard constraints — deadlines, other projects in flight, package boundaries?
+
+3. **Check for an existing issue.** If using GitHub, run `gh issue list --search "<keywords>" --state all` in the target repo. If a matching issue already exists, ask whether to edit it or create a fresh one.
+
+4. **Kebab-case the PRD name.** If the proposed name has spaces, camelCase, or punctuation, kebab-case it: `"Notification Center"` → `notification-center`. This slug goes in the `# PRD:` heading.
+
+5. **Compress the issue title before writing the body.** Default to a short imperative title, then derive the `# PRD:` heading from that final title. Put nuance in the Executive Summary, not the title.
+
+6. **Draft the PRD body** using the template above, in a scratch buffer. Fill every required section. If you can't fill a section, ask the user — don't hallucinate requirements.
+
+7. **Run the quality gates** against the draft. If any fail, keep the issue in draft/on-hold workflow state and tell the user which gates failed. If they all pass, mark it ready through native project state.
+
+8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it — e.g. `gh issue create --title "<Human Readable Title>" --body-file -` with the PRD markdown piped on stdin.
+
+9. **Confirm the outcome** to the user with the issue URL. Suggest the next step: "Ready to hand this to the planner? Say: plan issue #N".
+
+### When the user says "plan the X PRD"
+
+1. Fetch the current issue body (e.g. `gh issue view <N> --json body --jq .body`). Read it fully before producing anything.
+2. Verify the issue is ready through native project state — never plan a draft/on-hold issue.
+3. Translate directly: Executive Summary → objective, Success Criteria → acceptance criteria, Out of Scope → out-of-scope, complexity field → estimated complexity.
+4. The plan phase owns file changes and step breakdown — do not copy those out of the PRD (there shouldn't be any).
+
+### When the user says "update the X PRD"
+
+1. Fetch the current issue body (prefer the tracker's live read to guarantee freshness).
+2. Make the requested edit in a scratch buffer.
+3. Write it back (e.g. `gh issue edit <N> --body-file -`). The tracker records the edit history automatically.
+4. If the change invalidates an in-flight plan (new acceptance criterion, new out-of-scope item), flag that explicitly — the user may want to kill the thread and re-plan.
+
+## Anti-Patterns
+
+Observed failure modes — do not repeat:
+
+- **PRD full of implementation details.** Writing `use TanStack Query v5 for caching` in Functional Requirements. The PRD describes the *what*; the plan owns the *how*. This leaks into review and causes the reviewer to flag the plan for violating the PRD, which the planner then "fixes" by copying the implementation detail verbatim. Dead loop.
+- **Success Criteria written as vibes.** "Users should find the flow intuitive." Unverifiable → verification retries forever.
+- **Empty Out of Scope.** Always a sign the author is planning to sneak scope in later. Force the listing.
+- **Authoring a PRD with nowhere to put it.** If there's no agreed canonical location, the PRD becomes an orphan document that drifts out of sync. Decide the location first.
+- **Editing a cached copy instead of the source.** If your tracker caches issue bodies locally, the cache is downstream of the tracker, not upstream. Always edit via the tracker's API/CLI, never the cache.
+- **Creating an issue without running the quality gates first.** Half-formed PRDs thrash the planner and burn verification retries. Running gates after the issue is already public is embarrassing and harder to fix than running them first.
+- **Writing a PRD for something you should just ticket.** A typo fix does not need a PRD. A dependency bump does not need a PRD. Reserve PRDs for features and architectural changes that will run through plan / review / verify / ship.
+
+## Minimal Example
+
+The text below is the exact issue body to push (e.g. `gh issue create --body-file -`). Tracker metadata belongs in native fields, not in this body.
+
+```markdown
+# PRD: copy-issue-url-action
+
+## Executive Summary
+Users working in the board frequently need to paste an issue URL into chat,
+commit messages, or an external ticketing tool. Today the only way to get the
+URL is to click into the issue, then copy from the header — three clicks and
+a context switch. Add a "Copy URL" action to the card's context menu so it
+takes one click.
+
+## Problem Statement
+Observed on 2026-04-09: the user mentioned needing to paste an issue URL
+into a chat thread five times in a single session, each requiring a detour
+through the issue detail view. This is pure friction — the URL is already known.
+
+## Goals
+- Right-clicking a board card shows a context menu with "Copy URL".
+- Clicking "Copy URL" writes the issue's URL to the clipboard and
+  shows a toast confirming the copy.
+
+## Non-Goals
+- Copying anything other than the URL (title, body, ID — all separate actions
+  if demand appears).
+- A multi-select "copy all URLs" bulk action.
+- Keyboard shortcut for copy — mouse-only for v1.
+
+## User Stories
+- As a developer pasting issue links into chat, I want to copy an issue's
+  URL without leaving the board, so that I don't break my flow.
+  **Acceptance:**
+  - Right-click on a card surfaces a context menu including "Copy URL".
+  - Clicking it results in the URL being on the system clipboard.
+  - A toast appears within 200ms confirming the copy.
+
+## Functional Requirements
+1. The card component must support a right-click context menu.
+2. The context menu must include an action labeled "Copy URL".
+3. The URL written to the clipboard must be the canonical issue URL.
+4. The toast notification must use the existing UI toast primitive.
+
+## Non-Functional Requirements
+- Clipboard write must succeed or fail cleanly — no silent failures. On
+  permission denial, surface an error toast.
+
+## Success Criteria
+- Right-clicking any card opens a context menu with a "Copy URL" item.
+- Clicking "Copy URL" puts the exact canonical issue URL on the clipboard.
+- A success toast appears when the copy succeeds.
+- An error toast appears if the clipboard API rejects the write.
+
+## Out of Scope
+- Copying other fields (title, body, branch name).
+- Bulk selection + copy.
+- Keyboard shortcut bindings.
+- A "Share" action that opens the URL in the browser.
+
+## Dependencies
+- The existing UI toast primitive in the project's component library.
+- The issue number and repo identifier for URL construction.
+
+## Verification Plan
+- **tests:** add a test that simulates a right-click and asserts the context
+  menu includes a "Copy URL" item wired to a mocked clipboard write.
+- **manual:** right-click three cards from different projects, paste the
+  clipboard into a browser tab, verify the URL loads the correct issue.
+
+## Risks & Open Questions
+- Which clipboard API does the renderer use today? Check the existing
+  implementation before writing new clipboard code.
+- Do we need focus-management so the context menu doesn't fight with
+  drag-and-drop handlers on the same card?
+```
+
+Note: no `created`, `updated`, `status`, `complexity`, or `blast radius` fields in the body — the tracker and project board track those natively. No file path — the PRD lives in the issue body itself.

--- a/bundles/planning/skills/writing-prds/plugin.json
+++ b/bundles/planning/skills/writing-prds/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "writing-prds",
+  "version": "1.0.0",
+  "description": "Write a PRD a planning agent can consume in one shot — tracker-issue-as-PRD, section template, title discipline, and quality gates",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -151,6 +151,7 @@
         "context-fundamentals",
         "context-optimization",
         "context-degradation",
+        "context-engineering",
         "memory-systems",
         "multi-agent-patterns",
         "tool-design",
@@ -187,6 +188,8 @@
         "cto-advisor",
         "business-operator",
         "task-prd-creator",
+        "writing-prds",
+        "prd-quality-gate",
         "rules-capture"
       ]
     },
@@ -223,6 +226,7 @@
         "de-slop",
         "debug",
         "deploy",
+        "execution-debugging",
         "deployment-composer",
         "llm-structured-output",
         "production-audit",

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -190,7 +190,8 @@
         "task-prd-creator",
         "writing-prds",
         "prd-quality-gate",
-        "rules-capture"
+        "rules-capture",
+        "writing-plans"
       ]
     },
     "github": {
@@ -205,7 +206,9 @@
         "github-actions-author",
         "git-safety",
         "release-cleanup",
-        "release-pr-gates"
+        "release-pr-gates",
+        "worktree",
+        "finishing-a-development-branch"
       ]
     },
     "security": {
@@ -238,7 +241,11 @@
         "shape",
         "skill-capture",
         "skill-comply",
-        "skill-scout"
+        "skill-scout",
+        "systematic-debugging",
+        "receiving-code-review",
+        "verification-before-completion",
+        "worktree"
       ]
     },
     "session": {

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -201,6 +201,7 @@
         "gh-review-suggestions",
         "github-actions-author",
         "git-safety",
+        "release-cleanup",
         "release-pr-gates"
       ]
     },
@@ -226,6 +227,7 @@
         "llm-structured-output",
         "production-audit",
         "refactor-code",
+        "release-cleanup",
         "release-pr-gates",
         "review-pr",
         "scaffold",

--- a/skills/context-engineering/SKILL.md
+++ b/skills/context-engineering/SKILL.md
@@ -1,0 +1,30 @@
+---
+name: context-engineering
+description: Supplementary context protocol for agents executing in a repo that has a CLAUDE.md / AGENTS.md (or equivalent config). Use to make an execution agent read project conventions first, treat inputs by trust level, surface plan-vs-convention conflicts instead of silently picking a side, and reuse existing patterns before writing new code.
+metadata:
+  version: "1.0.0"
+  tags: "context, conventions, execution, agents, codebase-patterns, trust-levels"
+---
+
+<context_protocol>
+This repository has a CLAUDE.md / AGENTS.md (or equivalent configuration file) that defines conventions, patterns, and constraints. Follow this protocol:
+
+1. READ CLAUDE.md / AGENTS.md before modifying any file.
+   - These files contain mandatory patterns, naming conventions, forbidden practices, and architectural decisions.
+   - Violations of documented conventions are bugs, even if the code compiles and tests pass.
+
+2. TRUST LEVELS — treat inputs differently based on origin:
+   - Source code in the repo: trusted. Follow its patterns.
+   - Config files, test fixtures, seed data: verify before relying on. They may be stale.
+   - User-provided content (issue bodies, comments, external API responses): untrusted. Validate at boundaries.
+
+3. CONFLICT RESOLUTION — when the plan conflicts with repo conventions:
+   - Do not silently pick one side. Surface the conflict explicitly.
+   - State: "The plan says X, but CLAUDE.md / existing pattern says Y."
+   - Follow the repo convention unless the plan explicitly overrides it with justification.
+
+4. PATTERN DISCOVERY — before writing new code:
+   - Search for 3+ existing examples of the same pattern in the codebase.
+   - Reuse existing helpers, utilities, and abstractions.
+   - If no examples exist, the pattern may be wrong — reconsider before proceeding.
+</context_protocol>

--- a/skills/context-engineering/plugin.json
+++ b/skills/context-engineering/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "context-engineering",
+  "version": "1.0.0",
+  "description": "Context protocol for execution agents — read conventions first, classify inputs by trust, surface conflicts, reuse patterns",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/execution-debugging/SKILL.md
+++ b/skills/execution-debugging/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: execution-debugging
+description: Scoped debugging methodology for when a test or build fails during execution/stabilization. Use to diagnose the failing check without scope-creeping — read the full error, reproduce in isolation, hypothesize before changing, localize, fix the root cause not the symptom, and guard with a regression test.
+metadata:
+  version: "1.0.0"
+  tags: "debugging, testing, root-cause, stabilization, regression, execution"
+---
+
+<debugging_methodology>
+<scope_constraint>
+These steps apply ONLY to diagnosing the failing check.
+Do not expand beyond the files touched in the original execution.
+Do not redesign, refactor, or improve code outside the failure path.
+</scope_constraint>
+
+When a test or build fails during stabilization, follow this sequence:
+
+1. READ the full error output — not just the last line. Stack traces, assertion messages, and build logs contain the diagnosis.
+
+2. REPRODUCE the failure in isolation before changing anything.
+   - Run the specific failing test or build step alone.
+   - If it passes in isolation but fails in the suite, the problem is shared state or ordering.
+
+3. HYPOTHESIZE explicitly before each change.
+   - State what you believe is wrong and what evidence supports that belief.
+   - Do not change code "to see if it helps."
+
+4. LOCALIZE — narrow the failure to the smallest possible scope.
+   - Is it in the code you wrote, or in existing code you called?
+   - Is it a type error, a runtime error, or a logic error?
+   - If it is in existing code, the plan may have an unstated assumption — surface it.
+
+5. FIX the root cause, not the symptom.
+   - Suppressing an error message is not a fix.
+   - Adding a null check at the crash site when the upstream function should not return null is not a fix.
+   - Changing the test expectation to match broken behavior is not a fix.
+
+6. GUARD — write or update a test that fails without the fix and passes with it.
+   - This prevents the same failure from recurring in future stabilization cycles.
+</debugging_methodology>

--- a/skills/execution-debugging/plugin.json
+++ b/skills/execution-debugging/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "execution-debugging",
+  "version": "1.0.0",
+  "description": "Scoped root-cause debugging methodology for failing tests/builds during stabilization",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/finishing-a-development-branch/SKILL.md
+++ b/skills/finishing-a-development-branch/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: finishing-a-development-branch
+description: >-
+  Structured "done coding, now what?" workflow: verify tests pass, detect the
+  repository environment (normal repo vs worktree, named branch vs detached
+  HEAD), present exactly the right merge / PR / keep / discard options, and
+  execute the chosen path including safe worktree cleanup. Use when
+  implementation is complete and the branch needs to be integrated, published,
+  or abandoned.
+metadata:
+  version: "1.0.0"
+  tags: "git, branch, merge, pull-request, workflow, worktree, cleanup"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *) Bash(gh *)
+when_to_use: "finish branch, done coding, ready to merge, create PR, close branch, wrap up feature, branch cleanup, integration workflow"
+---
+
+# Finishing a Development Branch
+
+Guide completion of development work by presenting clear options and handling
+the chosen workflow end-to-end.
+
+**Core principle:** Verify tests → Detect environment → Present options →
+Execute choice → Clean up.
+
+## The Process
+
+### Step 1: Verify Tests
+
+Before presenting any options, run the project's test suite:
+
+```bash
+# Use whichever test runner the project uses
+npm test / bun test / cargo test / pytest / go test ./...
+```
+
+If tests fail:
+
+```
+Tests failing (<N> failures). Must fix before completing:
+
+[show failures]
+
+Cannot proceed with merge/PR until tests pass.
+```
+
+Stop. Do not continue to Step 2 while tests are red.
+
+If tests pass, continue to Step 2.
+
+### Step 2: Detect Environment
+
+Determine workspace state before presenting options:
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+```
+
+| State | Menu | Cleanup |
+|-------|------|---------|
+| `GIT_DIR == GIT_COMMON` (normal repo) | 4-option menu | No worktree to clean up |
+| `GIT_DIR != GIT_COMMON`, named branch | 4-option menu | Provenance-based (see Step 6) |
+| `GIT_DIR != GIT_COMMON`, detached HEAD | 3-option menu (no local merge) | Externally managed — do not remove |
+
+### Step 3: Determine Base Branch
+
+```bash
+git merge-base HEAD main 2>/dev/null || git merge-base HEAD master 2>/dev/null
+```
+
+If neither resolves, ask the user: "This branch appears to split from `main` —
+is that correct?"
+
+### Step 4: Present Options
+
+**Normal repo and named-branch worktree — exactly 4 options:**
+
+```
+Implementation complete. What would you like to do?
+
+1. Merge back to <base-branch> locally
+2. Push and create a Pull Request
+3. Keep the branch as-is (handle it later)
+4. Discard this work
+
+Which option?
+```
+
+**Detached HEAD — exactly 3 options:**
+
+```
+Implementation complete. You're on a detached HEAD (externally managed workspace).
+
+1. Push as new branch and create a Pull Request
+2. Keep as-is (handle it later)
+3. Discard this work
+
+Which option?
+```
+
+Do not add explanation text to the menu — keep it concise.
+
+### Step 5: Execute Choice
+
+#### Option 1: Merge Locally
+
+```bash
+# Resolve main repo root first (safe when running inside a worktree)
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+
+git checkout <base-branch>
+git pull
+git merge <feature-branch>
+```
+
+Run the test suite again on the merged result. Only after tests pass on the
+merge: run Step 6 to clean up the worktree, then delete the branch:
+
+```bash
+git branch -d <feature-branch>
+```
+
+#### Option 2: Push and Create PR
+
+```bash
+git push -u origin <feature-branch>
+
+gh pr create --title "<descriptive title>" --body "$(cat <<'EOF'
+## Summary
+- <what changed, 2-3 bullets>
+
+## Test Plan
+- [ ] <verification steps>
+EOF
+)"
+```
+
+Do **not** clean up the worktree — the user needs it alive to iterate on PR
+feedback.
+
+#### Option 3: Keep As-Is
+
+Report: "Keeping branch `<name>`. Worktree preserved at `<path>`."
+
+Do not clean up the worktree.
+
+#### Option 4: Discard
+
+Require typed confirmation before destroying anything:
+
+```
+This will permanently delete:
+- Branch <name>
+- All commits: <commit list>
+- Worktree at <path> (if applicable)
+
+Type 'discard' to confirm.
+```
+
+Wait for the exact word. If confirmed:
+
+```bash
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+```
+
+Run Step 6 to clean up the worktree, then force-delete the branch:
+
+```bash
+git branch -D <feature-branch>
+```
+
+### Step 6: Cleanup Workspace
+
+This step runs **only for Options 1 and 4**. Options 2 and 3 always preserve
+the worktree.
+
+```bash
+GIT_DIR=$(cd "$(git rev-parse --git-dir)" 2>/dev/null && pwd -P)
+GIT_COMMON=$(cd "$(git rev-parse --git-common-dir)" 2>/dev/null && pwd -P)
+WORKTREE_PATH=$(git rev-parse --show-toplevel)
+```
+
+**If `GIT_DIR == GIT_COMMON`:** This is a normal repo checkout. No worktree to
+clean up. Done.
+
+**If the worktree path is under `.worktrees/` or `worktrees/` relative to the
+main repo root:** The current workflow created this worktree — it is safe to
+remove it.
+
+```bash
+MAIN_ROOT=$(git -C "$(git rev-parse --git-common-dir)/.." rev-parse --show-toplevel)
+cd "$MAIN_ROOT"
+git worktree remove "$WORKTREE_PATH"
+git worktree prune   # clean up any stale registrations
+```
+
+**Otherwise:** The host environment owns this workspace. Do **not** remove it.
+Leave the workspace in place and report the path to the user.
+
+## Quick Reference
+
+| Option | Merge | Push | Keep Worktree | Delete Branch |
+|--------|-------|------|---------------|---------------|
+| 1. Merge locally | yes | — | — | yes (safe `-d`) |
+| 2. Create PR | — | yes | yes | — |
+| 3. Keep as-is | — | — | yes | — |
+| 4. Discard | — | — | — | yes (force `-D`) |
+
+## Common Mistakes
+
+**Skipping test verification**
+
+- Problem: Broken code gets merged or published as a PR.
+- Fix: Always verify tests before offering options.
+
+**Open-ended questions instead of the menu**
+
+- Problem: "What should I do next?" is ambiguous and stalls the workflow.
+- Fix: Present exactly 4 structured options (or 3 for detached HEAD).
+
+**Cleaning up the worktree for Option 2**
+
+- Problem: The user needs the worktree alive to iterate on PR feedback.
+- Fix: Only clean up for Options 1 and 4.
+
+**Deleting the branch before removing the worktree**
+
+- Problem: `git branch -d` fails because the worktree still references it.
+- Fix: Remove the worktree first, then delete the branch.
+
+**Running `git worktree remove` from inside the worktree**
+
+- Problem: The command fails or silently does nothing.
+- Fix: Always `cd` to the main repo root before calling `git worktree remove`.
+
+**Cleaning up externally-managed worktrees**
+
+- Problem: Removing a workspace the host environment created causes phantom state.
+- Fix: Only clean up worktrees under `.worktrees/` or `worktrees/` paths that
+  the current workflow owns. If provenance is unclear, leave it.
+
+**No confirmation for discard**
+
+- Problem: Work is accidentally destroyed.
+- Fix: Require the exact word `discard` typed by the user before proceeding.
+
+## Iron Rules
+
+Never:
+
+- Proceed with failing tests.
+- Merge without re-verifying tests on the merged result.
+- Delete work without explicit typed confirmation.
+- Force-push without an explicit request from the user.
+- Remove a worktree before confirming the merge succeeded.
+- Clean up worktrees whose provenance is unknown or externally managed.
+- Run `git worktree remove` from inside the worktree being removed.
+
+Always:
+
+- Verify tests before offering options.
+- Detect environment before presenting the menu.
+- Present exactly 4 options (or 3 for detached HEAD) — no more, no less.
+- Get typed `discard` confirmation for Option 4.
+- Clean up the worktree for Options 1 and 4 only.
+- `cd` to the main repo root before any worktree removal.
+- Run `git worktree prune` after removal.

--- a/skills/finishing-a-development-branch/plugin.json
+++ b/skills/finishing-a-development-branch/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "finishing-a-development-branch",
+  "version": "1.0.0",
+  "description": "Verify tests, detect environment, present merge/PR/cleanup options, execute the chosen path at branch completion.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/prd-quality-gate/SKILL.md
+++ b/skills/prd-quality-gate/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: prd-quality-gate
+description: PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
+metadata:
+  version: "1.0.0"
+  tags: "prd, planning, validation, quality-gate, spec, requirements"
+---
+
+<prd_quality_gate>
+A well-formed PRD (or the issue body that serves as one) must contain ALL of the
+following sections as markdown headings (## or ###). Missing sections reduce plan
+quality and risk hallucinated scope.
+
+Required sections:
+
+- Executive Summary
+- Problem Statement
+- Goals
+- Functional Requirements
+- Acceptance Criteria
+- Verification Plan
+
+When the quality gate is ENABLED (blocking):
+
+- Missing any required section → fail immediately with an actionable message
+  listing the missing sections.
+- The author must update the PRD and re-run the gate before planning proceeds.
+
+When the quality gate is DISABLED (default, warning-only):
+
+- Missing sections → log a warning.
+- Planning proceeds. The planner should still note the gaps in its output.
+
+Section matching is case-insensitive against ## and ### headings. Exact heading
+text must appear (e.g. "## Executive Summary" or "### Goals"). Headings nested
+inside code fences are ignored by convention (they are examples, not structure).
+</prd_quality_gate>

--- a/skills/prd-quality-gate/plugin.json
+++ b/skills/prd-quality-gate/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "prd-quality-gate",
+  "version": "1.0.0",
+  "description": "PRD completeness validation — check required sections before a spec is handed to a planning agent",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/receiving-code-review/SKILL.md
+++ b/skills/receiving-code-review/SKILL.md
@@ -1,0 +1,235 @@
+---
+name: receiving-code-review
+description: >-
+  Evaluate incoming code-review feedback with technical rigor before implementing any change. Verify each point against the codebase, push back with reasoning when the reviewer is wrong, and never perform empty agreement. Use when you receive a review, before touching any code, especially when feedback seems unclear or technically questionable.
+metadata:
+  version: "1.0.0"
+  tags: "code-review, feedback, review-response, pushback, verification"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *) Bash(gh *)
+when_to_use: "receiving review feedback, addressing PR comments, responding to reviewer, evaluating suggestions, pushing back on feedback"
+---
+
+# Receiving Code Review
+
+## Core Principle
+
+Code review requires technical evaluation, not emotional performance.
+
+**Verify before implementing. Ask before assuming. Technical correctness over social comfort.**
+
+## The Response Pattern
+
+```
+WHEN receiving code review feedback:
+
+1. READ: Complete feedback without reacting
+2. UNDERSTAND: Restate the requirement in your own words (or ask)
+3. VERIFY: Check against codebase reality
+4. EVALUATE: Is this technically sound for THIS codebase?
+5. RESPOND: Technical acknowledgment or reasoned pushback
+6. IMPLEMENT: One item at a time, test each
+```
+
+## Forbidden Responses
+
+**NEVER say:**
+
+- "You're absolutely right!"
+- "Great point!" / "Excellent feedback!"
+- "Let me implement that now" (before verification)
+- Any expression of gratitude ("Thanks for catching that!", "Thanks for [anything]")
+
+**INSTEAD:**
+
+- Restate the technical requirement
+- Ask clarifying questions
+- Push back with technical reasoning if the suggestion is wrong
+- Just start working — actions speak louder than words
+
+## Handling Unclear Feedback
+
+```
+IF any item is unclear:
+  STOP — do not implement anything yet
+  ASK for clarification on all unclear items before proceeding
+
+WHY: Items may be related. Partial understanding leads to wrong implementation.
+```
+
+**Example:**
+
+```
+Reviewer: "Fix items 1-6"
+You understand 1, 2, 3, 6. Unclear on 4, 5.
+
+❌ WRONG: Implement 1, 2, 3, 6 now — ask about 4, 5 later
+✅ RIGHT: "I understand items 1, 2, 3, 6. Need clarification on 4 and 5 before proceeding."
+```
+
+## Evaluating Feedback by Source
+
+### From the codebase owner / requester
+
+- **Trusted** — implement after understanding
+- Still ask if scope is unclear
+- No performative agreement
+- Skip to action or technical acknowledgment
+
+### From external reviewers
+
+```
+BEFORE implementing:
+  1. Check: Is this technically correct for THIS codebase?
+  2. Check: Would this break existing functionality?
+  3. Check: Is there a reason the current implementation exists?
+  4. Check: Does this work on all required platforms/versions?
+  5. Check: Does the reviewer understand the full context?
+
+IF the suggestion seems wrong:
+  Push back with technical reasoning
+
+IF you cannot easily verify:
+  Say so: "I can't verify this without [X]. Should I [investigate / ask / proceed]?"
+
+IF the suggestion conflicts with prior architectural decisions:
+  Stop and surface the conflict before implementing
+```
+
+## YAGNI Check for "Implement Properly" Suggestions
+
+```
+IF a reviewer suggests adding or expanding a feature "properly":
+  grep the codebase for actual usage
+
+  IF unused: "This isn't called anywhere. Remove it (YAGNI)?"
+  IF used: Then evaluate and implement properly
+```
+
+Reviewers often suggest improvements to code that isn't wired up anywhere. Verify usage before expanding scope.
+
+## Implementation Order
+
+```
+FOR multi-item feedback:
+  1. Clarify anything unclear FIRST
+  2. Then implement in this order:
+     - Blocking issues (broken behaviour, security)
+     - Simple fixes (typos, imports, naming)
+     - Complex fixes (refactoring, logic changes)
+  3. Test each fix individually
+  4. Verify no regressions before moving to the next item
+```
+
+## When to Push Back
+
+Push back when the suggestion:
+
+- Breaks existing functionality
+- Assumes context the reviewer doesn't have
+- Violates YAGNI (adds unused code)
+- Is technically incorrect for this stack
+- Conflicts with legacy or compatibility requirements
+- Contradicts established architectural decisions
+
+**How to push back:**
+
+- Use technical reasoning, not defensiveness
+- Ask specific questions that surface the gap
+- Reference existing tests or working code
+- Escalate to the codebase owner if the disagreement is architectural
+
+## Acknowledging Correct Feedback
+
+When feedback IS correct:
+
+```
+✅ "Fixed. [Brief description of what changed]"
+✅ "Good catch — [specific issue]. Fixed in [location]."
+✅ [Just fix it and let the diff speak]
+
+❌ "You're absolutely right!"
+❌ "Great point!"
+❌ "Thanks for catching that!"
+❌ Any gratitude expression
+```
+
+**Why no thanks:** The fix itself is the acknowledgment. State what changed and move on.
+
+## Gracefully Correcting Your Own Pushback
+
+If you pushed back and were wrong:
+
+```
+✅ "You were right — I checked [X] and it does [Y]. Implementing now."
+✅ "Verified this and you're correct. My initial understanding was wrong because [reason]. Fixing."
+
+❌ Long apology
+❌ Defending why you pushed back
+❌ Over-explaining
+```
+
+State the correction factually and move on.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Performative agreement | State the requirement or just act |
+| Blind implementation | Verify against the codebase first |
+| Implementing in batch without testing | One item at a time, test each |
+| Assuming the reviewer is right | Check whether the suggestion breaks things |
+| Avoiding pushback | Technical correctness over social comfort |
+| Partial implementation | Clarify all items before starting |
+| Cannot verify — proceed anyway | State the limitation, ask for direction |
+
+## Real Examples
+
+**Performative agreement (bad):**
+
+```
+Reviewer: "Remove the legacy code"
+❌ "You're absolutely right! Let me remove that..."
+```
+
+**Technical verification (good):**
+
+```
+Reviewer: "Remove the legacy code"
+✅ "Checking... build target is 10.15+, this API requires 13+.
+   Removing it drops pre-13 support. Is that intentional,
+   or should I gate it behind a version check instead?"
+```
+
+**YAGNI check (good):**
+
+```
+Reviewer: "Implement proper metrics tracking with database, date filters, CSV export"
+✅ "Grepped the codebase — nothing calls this endpoint.
+   Remove it (YAGNI)? Or is there usage I'm missing?"
+```
+
+**Unclear item (good):**
+
+```
+Reviewer: "Fix items 1-6"
+You understand 1, 2, 3, 6. Unclear on 4, 5.
+✅ "Understand 1, 2, 3, 6. Need clarification on 4 and 5 before implementing."
+```
+
+## GitHub PR Comment Replies
+
+When responding to inline review comments on GitHub, reply in the comment thread — not as a top-level PR comment:
+
+```bash
+gh api repos/{owner}/{repo}/pulls/{pr}/comments/{id}/replies \
+  -f body="[your response]"
+```
+
+## The Bottom Line
+
+**Reviewer feedback = suggestions to evaluate, not orders to follow.**
+
+Verify. Question. Then implement.
+
+No performative agreement. Technical rigor always.

--- a/skills/receiving-code-review/plugin.json
+++ b/skills/receiving-code-review/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "receiving-code-review",
+  "version": "1.0.0",
+  "description": "Evaluate incoming code-review feedback with technical rigor: verify before acting, push back when wrong.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/release-cleanup/SKILL.md
+++ b/skills/release-cleanup/SKILL.md
@@ -1,0 +1,230 @@
+---
+name: release-cleanup
+description: Verify a release was fully promoted through develop, staging, and master/main, then prune merged local and remote branches and stale git worktrees. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, tidy up after promoting develop to staging to master, or confirm nothing stale was left behind before pruning.
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+metadata:
+  version: "1.0.0"
+  tags: "git, cleanup, branches, worktrees, release, prune, ci-cd"
+allowed-tools: Bash(git *) Bash(gh *)
+---
+
+# Release Cleanup
+
+Confirm a release was fully promoted up the branch chain, then prune the branches
+and git worktrees that promotion left behind. Verification is a hard gate: never
+prune until the chain is proven complete and no in-flight work is stranded.
+
+This skill is standalone and manually triggerable. It does not promote code (use
+`release-pr-gates` for that) and does not deploy (use `deploy`). It runs after a
+promotion has landed and tidies up.
+
+## Contract
+
+Inputs:
+
+- Repository root with a git remote
+- Branch chain to verify, or permission to auto-detect (`develop` -> `staging` -> `master`/`main`)
+- Optional mode: `verify` (gate only), `dry-run` (default, plan only), or `prune` (execute after confirmation)
+
+Outputs:
+
+- Promotion verification result per chain hop (complete / incomplete)
+- List of stranded branches not merged into `develop` (potential forgotten work)
+- Prune plan: local branches, remote branches, and worktrees that are safe to remove
+- Final summary of what was removed and what was skipped
+
+Creates/Modifies:
+
+- Deletes local branches merged into the production branch (never the protected set)
+- Deletes remote branches merged into the production branch
+- Removes git worktrees whose branch is merged or whose upstream is gone, and runs `git worktree prune`
+- Prunes stale remote-tracking refs (`git remote prune`)
+- Never deletes anything with unmerged commits or a dirty worktree
+
+External Side Effects:
+
+- Reads and deletes GitHub remote branches via `git push origin --delete`
+- Reads GitHub branch and PR state to confirm merges
+- Does not merge, deploy, or rewrite history
+
+Confirmation Required:
+
+- Before any deletion (local branch, remote branch, or worktree) — always print the dry-run plan and require an explicit yes
+- Before pruning when promotion verification is incomplete (default is to STOP, not prompt)
+- Before force-removing a worktree or force-deleting a branch (never done automatically)
+
+Delegates To:
+
+- `release-pr-gates` when the chain is NOT fully promoted and the user wants to finish the promotion first
+- `gh-fix-ci` when a promotion PR is still open with failing checks
+- `git-safety` when a branch about to be pruned may contain secrets in history worth scrubbing first
+
+## When to Use
+
+- After promoting `develop` -> `staging` -> `master` and you want to delete the merged feature/release branches and worktrees
+- Manually, any time, to verify the chain is fully promoted and see what is safe to prune
+- To confirm "nothing is stale" — that every branch intended for the release actually reached the production branch — before tidying up
+
+Do not use this skill to promote code or to delete unmerged work. It only removes
+what is provably merged.
+
+## Safety Model
+
+Protected branches are never deleted:
+
+```
+develop  staging  master  main  + the currently checked-out branch + HEAD
+```
+
+Hard rules:
+
+1. Pruning uses `git branch --merged` / `git branch -r --merged` against the
+   production branch only. A branch with even one commit not in the production
+   branch is never listed for deletion.
+2. Worktrees with uncommitted changes are never removed. They are reported and skipped.
+3. The default mode is `dry-run`: print the exact plan and stop. Deletion only
+   happens in `prune` mode after the user confirms the printed plan.
+4. Force flags (`git branch -D`, `git worktree remove --force`, `git push --delete`
+   of an unmerged branch) are never used automatically. If a branch looks
+   important but is unmerged, report it — do not remove it.
+5. If promotion verification fails, STOP. Do not offer to prune around it.
+
+## Phase 1: Discover Branches and Refresh State
+
+```bash
+gh auth status -h github.com
+git status -sb
+git remote -v
+git fetch --all --prune
+gh repo view --json nameWithOwner,defaultBranchRef
+git branch -r --list 'origin/develop' 'origin/staging' 'origin/master' 'origin/main'
+```
+
+Determine the chain from the branches that actually exist on the remote:
+
+- Production branch = `master` if it exists, else `main`, else the repo default branch.
+- Chain = the subset of `develop` -> `staging` -> production that exists.
+- If neither `develop` nor `staging` exists (e.g. a master-only repo), the chain
+  collapses to "everything is merged into the production branch" and verification
+  checks only that.
+
+## Phase 2: Promotion Verification (Hard Gate)
+
+Prove each hop carries no un-promoted commits. Each command must return empty.
+
+```bash
+# develop fully promoted into staging? (commits in develop missing from staging)
+git log --oneline origin/staging..origin/develop
+
+# staging fully promoted into production? (commits in staging missing from master/main)
+git log --oneline origin/master..origin/staging
+```
+
+When `staging` does not exist, check `develop` against production directly:
+
+```bash
+git log --oneline origin/master..origin/develop
+```
+
+Also surface potential forgotten work — branches whose commits never reached
+`develop`. These are "stale" candidates the user may have meant to include:
+
+```bash
+# remote branches NOT merged into develop (or production if no develop)
+git branch -r --no-merged origin/develop --format '%(refname:short)' \
+  | grep -vE '^origin/(develop|staging|master|main|HEAD)'
+```
+
+Gate outcome:
+
+- Any non-empty promotion hop => promotion is INCOMPLETE. Report exactly which
+  commits are un-promoted and STOP. Offer to hand off to `release-pr-gates` to
+  finish the promotion. Do not prune.
+- Stranded branches not merged into `develop` => report them as a warning. They
+  are not pruned (they are unmerged) but the user should decide whether they were
+  meant to ship. This is the "nothing is stale" check.
+- All hops empty and no surprising stranded branches => verification passes;
+  continue to Phase 3.
+
+## Phase 3: Build the Prune Plan (Dry-Run, Default)
+
+Compute the safe-to-remove sets against the production branch only.
+
+```bash
+PROD=origin/master   # or origin/main per Phase 1
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo)"
+PROTECT='develop|staging|master|main'
+
+# Local branches fully merged into production (excluding protected + current)
+git branch --merged "$PROD" --format '%(refname:short)' \
+  | grep -vxE "$PROTECT" \
+  | { [ -n "$CURRENT" ] && grep -vx "$CURRENT" || cat; }
+
+# Remote branches fully merged into production (excluding protected)
+git branch -r --merged "$PROD" --format '%(refname:short)' \
+  | sed 's#^origin/##' \
+  | grep -vxE "$PROTECT|HEAD"
+
+# Worktrees: list, then classify
+git worktree list --porcelain
+```
+
+For each worktree other than the main checkout, classify it:
+
+- Branch merged into production AND no uncommitted changes (`git -C <path> status --porcelain` empty) => safe to remove.
+- Uncommitted changes => SKIP, report as dirty.
+- Branch unmerged => SKIP, report as unmerged.
+- Upstream gone (branch deleted on remote) and merged => safe to remove.
+
+Print the plan as three explicit lists — local branches, remote branches,
+worktree paths — plus a skipped list with reasons. Then stop and ask for
+confirmation. In `dry-run` (default) and `verify` modes, end here.
+
+## Phase 4: Execute Prune (Only in `prune` Mode, After Confirmation)
+
+Only after the user confirms the printed plan:
+
+```bash
+# Local merged branches
+git branch -d <branch> ...        # -d (safe). Never -D automatically.
+
+# Remote merged branches (origin is HTTPS or SSH; uses configured auth)
+git push origin --delete <branch> ...
+
+# Worktrees flagged safe
+git worktree remove <path> ...    # never --force; refuses on dirty
+git worktree prune
+
+# Drop stale remote-tracking refs
+git remote prune origin
+git fetch --all --prune
+```
+
+Rules during execution:
+
+- If `git branch -d` refuses (not fully merged), do not escalate to `-D`. Report and skip.
+- If `git worktree remove` refuses (dirty/locked), do not `--force`. Report and skip.
+- Delete remote branches one batch; if a delete fails (protected on the server),
+  report it and continue with the rest.
+
+## Modes
+
+- `release-cleanup verify` — Phase 1 + 2 only. Report promotion status and stranded branches. No plan, no deletion.
+- `release-cleanup` or `release-cleanup dry-run` — Phases 1-3. Verify, then print the prune plan. No deletion. (Default.)
+- `release-cleanup prune` — Phases 1-4. Verify, print plan, confirm, then delete.
+
+If the user explicitly scopes the cleanup ("only worktrees", "local branches
+only", "skip remote"), honor it: still run verification, but restrict the plan
+and execution to the requested resource types.
+
+## Final Status
+
+Report:
+
+- Repository and production branch used
+- Chain verified and each hop's result (complete / incomplete)
+- Stranded branches not merged into `develop`, if any
+- Local branches deleted / skipped (with reasons)
+- Remote branches deleted / skipped (with reasons)
+- Worktrees removed / skipped (with reasons)
+- Whether anything was blocked and what the user should decide next

--- a/skills/release-cleanup/plugin.json
+++ b/skills/release-cleanup/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "release-cleanup",
+  "version": "1.0.0",
+  "description": "Verify a release was fully promoted through develop, staging, and master, then prune merged branches and stale worktrees",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/systematic-debugging/SKILL.md
+++ b/skills/systematic-debugging/SKILL.md
@@ -1,0 +1,250 @@
+---
+name: systematic-debugging
+description: >-
+  Enforces root-cause investigation before any fix attempt using a rigorous four-phase methodology: investigate, analyze patterns, hypothesize, implement. Use when encountering any bug, test failure, unexpected behavior, or performance regression — especially under time pressure or after multiple failed fix attempts.
+metadata:
+  version: "1.0.0"
+  tags: "debugging, root-cause, diagnosis, investigation, methodology, hypothesis"
+when_to_use: "bug, broken, not working, test failing, unexpected behavior, regression, fix not working, keeps breaking, investigate, diagnose"
+---
+
+# Systematic Debugging
+
+## Core Principle
+
+Random fixes waste time and create new bugs. Quick patches mask underlying issues.
+
+**NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST.**
+
+If Phase 1 is not complete, no fix may be proposed. Violating this process violates the spirit of debugging.
+
+## The Iron Law
+
+```
+NO FIXES WITHOUT ROOT CAUSE INVESTIGATION FIRST
+```
+
+## When to Use
+
+Use for ANY technical issue:
+
+- Test failures
+- Bugs in production
+- Unexpected behavior
+- Performance problems
+- Build failures
+- Integration issues
+
+Use this ESPECIALLY when:
+
+- Under time pressure (emergencies make guessing tempting)
+- "Just one quick fix" seems obvious
+- Multiple fixes have already been attempted
+- The previous fix did not work
+- The issue is not fully understood
+
+Do not skip when:
+
+- The issue seems simple (simple bugs have root causes too)
+- You are in a hurry (rushing guarantees rework)
+- Stakeholders want it fixed immediately (systematic is faster than thrashing)
+
+## The Four Phases
+
+Complete each phase before proceeding to the next.
+
+---
+
+### Phase 1: Root Cause Investigation
+
+**Before attempting ANY fix:**
+
+**1. Read error messages carefully.**
+
+- Do not skip past errors or warnings — they often contain the exact solution.
+- Read stack traces completely.
+- Note line numbers, file paths, error codes.
+
+**2. Reproduce consistently.**
+
+- Can you trigger the failure reliably?
+- What are the exact steps?
+- Does it happen every time?
+- If not reproducible: gather more data. Do not guess.
+
+**3. Check recent changes.**
+
+- What changed that could cause this?
+- Review git diff, recent commits, new dependencies, config changes, environment differences.
+
+**4. Gather evidence in multi-component systems.**
+
+When a system has multiple components (e.g., API → service → database, CI → build → signing):
+
+Before proposing any fix, add diagnostic instrumentation at each component boundary:
+
+```
+For EACH component boundary:
+  - Log what data enters the component
+  - Log what data exits the component
+  - Verify environment / config propagation
+  - Check state at each layer
+
+Run once to gather evidence showing WHERE it breaks.
+Analyze evidence to identify the failing component.
+Then investigate that specific component.
+```
+
+Example instrumentation pattern:
+
+```bash
+# Layer 1: entry point
+echo "=== Input at layer 1: ${VAR:+SET}${VAR:-UNSET} ==="
+
+# Layer 2: downstream component
+echo "=== Env vars reaching layer 2: ==="
+env | grep VAR || echo "VAR not in environment"
+
+# Layer 3: leaf operation
+echo "=== State at layer 3: ==="
+# inspect relevant runtime state here
+```
+
+This reveals which layer fails (e.g., value passes layer 1 but is missing at layer 2).
+
+**5. Trace data flow.**
+
+When an error is deep in a call stack:
+
+- Where does the bad value originate?
+- What called this function with the bad value?
+- Keep tracing up until you find the source.
+- Fix at the source, not at the symptom.
+
+---
+
+### Phase 2: Pattern Analysis
+
+**Find the pattern before fixing:**
+
+1. **Find working examples.** Locate similar working code in the same codebase.
+2. **Compare against references.** If implementing a pattern, read the reference implementation completely — do not skim.
+3. **Identify differences.** List every difference between working and broken, however small. Do not assume "that can't matter."
+4. **Understand dependencies.** What config, environment, or assumptions does the component require?
+
+---
+
+### Phase 3: Hypothesis and Testing
+
+**Apply scientific method:**
+
+1. **Form a single hypothesis.** State clearly: "I think X is the root cause because Y." Be specific.
+2. **Test minimally.** Make the smallest possible change to test the hypothesis. One variable at a time.
+3. **Verify before continuing.**
+   - Did it work? Yes → proceed to Phase 4.
+   - Did not work? Form a NEW hypothesis. Do not add more fixes on top of the failed one.
+4. **When you do not know:** say so. Ask for help or gather more evidence. Do not pretend to understand.
+
+---
+
+### Phase 4: Implementation
+
+**Fix the root cause, not the symptom:**
+
+1. **Create a failing test case** — the simplest possible reproduction — automated if a test framework exists, a one-off script otherwise. This must exist before the fix is written.
+
+2. **Implement a single fix.** Address the identified root cause. One change at a time. No "while I'm here" improvements or bundled refactoring.
+
+3. **Verify the fix.**
+   - Does the test now pass?
+   - Are other tests still passing?
+   - Is the issue actually resolved?
+
+4. **If the fix does not work:**
+   - STOP.
+   - Count: how many fixes have been attempted?
+   - If fewer than 3: return to Phase 1 and re-analyze with the new information.
+   - If 3 or more: see step 5.
+
+5. **If 3+ fixes have failed — question the architecture.**
+
+   Signs of an architectural problem:
+   - Each fix exposes new shared state, coupling, or a problem in a different place.
+   - Fixes require massive refactoring to implement.
+   - Each fix creates new symptoms elsewhere.
+
+   Stop and question fundamentals:
+   - Is this pattern fundamentally sound?
+   - Are we continuing out of inertia rather than evidence?
+   - Should the architecture be redesigned rather than another patch applied?
+
+   Discuss with the user before attempting any further fixes. This is not a failed hypothesis — it is a wrong architecture.
+
+---
+
+## Red Flags — Stop and Return to Phase 1
+
+If any of these thoughts arise, stop immediately:
+
+- "Quick fix for now, investigate later"
+- "Just try changing X and see if it works"
+- "Add multiple changes, run tests"
+- "Skip the test, I'll manually verify"
+- "It's probably X, let me fix that"
+- "I don't fully understand but this might work"
+- "Here are the main problems: [lists fixes without investigation]"
+- Proposing solutions before tracing data flow
+- "One more fix attempt" (when 2+ have already failed)
+- Each fix reveals a new problem in a different place
+
+**All of these mean: STOP. Return to Phase 1.**
+
+If 3+ fixes have failed: question the architecture (Phase 4, step 5).
+
+---
+
+## Common Rationalizations
+
+| Excuse | Reality |
+|--------|---------|
+| "Issue is simple, don't need process" | Simple issues have root causes too. Process is fast for simple bugs. |
+| "Emergency, no time for process" | Systematic debugging is faster than guess-and-check thrashing. |
+| "Just try this first, then investigate" | The first fix sets the pattern. Do it right from the start. |
+| "I'll write the test after confirming the fix works" | Untested fixes do not stick. A test first proves it. |
+| "Multiple fixes at once saves time" | Cannot isolate what worked. Causes new bugs. |
+| "Reference too long, I'll adapt the pattern" | Partial understanding guarantees bugs. Read it completely. |
+| "I see the problem, let me fix it" | Seeing symptoms does not equal understanding root cause. |
+| "One more fix attempt" (after 2+ failures) | 3+ failures = architectural problem. Question the pattern, do not fix again. |
+
+---
+
+## Quick Reference
+
+| Phase | Key Activities | Success Criteria |
+|-------|----------------|------------------|
+| **1. Root Cause** | Read errors, reproduce, check changes, gather evidence | Understand WHAT and WHY |
+| **2. Pattern** | Find working examples, compare against broken | Differences identified |
+| **3. Hypothesis** | Form specific theory, test minimally | Confirmed or new hypothesis formed |
+| **4. Implementation** | Create failing test, apply single fix, verify | Bug resolved, tests pass |
+
+---
+
+## When Investigation Reveals No Root Cause
+
+If systematic investigation genuinely reveals the issue is environmental, timing-dependent, or fully external:
+
+1. You have completed the process correctly.
+2. Document what was investigated and what was ruled out.
+3. Implement appropriate handling (retry logic, timeout, error message).
+4. Add monitoring or logging for future investigation.
+
+Note: 95% of "no root cause found" cases are incomplete investigation. Exhaust Phase 1 fully before concluding this.
+
+---
+
+## Impact
+
+- Systematic approach: 15–30 minutes to resolution.
+- Random-fix approach: 2–3 hours of thrashing.
+- First-time fix rate: ~95% vs ~40%.
+- New bugs introduced: near zero vs common.

--- a/skills/systematic-debugging/plugin.json
+++ b/skills/systematic-debugging/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "systematic-debugging",
+  "version": "1.0.0",
+  "description": "Enforce root-cause investigation before any fix: structured four-phase debugging methodology.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/verification-before-completion/SKILL.md
+++ b/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: verification-before-completion
+description: >-
+  Enforce evidence-based completion: no success, done, fixed, or passing claim may be made without first running the verification command and reading its full output. Use when about to claim work is complete, a bug is fixed, tests pass, a build succeeds, or before committing, pushing, or opening a PR.
+metadata:
+  version: "1.0.0"
+  tags: "verification, completion, evidence, quality-gate, testing, ci-cd"
+when_to_use: "claiming done, marking task complete, tests passing, bug fixed, linter clean, build succeeds, before commit, before PR, before merging"
+---
+
+# Verification Before Completion
+
+Claiming work is complete without verification is dishonesty, not efficiency.
+
+**Core principle: evidence before claims, always.**
+
+**Violating the letter of this rule is violating the spirit of this rule.**
+
+## The Iron Law
+
+```
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+```
+
+If the verification command has not been run in the current action, no completion claim may be made.
+
+## The Gate Function
+
+Before claiming any status or expressing satisfaction:
+
+1. **IDENTIFY** — What command proves this claim?
+2. **RUN** — Execute the full command fresh and completely.
+3. **READ** — Consume the full output; check exit code; count failures.
+4. **VERIFY** — Does the output confirm the claim?
+   - If NO: state the actual status with evidence.
+   - If YES: state the claim WITH the evidence.
+5. **ONLY THEN** — Make the claim.
+
+Skipping any step = lying, not verifying.
+
+## Common Failures
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| Tests pass | Test command output: 0 failures | Previous run, "should pass" |
+| Linter clean | Linter output: 0 errors | Partial check, extrapolation |
+| Build succeeds | Build command: exit 0 | Linter passing, logs look good |
+| Bug fixed | Reproduce original symptom: passes | Code changed, assumed fixed |
+| Regression test works | Red-green cycle verified | Test passes once |
+| Subagent completed | VCS diff shows actual changes | Subagent reports "success" |
+| Requirements met | Line-by-line checklist verified | Tests passing |
+
+## Red Flags — STOP
+
+Stop before proceeding if any of these are true:
+
+- Using "should", "probably", "seems to", "looks like"
+- Expressing satisfaction before running verification ("Great!", "Perfect!", "Done!")
+- About to commit, push, or open a PR without fresh verification
+- Trusting a subagent's self-reported success
+- Relying on a partial or scoped verification pass
+- Thinking "just this once"
+- Fatigued and wanting the task to be over
+- Any wording implying success without having run the verification command
+
+## Rationalization Prevention
+
+| Excuse | Reality |
+|--------|---------|
+| "Should work now" | Run the verification |
+| "I'm confident" | Confidence is not evidence |
+| "Just this once" | No exceptions |
+| "Linter passed" | Linter is not the compiler |
+| "Subagent said success" | Verify independently |
+| "Partial check is enough" | Partial proves nothing |
+| "Different words so rule doesn't apply" | Spirit over letter |
+
+## Key Patterns
+
+**Tests:**
+
+```
+CORRECT:   [Run test command] → see "34/34 pass" → state "All tests pass"
+INCORRECT: "Should pass now" / "Looks correct"
+```
+
+**Regression tests (red-green-refactor):**
+
+```
+CORRECT:   Write test → Run (must PASS) → Revert fix → Run (must FAIL) → Restore fix → Run (must PASS)
+INCORRECT: "I've written a regression test" without running the red-green cycle
+```
+
+**Build:**
+
+```
+CORRECT:   [Run build command] → see exit 0 → state "Build passes"
+INCORRECT: "Linter passed" (linter does not check compilation)
+```
+
+**Requirements checklist:**
+
+```
+CORRECT:   Re-read the original requirements → create a line-by-line checklist → verify each item → report gaps or completion
+INCORRECT: "Tests pass, phase complete"
+```
+
+**Subagent delegation:**
+
+```
+CORRECT:   Subagent reports success → inspect VCS diff → run verification → report actual state
+INCORRECT: Trust the subagent's self-report and propagate it as fact
+```
+
+## When to Apply
+
+Apply **always** before:
+
+- Any variation of success, completion, or done claims
+- Any expression of satisfaction with work state
+- Any positive statement about correctness
+- Committing, opening a PR, or marking a task complete
+- Moving on to the next task
+- Reporting subagent results to the user
+
+The rule applies to exact phrases, paraphrases, synonyms, and any implication of success — not just the literal word "done."
+
+## The Bottom Line
+
+Run the command. Read the output. Then make the claim.
+
+No shortcuts. No exceptions.

--- a/skills/verification-before-completion/plugin.json
+++ b/skills/verification-before-completion/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "verification-before-completion",
+  "version": "1.0.0",
+  "description": "Hard gate: forbids completion claims without running verification and reading fresh output.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/worktree/SKILL.md
+++ b/skills/worktree/SKILL.md
@@ -1,0 +1,239 @@
+---
+name: worktree
+description: Create an isolated git worktree from the correct base branch and check it out into a clean, gitignored directory. Use when the user asks to make a worktree, spin up a parallel/isolated workspace, work on something without disturbing the current checkout, branch off the current work, or run multiple agents on the same repo at once. Picks the base branch smartly — the current feature branch when you are on one, otherwise the develop integration branch — so worktrees continue your in-progress work by default instead of forking from the wrong place.
+compatibility: Requires git 2.5+ (worktree support).
+metadata:
+  version: "1.0.0"
+  tags: "git, worktree, branch, isolation, parallel, workspace"
+  author: Ship Shit Dev
+allowed-tools: Bash(git *)
+when_to_use: "make a worktree, create a worktree, new worktree, isolated workspace, parallel workspace, work on this separately, branch off current work, spin up a sibling checkout, run another agent on this repo"
+---
+
+# Worktree
+
+Create a git worktree off the **right base branch**, in a clean gitignored
+directory, with the safety checks that keep the main checkout and `.gitignore`
+correct. This skill only **creates** and **lists** worktrees. Removing and
+pruning merged worktrees is `release-cleanup`'s job — do not delete here.
+
+## Contract
+
+Inputs:
+
+- Repository root (must be inside a git work tree)
+- Optional worktree/branch name (the new branch to create)
+- Optional explicit base branch override (`from <base>` / `--base <base>`)
+- Optional `--fetch` flag to refresh the base from origin before branching
+
+Outputs:
+
+- A new worktree directory at `.worktrees/<name>` checked out on a new branch
+- The resolved base branch and why it was chosen
+- A warning if the base is behind its remote (local mode does not auto-fetch)
+- The path to `cd` into, ready for a parallel session
+
+Creates/Modifies:
+
+- Adds `.worktrees/` to `.gitignore` and commits that change if not already ignored
+- Creates a new branch and a new worktree directory
+- Never touches the current working tree's tracked files, never switches the current branch
+
+External Side Effects:
+
+- None by default (local tips only, no network)
+- Only with `--fetch`: a single `git fetch origin <base>` to refresh the base ref
+
+Confirmation Required:
+
+- Before writing to `.gitignore` and committing it (one-time, only if `.worktrees/` is not yet ignored)
+- Before reusing an existing branch instead of creating a new one
+- Before overwriting or reusing a worktree path that already exists
+
+Delegates To:
+
+- `release-cleanup` to verify promotion and prune merged worktrees and branches
+- `git-safety` if a branch about to live in a worktree may contain secrets
+
+## Base Branch Selection (the core behavior)
+
+The base is resolved in this order. **Local tips only — no automatic fetch.**
+
+1. **Explicit override.** If the user named a base (`/worktree fix-auth from develop`
+   or `--base release/1.4`), use it verbatim.
+2. **On a feature branch → branch off the current branch.** If the current branch
+   is not one of the protected/integration branches, the worktree forks from it.
+   This is the default: you stay on your in-progress work and explore a sibling
+   line without disturbing the current checkout.
+3. **On a protected branch or detached HEAD → branch off `develop`.** If the
+   current branch is `master`, `main`, `develop`, or `staging`, or HEAD is
+   detached, fork from the integration branch instead of an integration branch's
+   tip-as-feature. Prefer local `develop`; if no `develop` exists, fall back to
+   the repository's default branch.
+
+```text
+current branch          ->  base the worktree forks from
+----------------------      ----------------------------
+feat/foo  (feature)     ->  feat/foo        (continue current work)
+bugfix/x  (feature)     ->  bugfix/x        (continue current work)
+master / main           ->  develop         (or default branch if no develop)
+develop / staging       ->  develop
+detached HEAD           ->  develop         (or default branch if no develop)
+explicit "from <base>"  ->  <base>          (always wins)
+```
+
+Protected/integration set (never used as a "feature" base in step 2):
+
+```
+master  main  develop  staging
+```
+
+## Phase 1: Verify Repo and Resolve Inputs
+
+```bash
+git rev-parse --is-inside-work-tree            # must be true; else STOP
+TOPLEVEL="$(git rev-parse --show-toplevel)"
+CURRENT="$(git symbolic-ref --quiet --short HEAD || echo DETACHED)"
+git worktree list                              # show what already exists
+```
+
+Resolve the **new branch name**:
+
+- If the user gave a name, use it as the new branch name and the directory name.
+- If no name was given, ask for one. Do not invent a throwaway name.
+- Sanitize the directory name from the branch name (a branch like `feat/foo`
+  becomes directory `.worktrees/feat-foo` while the branch stays `feat/foo`).
+
+## Phase 2: Resolve the Base Branch
+
+```bash
+PROTECTED='master|main|develop|staging'
+
+# Integration fallback, resolved to a ref that actually exists locally.
+# Prefer local develop, then the remote-tracking origin/develop (still local,
+# no fetch), then the repo's default branch.
+if git show-ref --verify --quiet refs/heads/develop; then
+  FALLBACK=develop
+elif git show-ref --verify --quiet refs/remotes/origin/develop; then
+  FALLBACK=origin/develop   # new branch will fork from and track origin/develop
+else
+  DEF="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD | sed 's#^origin/##')"
+  DEF="${DEF:-master}"
+  git show-ref --verify --quiet "refs/heads/$DEF" && FALLBACK="$DEF" || FALLBACK="origin/$DEF"
+fi
+
+# Apply the precedence. BASE is the start-point ref passed to `git worktree add`.
+if [ -n "$EXPLICIT_BASE" ]; then
+  BASE="$EXPLICIT_BASE"
+elif printf '%s\n' "$CURRENT" | grep -qxE "$PROTECTED" || [ "$CURRENT" = DETACHED ]; then
+  BASE="$FALLBACK"          # on a protected/detached ref -> integration branch
+else
+  BASE="$CURRENT"           # on a feature branch -> continue current work
+fi
+echo "Base: $BASE  (current: $CURRENT)"
+```
+
+`BASE` is always a concrete start-point (a local branch like `develop`, a
+remote-tracking ref like `origin/develop`, or the user's explicit base). Report
+the resolved base and the reason before creating anything.
+
+## Phase 3: Freshness Check (warn, do not fetch)
+
+Local mode is the default: branch from the local tip of `$BASE`. If the base has
+an upstream and is behind it, warn — do not silently fetch.
+
+```bash
+if git rev-parse --verify --quiet "$BASE@{upstream}" >/dev/null; then
+  BEHIND="$(git rev-list --count "$BASE..$BASE@{upstream}" 2>/dev/null || echo 0)"
+  [ "$BEHIND" -gt 0 ] && echo "WARNING: local $BASE is $BEHIND commit(s) behind its remote. Using local tip. Pass --fetch to update first."
+fi
+```
+
+Only if the user passed `--fetch`:
+
+```bash
+git fetch origin "$BASE"
+git update-ref "refs/heads/$BASE" "origin/$BASE"   # only when safe / fast-forward
+```
+
+Do not fetch by default. Do not rewrite a base branch that has local commits not
+on the remote — warn and use the local tip instead.
+
+## Phase 4: Ensure `.worktrees/` Is Gitignored
+
+The worktree directory must never be tracked. Verify, and fix once if needed.
+
+```bash
+if ! git -C "$TOPLEVEL" check-ignore -q .worktrees; then
+  # .worktrees/ is not ignored yet — confirm, then add and commit
+  printf '\n# Local git worktrees (created by the worktree skill)\n.worktrees/\n' >> "$TOPLEVEL/.gitignore"
+  git -C "$TOPLEVEL" add .gitignore
+  git -C "$TOPLEVEL" commit -m "chore: ignore .worktrees/ directory"
+fi
+```
+
+This is the only commit the skill makes, and only the first time in a repo.
+Confirm before committing in a shared repo.
+
+## Phase 5: Create the Worktree
+
+```bash
+NAME="<sanitized-name>"
+BRANCH="<new-branch-name>"
+DEST="$TOPLEVEL/.worktrees/$NAME"
+
+# Guard: destination must not already exist
+[ -e "$DEST" ] && { echo "Path exists: $DEST — choose another name or remove it first."; exit 1; }
+
+if git show-ref --verify --quiet "refs/heads/$BRANCH"; then
+  # Branch already exists: confirm, then attach it (no -b, no new branch)
+  git worktree add "$DEST" "$BRANCH"
+else
+  # New branch off the resolved local base tip
+  git worktree add -b "$BRANCH" "$DEST" "$BASE"
+fi
+
+git worktree list
+```
+
+Rules:
+
+- Use `-b` only when creating a new branch. If the branch exists, attach it and
+  say so — never silently reset an existing branch.
+- A branch can be checked out in only one worktree at a time. If `$BRANCH` is
+  already checked out elsewhere, report where and stop.
+- Never pass `--force`. If git refuses, surface the reason and let the user decide.
+
+## Phase 6: Report and Hand Off
+
+Report:
+
+- Worktree path: `.worktrees/<name>`
+- New branch and the base it forked from (plus why that base)
+- Any freshness warning from Phase 3
+- How to start work there: `cd .worktrees/<name>` and open a parallel session in
+  that directory. Each worktree is an independent checkout sharing one `.git`.
+- If the project needs dependencies, install them inside the worktree before
+  running anything (worktrees do not share `node_modules`).
+
+## Modes
+
+- `worktree <name>` — create a worktree named `<name>` on a new branch `<name>`,
+  base resolved by the smart rules above. (Default.)
+- `worktree <name> from <base>` / `worktree <name> --base <base>` — force the base.
+- `worktree <name> --fetch` — refresh the base from origin before branching.
+- `worktree list` — list existing worktrees and their branches; create nothing.
+
+When the user scopes it differently ("off master", "use my current branch",
+"don't touch gitignore"), honor the scope but keep the safety checks that prevent
+tracking the worktree dir or clobbering an existing branch/path.
+
+## Safety Model
+
+1. Never switches the current branch or modifies the current working tree's
+   tracked files. A worktree is additive.
+2. Never tracks the worktree directory — `.worktrees/` is verified ignored first.
+3. Local tips by default; network only on explicit `--fetch`.
+4. Never `--force`, never reset an existing branch, never overwrite an existing
+   path. On conflict, report and stop.
+5. Removal and pruning are out of scope — hand off to `release-cleanup`.

--- a/skills/worktree/plugin.json
+++ b/skills/worktree/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "worktree",
+  "version": "1.0.0",
+  "description": "Create an isolated git worktree off the right base branch (current feature branch, else develop) in a clean gitignored directory",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -1,0 +1,158 @@
+---
+name: writing-plans
+description: >-
+  Turn a spec or requirements doc into a comprehensive, bite-sized implementation plan: map every file, define 2-5 minute TDD tasks with complete code, and enforce DRY/YAGNI/frequent-commits discipline. Use when you have requirements ready and need a concrete execution plan before touching code, when a feature spans multiple files and needs decomposition, or when you want agentic workers to execute tasks reliably without guessing.
+metadata:
+  version: "1.0.0"
+  tags: "planning, implementation-plan, tasks, tdd, dry, yagni, decomposition"
+  author: Ship Shit Dev
+when_to_use: "write a plan, create implementation plan, plan this feature, break this into tasks, plan before coding, spec to tasks"
+---
+
+# Writing Plans
+
+Write a comprehensive implementation plan assuming the implementer has zero context about the codebase and questionable test instincts. Document everything: which files to touch, complete code, exact commands, expected output, and how to verify. Deliver the whole plan as bite-sized checkboxed tasks. DRY. YAGNI. TDD. Frequent commits.
+
+## Scope Check
+
+If the spec covers multiple independent subsystems, consider breaking it into separate plans — one per subsystem. Each plan should produce working, testable software on its own. Deeply coupled work can share a plan; independently deployable subsystems should not.
+
+## File Mapping (Before Any Tasks)
+
+Before defining tasks, map out which files will be created or modified and what each one is responsible for. This is where decomposition decisions get locked in.
+
+- Design units with clear boundaries and well-defined interfaces. Each file should have one clear responsibility.
+- Prefer smaller, focused files over large files that do too much. The agent edits most reliably when it can hold the full file in context.
+- Files that change together should live together. Split by responsibility, not by technical layer.
+- In existing codebases, follow established patterns. If the codebase uses large files, do not unilaterally restructure — but if a file you are modifying has grown unwieldy, including a split in the plan is reasonable.
+
+This structure informs task decomposition. Each task should produce self-contained changes that make sense independently.
+
+## Bite-Sized Task Granularity
+
+Each step is one action, completable in 2-5 minutes:
+
+- "Write the failing test" — one step
+- "Run it to confirm it fails" — one step
+- "Write the minimal implementation to make it pass" — one step
+- "Run the tests and confirm they pass" — one step
+- "Commit" — one step
+
+Never combine steps. Never skip the failure confirmation.
+
+## Plan Document Header
+
+Every plan MUST start with this header:
+
+```markdown
+# [Feature Name] Implementation Plan
+
+**Goal:** [One sentence describing what this builds]
+
+**Architecture:** [2-3 sentences about approach]
+
+**Tech Stack:** [Key technologies/libraries used]
+
+---
+```
+
+## Task Structure Template
+
+````markdown
+### Task N: [Component Name]
+
+**Files:**
+- Create: `exact/path/to/file.ts`
+- Modify: `exact/path/to/existing.ts`
+- Test: `tests/exact/path/to/file.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+it('describes specific behavior', () => {
+  const result = functionUnderTest(input)
+  expect(result).toBe(expectedValue)
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+bun run test tests/path/to/file.test.ts
+```
+
+Expected: FAIL — `functionUnderTest is not defined` (or similar)
+
+- [ ] **Step 3: Write minimal implementation**
+
+```typescript
+export function functionUnderTest(input: InputType): OutputType {
+  return expectedValue
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+bun run test tests/path/to/file.test.ts
+```
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/path/to/file.test.ts src/path/to/file.ts
+git commit -m "feat: add specific behavior"
+```
+````
+
+## No Placeholders
+
+Every step must contain the actual content the implementer needs. The following are **plan failures** — never write them:
+
+- "TBD", "TODO", "implement later", "fill in details"
+- "Add appropriate error handling" / "add validation" / "handle edge cases"
+- "Write tests for the above" without the actual test code
+- "Similar to Task N" — repeat the code; the implementer may read tasks out of order
+- Steps that describe what to do without showing how (every code step requires a code block)
+- References to types, functions, or methods not defined anywhere in the plan
+
+## Iron Rules
+
+- Exact file paths always — no "somewhere in src/"
+- Complete code in every step — if a step changes code, show the full changed code
+- Exact commands with expected output or expected failure message
+- Every test written before the implementation it tests
+- Every task ends with a commit
+- DRY, YAGNI — no speculative abstractions, no future-proofing not required by the spec
+
+## Self-Review Checklist
+
+After writing the complete plan, review it against the spec before handing it off. Run this yourself — do not delegate it.
+
+**1. Spec coverage.** Skim each requirement in the spec. Can you point to a task that implements it? List any gaps and add tasks for them.
+
+**2. Placeholder scan.** Search the plan for any pattern from the "No Placeholders" section above. Fix every hit before proceeding.
+
+**3. Type and name consistency.** Do the types, method signatures, and property names used in later tasks match what is defined in earlier tasks? A function named `clearItems()` in Task 3 and `clearAllItems()` in Task 7 is a bug in the plan. Fix it.
+
+If you find issues, fix them inline. Then hand off.
+
+## Saving the Plan
+
+Save the plan to a file in the project before execution. A sensible default location is `docs/plans/YYYY-MM-DD-<feature-name>.md`, but defer to any project convention or user preference.
+
+## Execution Handoff
+
+After saving the plan, offer the user two execution paths:
+
+> **Plan saved. Two options for execution:**
+>
+> **1. Subagent-per-task (recommended)** — dispatch a fresh subagent for each task with a review checkpoint between tasks. Faster iteration, isolated context per task, catches drift early.
+>
+> **2. Inline execution** — work through tasks sequentially in the current session, checking off each step before moving to the next.
+>
+> Which approach?
+
+Whichever path the user chooses, enforce strict task-by-task execution: complete every checkbox in a task before starting the next task. No skipping steps. No batching tasks.

--- a/skills/writing-plans/plugin.json
+++ b/skills/writing-plans/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "writing-plans",
+  "version": "1.0.0",
+  "description": "Turn a spec into a bite-sized TDD implementation plan with mapped files, exact code, and frequent commits.",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/skills/writing-prds/SKILL.md
+++ b/skills/writing-prds/SKILL.md
@@ -1,0 +1,295 @@
+---
+name: writing-prds
+description: Use when the user wants to draft, scope, or formalize a feature — "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before an agent plans it. Writes a PRD that a planning agent can consume in one shot without re-elicitation. Do NOT use for code edits, debugging, or PR reviews.
+metadata:
+  version: "1.0.0"
+  tags: "prd, planning, requirements, spec, github-issue, scoping"
+---
+
+# Writing PRDs
+
+A PRD is the input contract for the planning phase. A good PRD lets a planning
+agent produce a usable plan in one shot instead of burning turns asking "what did
+you mean by X?". A bad PRD causes planner thrash, review rejection, and
+verification failures downstream.
+
+This skill is platform-agnostic. It assumes a plan → review → verify → ship flow
+where a PRD is written first, a planner decomposes it into steps, and a verifier
+checks the result against the PRD's acceptance criteria. Adapt the storage and
+field mechanics below to whatever tracker you use.
+
+## Storage Location
+
+**Prefer making the tracker issue body the PRD.** One document per work item, one
+location: the body of an issue in the project's tracker (a GitHub issue is the
+recommended default). Avoid scattering PRDs across local sidecar files that drift
+out of sync the moment work starts.
+
+- **Create** a PRD by creating an issue whose body is clean PRD markdown.
+- **Edit** a PRD by editing that issue's body.
+- **Version history** is the tracker's edit history — no manual `updated` field.
+- **The planner reads the issue body verbatim.** What you write in the body is
+  exactly what the planning agent sees, so it must stand alone.
+
+If there is no connected tracker, decide on the single canonical location for the
+PRD before writing — do not draft into a throwaway scratch file that nobody will
+find again.
+
+## Native Tracker Metadata
+
+Do not put YAML frontmatter at the top of issue bodies. Trackers render
+issue-body frontmatter as visible noise and already have native fields for this
+metadata.
+
+Use native tracker / project-board fields instead:
+
+- **Issue type:** `Feature`, `Bug`, or `Task`.
+- **Status:** `Todo`, `In Progress`, `Done`, or `On hold`.
+- **Priority:** `P0`, `P1`, `P2`, or `P3`.
+- **Complexity:** `Low`, `Medium`, or `High`.
+- **Blast radius:** `Contained`, `Cross-package`, `Cross-app`, or `Infra`.
+
+Rules:
+
+- The PRD body starts with `# PRD: <name>` and contains only human-readable PRD content.
+- Put card/list summaries in the issue title, project fields, or a short Executive Summary, not in hidden metadata.
+- If you cannot estimate complexity, set the field to `Medium` and explain why in Risks & Open Questions.
+- `Draft` is workflow state, not body text. Keep draft PRDs off the runnable board path through status fields, not by editing the body.
+
+## Issue Title Style
+
+The issue title is what the board shows most of the time. Keep it short.
+
+- Prefer **4-7 words** when possible.
+- Prefer an **imperative verb + object** shape: `Add pipeline checkpoints`, `Track CI blockers on issues`, `Expose model selectors in settings`.
+- Put the detail in the Executive Summary and body, not in the title.
+- Avoid titles chained together with `and` / `while` / `during` unless the feature is truly one inseparable unit.
+- Avoid titles that restate the full implementation loop. The title names the work item; the PRD explains it.
+- Keep the `# PRD:` name aligned with the final issue title's slugified form. If you shorten the title, shorten the PRD heading too.
+
+Bad:
+
+- `Open draft PR during execution and ingest PR feedback into stabilization loop`
+- `Treat CI failures as blocker state on GitHub issue tasks`
+
+Better:
+
+- `Add draft PR feedback loop`
+- `Track CI blockers on issues`
+
+## Required Sections
+
+Every PRD must have these sections, in this order. Missing sections fail quality gate.
+
+```markdown
+# PRD: <name>
+
+## Executive Summary
+<2–4 sentences. What is this feature, why now, who wins.>
+
+## Problem Statement
+<The concrete pain. Reference real incidents, real users, real metrics where possible.
+Avoid "users might want..." — if you can't name the user, you don't have a problem yet.>
+
+## Goals
+- <measurable, verifiable goal>
+- <measurable, verifiable goal>
+
+## Non-Goals
+- <thing this explicitly does NOT do — the more you list, the less scope creep downstream>
+
+## User Stories
+- As a <role>, I want <capability> so that <outcome>.
+- Each story ends with "**Acceptance:**" followed by 1–3 concrete checks.
+
+## Functional Requirements
+<Numbered list. Each item must be verifiable by reading code or running it.
+NO implementation details — "the system must do X", not "use Zustand to do X".>
+
+## Non-Functional Requirements
+<Performance, accessibility, error-handling, offline, observability.
+Only list the ones that actually matter for this feature.>
+
+## Success Criteria
+<The bar the verification phase will check against.
+Every bullet here becomes an acceptance criterion the verifier asserts on.
+Write them like test assertions.>
+
+## Out of Scope
+<Be ruthless. Future-proofs the review phase against scope creep.>
+
+## Dependencies
+<Other PRDs, packages, external APIs, feature flags. Reference by path or URL.>
+
+## Verification Plan
+<How the verifier will know this shipped correctly.
+`tests`: list the test files/suites that must exist and pass.
+`manual`: list the manual QA steps a human will run post-merge.
+`both`: both sections. The clearer this section, the fewer verification retries you burn.>
+
+## Risks & Open Questions
+<Unknowns, edge cases, things that could kill the plan mid-execution.
+Open questions get tracked here until answered, then deleted.>
+```
+
+## Mapping PRD Sections to the Plan
+
+A PRD is read by the planning agent. Every section has a downstream consumer:
+
+| PRD section | Feeds | Consumer |
+|---|---|---|
+| Executive Summary | Plan objective | Plan display, PR title, board card |
+| Goals + Functional Requirements | Plan steps | Planner decomposition |
+| Success Criteria | Acceptance criteria | Verification phase |
+| Out of Scope | Plan out-of-scope list | Review phase (rejects scope creep) |
+| Complexity field | Estimated complexity | Review rubric, retry budget |
+| Verification Plan | Verification prompt input | Verification phase |
+| Non-Goals + Out of Scope | Review gate | Reviewer rejects patches that violate these |
+
+**Do not write sections that describe files to change, function names, or implementation choices.** Those belong in the plan, not the PRD. If you can't resist writing pseudo-code, put it under "Risks & Open Questions" as "I suspect we'll need to touch X" — not as a requirement.
+
+## Quality Gates
+
+Before marking a PRD ready for a planner to consume, every one of these must be true:
+
+- [ ] No placeholder text (`TODO`, `TBD`, `<fill this in>`) remains in any section.
+- [ ] `Goals` has at least one measurable bullet.
+- [ ] `Success Criteria` has at least one bullet, and every bullet is **verifiable without judgement** — it either passes or fails. "Feels fast" is not verifiable. "p95 latency < 300ms on the issues query" is.
+- [ ] `Out of Scope` has at least one bullet. Empty `Out of Scope` is a tell that the author didn't scope the feature.
+- [ ] `User Stories` has at least one story with explicit Acceptance bullets.
+- [ ] Every external dependency in `Dependencies` is named (package, PRD path, or URL), not described vaguely.
+- [ ] `Verification Plan` names either test file paths, suite names, or concrete manual steps — not "write some tests".
+
+If any gate fails, keep it in draft/on-hold workflow state and do not mark it ready to plan.
+
+## Workflow
+
+### When the user says "write a PRD for X"
+
+1. **Confirm where the PRD will live.** If using a tracker, confirm the target repo/project. If nothing is connected, agree on the single canonical location first — there must be exactly one.
+
+2. **Do not start writing immediately.** Run a short elicitation pass first — you need answers before section-filling is meaningful:
+   - What problem does this solve, and for whom specifically?
+   - What does success look like — how would we measure it?
+   - What is explicitly out of scope?
+   - What's the complexity gut feel (low/medium/high) and why?
+   - Any hard constraints — deadlines, other projects in flight, package boundaries?
+
+3. **Check for an existing issue.** If using GitHub, run `gh issue list --search "<keywords>" --state all` in the target repo. If a matching issue already exists, ask whether to edit it or create a fresh one.
+
+4. **Kebab-case the PRD name.** If the proposed name has spaces, camelCase, or punctuation, kebab-case it: `"Notification Center"` → `notification-center`. This slug goes in the `# PRD:` heading.
+
+5. **Compress the issue title before writing the body.** Default to a short imperative title, then derive the `# PRD:` heading from that final title. Put nuance in the Executive Summary, not the title.
+
+6. **Draft the PRD body** using the template above, in a scratch buffer. Fill every required section. If you can't fill a section, ask the user — don't hallucinate requirements.
+
+7. **Run the quality gates** against the draft. If any fail, keep the issue in draft/on-hold workflow state and tell the user which gates failed. If they all pass, mark it ready through native project state.
+
+8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it — e.g. `gh issue create --title "<Human Readable Title>" --body-file -` with the PRD markdown piped on stdin.
+
+9. **Confirm the outcome** to the user with the issue URL. Suggest the next step: "Ready to hand this to the planner? Say: plan issue #N".
+
+### When the user says "plan the X PRD"
+
+1. Fetch the current issue body (e.g. `gh issue view <N> --json body --jq .body`). Read it fully before producing anything.
+2. Verify the issue is ready through native project state — never plan a draft/on-hold issue.
+3. Translate directly: Executive Summary → objective, Success Criteria → acceptance criteria, Out of Scope → out-of-scope, complexity field → estimated complexity.
+4. The plan phase owns file changes and step breakdown — do not copy those out of the PRD (there shouldn't be any).
+
+### When the user says "update the X PRD"
+
+1. Fetch the current issue body (prefer the tracker's live read to guarantee freshness).
+2. Make the requested edit in a scratch buffer.
+3. Write it back (e.g. `gh issue edit <N> --body-file -`). The tracker records the edit history automatically.
+4. If the change invalidates an in-flight plan (new acceptance criterion, new out-of-scope item), flag that explicitly — the user may want to kill the thread and re-plan.
+
+## Anti-Patterns
+
+Observed failure modes — do not repeat:
+
+- **PRD full of implementation details.** Writing `use TanStack Query v5 for caching` in Functional Requirements. The PRD describes the *what*; the plan owns the *how*. This leaks into review and causes the reviewer to flag the plan for violating the PRD, which the planner then "fixes" by copying the implementation detail verbatim. Dead loop.
+- **Success Criteria written as vibes.** "Users should find the flow intuitive." Unverifiable → verification retries forever.
+- **Empty Out of Scope.** Always a sign the author is planning to sneak scope in later. Force the listing.
+- **Authoring a PRD with nowhere to put it.** If there's no agreed canonical location, the PRD becomes an orphan document that drifts out of sync. Decide the location first.
+- **Editing a cached copy instead of the source.** If your tracker caches issue bodies locally, the cache is downstream of the tracker, not upstream. Always edit via the tracker's API/CLI, never the cache.
+- **Creating an issue without running the quality gates first.** Half-formed PRDs thrash the planner and burn verification retries. Running gates after the issue is already public is embarrassing and harder to fix than running them first.
+- **Writing a PRD for something you should just ticket.** A typo fix does not need a PRD. A dependency bump does not need a PRD. Reserve PRDs for features and architectural changes that will run through plan / review / verify / ship.
+
+## Minimal Example
+
+The text below is the exact issue body to push (e.g. `gh issue create --body-file -`). Tracker metadata belongs in native fields, not in this body.
+
+```markdown
+# PRD: copy-issue-url-action
+
+## Executive Summary
+Users working in the board frequently need to paste an issue URL into chat,
+commit messages, or an external ticketing tool. Today the only way to get the
+URL is to click into the issue, then copy from the header — three clicks and
+a context switch. Add a "Copy URL" action to the card's context menu so it
+takes one click.
+
+## Problem Statement
+Observed on 2026-04-09: the user mentioned needing to paste an issue URL
+into a chat thread five times in a single session, each requiring a detour
+through the issue detail view. This is pure friction — the URL is already known.
+
+## Goals
+- Right-clicking a board card shows a context menu with "Copy URL".
+- Clicking "Copy URL" writes the issue's URL to the clipboard and
+  shows a toast confirming the copy.
+
+## Non-Goals
+- Copying anything other than the URL (title, body, ID — all separate actions
+  if demand appears).
+- A multi-select "copy all URLs" bulk action.
+- Keyboard shortcut for copy — mouse-only for v1.
+
+## User Stories
+- As a developer pasting issue links into chat, I want to copy an issue's
+  URL without leaving the board, so that I don't break my flow.
+  **Acceptance:**
+  - Right-click on a card surfaces a context menu including "Copy URL".
+  - Clicking it results in the URL being on the system clipboard.
+  - A toast appears within 200ms confirming the copy.
+
+## Functional Requirements
+1. The card component must support a right-click context menu.
+2. The context menu must include an action labeled "Copy URL".
+3. The URL written to the clipboard must be the canonical issue URL.
+4. The toast notification must use the existing UI toast primitive.
+
+## Non-Functional Requirements
+- Clipboard write must succeed or fail cleanly — no silent failures. On
+  permission denial, surface an error toast.
+
+## Success Criteria
+- Right-clicking any card opens a context menu with a "Copy URL" item.
+- Clicking "Copy URL" puts the exact canonical issue URL on the clipboard.
+- A success toast appears when the copy succeeds.
+- An error toast appears if the clipboard API rejects the write.
+
+## Out of Scope
+- Copying other fields (title, body, branch name).
+- Bulk selection + copy.
+- Keyboard shortcut bindings.
+- A "Share" action that opens the URL in the browser.
+
+## Dependencies
+- The existing UI toast primitive in the project's component library.
+- The issue number and repo identifier for URL construction.
+
+## Verification Plan
+- **tests:** add a test that simulates a right-click and asserts the context
+  menu includes a "Copy URL" item wired to a mocked clipboard write.
+- **manual:** right-click three cards from different projects, paste the
+  clipboard into a browser tab, verify the URL loads the correct issue.
+
+## Risks & Open Questions
+- Which clipboard API does the renderer use today? Check the existing
+  implementation before writing new clipboard code.
+- Do we need focus-management so the context menu doesn't fight with
+  drag-and-drop handlers on the same card?
+```
+
+Note: no `created`, `updated`, `status`, `complexity`, or `blast radius` fields in the body — the tracker and project board track those natively. No file path — the PRD lives in the issue body itself.

--- a/skills/writing-prds/plugin.json
+++ b/skills/writing-prds/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "writing-prds",
+  "version": "1.0.0",
+  "description": "Write a PRD a planning agent can consume in one shot — tracker-issue-as-PRD, section template, title discipline, and quality gates",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}


### PR DESCRIPTION
Adds five skills to the library.

## release-cleanup
Release-readiness cleanup pass before tagging.

## Ported spec-pipeline skills (genericized, no client coupling)
- **writing-prds** — tracker-issue-as-PRD model, section template, title discipline, quality gates
- **prd-quality-gate** — six-section PRD readiness gate before planning
- **context-engineering** — read-conventions-first protocol (trust levels, conflict resolution, pattern discovery)
- **execution-debugging** — scoped root-cause debugging for failing tests/builds during stabilization

All five pass `validate-skill-sync.sh` (0 errors / 0 warnings). marketplace.json, bundle READMEs, and plugin-categories.json regenerated.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added many new skills, including release-cleanup, context-engineering, execution-debugging, systematic-debugging, receiving-code-review, verification-before-completion, worktree, writing-plans, writing-prds, prd-quality-gate, finishing-a-development-branch, and related items.
* **Documentation**
  * Bundle and README docs updated to list and describe the new skills.
* **Marketplace**
  * Marketplace catalog updated to reflect an increased total of skills (now 181).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->