### PR TITLE
feat(skills): add /bug — file a GitHub Bug issue

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,7 +3,7 @@
   "owner": {
     "name": "Ship Shit Dev"
   },
-  "description": "180 AI agent skills for indie developers building startups",
+  "description": "181 AI agent skills for indie developers building startups",
   "plugins": [
     {
       "name": "shipshitdev-startup",
@@ -164,6 +164,11 @@
       "name": "brand-architect",
       "source": "./skills/brand-architect",
       "description": "Use this skill when users need to develop brand strategy, choose a company name, define brand positi"
+    },
+    {
+      "name": "bug",
+      "source": "./skills/bug",
+      "description": "File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps t"
     },
     {
       "name": "bun-validator",

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 ```
 skills/
 ├── skills/              # All skills (182)
-├── commands/            # All commands (11)
+├── commands/            # All commands (12)
 ├── bundles/             # Generated marketplace bundles
 ├── .agents/             # Repo management, memory, meta-skills
 │   ├── SYSTEM/          # Architecture docs, skill standards
@@ -98,6 +98,7 @@ touch skills/my-skill/SKILL.md
 
 | Command | Description |
 |---------|-------------|
+| bug | File a GitHub bug issue |
 | check-domain | Domain name generator & availability checker |
 | clean | Cleanup workflow |
 | co-founder | Strategic business partner workflow |

--- a/bundles/github/README.md
+++ b/bundles/github/README.md
@@ -11,6 +11,7 @@ GitHub workflow and automation skills
 
 ## Included Skills
 
+- `bug`
 - `gh-address-comments`
 - `gh-fix-ci`
 - `gh-inbox`

--- a/bundles/github/skills/bug/SKILL.md
+++ b/bundles/github/skills/bug/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: bug
+description: File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug.
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+metadata:
+  version: "1.0.0"
+  tags: "github, issue, bug, report, gh, triage"
+allowed-tools: Bash(gh *) Bash(git *)
+disable-model-invocation: true
+---
+
+# Bug
+
+Turn a description of something broken into a clean, well-structured GitHub issue
+of type **Bug**. It drafts the report from what the user gives (plus repo context),
+shows it for approval, and only then files the issue — typed `Bug` where the repo
+supports issue types, otherwise labelled `bug`.
+
+It never opens an issue without confirmation and never invents reproduction steps
+or facts the user did not provide; unknowns are marked as such.
+
+## Contract
+
+Inputs:
+
+- A description of the bug (free text, an error/stack trace, or a title plus details)
+- The target repository (auto-detected from the current directory's remote)
+- Optional: labels, assignee, milestone, or severity the user specifies
+
+Outputs:
+
+- A structured bug report (title + body) shown before anything is created
+- Whether the issue will be typed `Bug` or labelled `bug` (and why)
+- The created issue number and URL
+
+Creates/Modifies:
+
+- Creates one GitHub issue of type `Bug` (or with the `bug` label) via `gh`
+- Applies only the labels/assignee/milestone the user asked for
+- Creates the `bug` label if it is used as a fallback and does not yet exist
+- Does not edit code, close other issues, or modify repository settings
+
+External Side Effects:
+
+- Reads repository, label, and issue-type metadata from GitHub
+- Creates a GitHub issue (visible to everyone with repo access)
+
+Confirmation Required:
+
+- Before creating the issue — always print the drafted title + body and require an
+  explicit yes
+- Before creating a new `bug` label (fallback path), if one does not already exist
+
+Delegates To:
+
+- `gh-fix-ci` when the bug is a failing CI check the user wants fixed instead of filed
+- `debug` / `systematic-debugging` when the user wants to root-cause before filing
+
+## When to Use
+
+- To file a clean bug report from a rough description or an error message
+- To log a bug found mid-session without leaving the terminal
+- When the user says "open a bug", "file this", "create a bug issue", or runs `/bug`
+
+Do not use this skill to fix the bug, to file feature requests or tasks (those are a
+different issue type), or to triage existing issues.
+
+## Phase 1: Repository and Type Detection
+
+```bash
+gh auth status -h github.com
+gh repo view --json nameWithOwner,hasIssuesEnabled --jq '{repo:.nameWithOwner, issues:.hasIssuesEnabled}'
+```
+
+Stop if issues are disabled. Detect whether the repo's owner defines issue **types**
+and whether a `Bug` type exists:
+
+```bash
+gh issue create --help | grep -q -- '--type' && echo "type-flag: supported"
+gh api "repos/{owner}/{repo}" --jq '.owner.type' 2>/dev/null
+```
+
+Decide the path:
+
+- **Bug issue type** — preferred when the org/repo exposes a `Bug` type. Use
+  `--type Bug`.
+- **`bug` label** — fallback when no issue types exist. Check for the label and plan
+  to create it only if needed:
+
+```bash
+gh label list --search bug --json name --jq '.[].name'
+```
+
+## Phase 2: Draft the Bug Report
+
+Structure the report from what the user gave. Keep it factual — never fabricate
+steps, versions, or behavior. Mark anything unknown as `_not provided_`.
+
+**Title:** a short, specific summary of the symptom (not "bug" or "it's broken").
+
+**Body** (omit sections that genuinely do not apply):
+
+```markdown
+## Summary
+<one or two sentences: what is broken>
+
+## Steps to Reproduce
+1. …
+2. …
+
+## Expected
+<what should happen>
+
+## Actual
+<what happens instead — include the error/stack trace verbatim if provided>
+
+## Environment
+<app/service, version or commit, OS/browser, anything relevant — or _not provided_>
+
+## Notes
+<links, related issues, suspected area — only if the user gave them>
+```
+
+If the user pasted a stack trace or error, quote it verbatim in a fenced block under
+**Actual**. Ask one concise follow-up only if the report is unusable without it
+(e.g. no symptom at all); otherwise draft with what you have and mark gaps.
+
+## Phase 3: Preview and Confirm
+
+Print the full drafted issue — title, body, the type/label decision, and any
+labels/assignee/milestone to apply — then stop and wait for an explicit yes. In a
+read-only or dry-run request, end here and file nothing.
+
+## Phase 4: Create the Issue
+
+Only after confirmation, write the body to a temp file (to preserve formatting) and
+create the issue.
+
+Preferred — Bug issue type:
+
+```bash
+gh issue create --title "<title>" --body-file /tmp/bug_body.md --type Bug
+```
+
+Fallback — `bug` label (create the label first only if it is missing and the user
+agreed):
+
+```bash
+gh label create bug --color d73a4a --description "Something isn't working" 2>/dev/null || true
+gh issue create --title "<title>" --body-file /tmp/bug_body.md --label bug
+```
+
+Add `--assignee`, `--label`, `--milestone`, or `--project` only for values the user
+specified. If `--type Bug` fails because the type does not exist, fall back to the
+label path and say so rather than failing the run.
+
+## Modes
+
+- `bug` / `bug <description>` — Phases 1-4. Draft, confirm, file the issue. (Default.)
+- `bug draft` — Phases 1-3. Draft and print the report only; create nothing.
+
+If the user names labels, an assignee, a milestone, or a severity, honor them. If
+they ask for a feature or task instead of a bug, say this skill files bugs and point
+them to the right issue type.
+
+## Final Status
+
+Report:
+
+- The repository and whether the issue was typed `Bug` or labelled `bug`
+- The created issue number and URL
+- Any labels, assignee, or milestone applied
+- What to do next — e.g. root-cause with `debug` / `systematic-debugging`, or fix a
+  failing check with `gh-fix-ci`

--- a/bundles/github/skills/bug/plugin.json
+++ b/bundles/github/skills/bug/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "bug",
+  "version": "1.0.0",
+  "description": "File a GitHub issue of type Bug from a description: structures a clear bug report (summary, repro, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type, falling back to a bug label when the repo has no issue types",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}

--- a/commands/bug.md
+++ b/commands/bug.md
@@ -1,0 +1,34 @@
+# Bug - File a GitHub Bug Issue
+
+Turn a description of something broken into a clean GitHub issue of type **Bug**.
+Drafts a structured report, previews it, and only files it after you confirm —
+typed `Bug` where the repo supports issue types, otherwise labelled `bug`.
+
+## Usage
+
+```bash
+/bug <description>   # draft a bug report from the description, preview, then file (default)
+/bug                 # draft from the current context / recent error, preview, then file
+/bug draft <desc>    # draft and print the report only — create nothing
+```
+
+## Workflow
+
+Use the `bug` skill.
+
+1. Detect the repo (from the current remote) and whether it supports a `Bug` issue
+   type or needs the `bug` label fallback. Stop if issues are disabled.
+2. Draft a structured report — title, summary, steps to reproduce, expected vs
+   actual, environment — from what you provided. Unknowns are marked, never invented.
+   Pasted errors/stack traces are quoted verbatim.
+3. Print the drafted issue and wait for explicit confirmation.
+4. Create the issue with `--type Bug` (or `--label bug` fallback), applying only the
+   labels/assignee/milestone you named, and return the issue URL.
+
+## Gates
+
+- Never open the issue without explicit confirmation.
+- Never fabricate reproduction steps, versions, or behavior — mark gaps as not provided.
+- Files bugs only; for feature requests or tasks, use the matching issue type.
+- To root-cause before filing, use `debug` / `systematic-debugging`; for a failing
+  CI check, use `gh-fix-ci`.

--- a/scripts/plugin-categories.json
+++ b/scripts/plugin-categories.json
@@ -196,6 +196,7 @@
     "github": {
       "description": "GitHub workflow and automation skills",
       "skills": [
+        "bug",
         "gh-address-comments",
         "gh-fix-ci",
         "gh-inbox",

--- a/skills/bug/SKILL.md
+++ b/skills/bug/SKILL.md
@@ -1,0 +1,174 @@
+---
+name: bug
+description: File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug.
+compatibility: Requires git and GitHub CLI gh access to the target repository.
+metadata:
+  version: "1.0.0"
+  tags: "github, issue, bug, report, gh, triage"
+allowed-tools: Bash(gh *) Bash(git *)
+disable-model-invocation: true
+---
+
+# Bug
+
+Turn a description of something broken into a clean, well-structured GitHub issue
+of type **Bug**. It drafts the report from what the user gives (plus repo context),
+shows it for approval, and only then files the issue — typed `Bug` where the repo
+supports issue types, otherwise labelled `bug`.
+
+It never opens an issue without confirmation and never invents reproduction steps
+or facts the user did not provide; unknowns are marked as such.
+
+## Contract
+
+Inputs:
+
+- A description of the bug (free text, an error/stack trace, or a title plus details)
+- The target repository (auto-detected from the current directory's remote)
+- Optional: labels, assignee, milestone, or severity the user specifies
+
+Outputs:
+
+- A structured bug report (title + body) shown before anything is created
+- Whether the issue will be typed `Bug` or labelled `bug` (and why)
+- The created issue number and URL
+
+Creates/Modifies:
+
+- Creates one GitHub issue of type `Bug` (or with the `bug` label) via `gh`
+- Applies only the labels/assignee/milestone the user asked for
+- Creates the `bug` label if it is used as a fallback and does not yet exist
+- Does not edit code, close other issues, or modify repository settings
+
+External Side Effects:
+
+- Reads repository, label, and issue-type metadata from GitHub
+- Creates a GitHub issue (visible to everyone with repo access)
+
+Confirmation Required:
+
+- Before creating the issue — always print the drafted title + body and require an
+  explicit yes
+- Before creating a new `bug` label (fallback path), if one does not already exist
+
+Delegates To:
+
+- `gh-fix-ci` when the bug is a failing CI check the user wants fixed instead of filed
+- `debug` / `systematic-debugging` when the user wants to root-cause before filing
+
+## When to Use
+
+- To file a clean bug report from a rough description or an error message
+- To log a bug found mid-session without leaving the terminal
+- When the user says "open a bug", "file this", "create a bug issue", or runs `/bug`
+
+Do not use this skill to fix the bug, to file feature requests or tasks (those are a
+different issue type), or to triage existing issues.
+
+## Phase 1: Repository and Type Detection
+
+```bash
+gh auth status -h github.com
+gh repo view --json nameWithOwner,hasIssuesEnabled --jq '{repo:.nameWithOwner, issues:.hasIssuesEnabled}'
+```
+
+Stop if issues are disabled. Detect whether the repo's owner defines issue **types**
+and whether a `Bug` type exists:
+
+```bash
+gh issue create --help | grep -q -- '--type' && echo "type-flag: supported"
+gh api "repos/{owner}/{repo}" --jq '.owner.type' 2>/dev/null
+```
+
+Decide the path:
+
+- **Bug issue type** — preferred when the org/repo exposes a `Bug` type. Use
+  `--type Bug`.
+- **`bug` label** — fallback when no issue types exist. Check for the label and plan
+  to create it only if needed:
+
+```bash
+gh label list --search bug --json name --jq '.[].name'
+```
+
+## Phase 2: Draft the Bug Report
+
+Structure the report from what the user gave. Keep it factual — never fabricate
+steps, versions, or behavior. Mark anything unknown as `_not provided_`.
+
+**Title:** a short, specific summary of the symptom (not "bug" or "it's broken").
+
+**Body** (omit sections that genuinely do not apply):
+
+```markdown
+## Summary
+<one or two sentences: what is broken>
+
+## Steps to Reproduce
+1. …
+2. …
+
+## Expected
+<what should happen>
+
+## Actual
+<what happens instead — include the error/stack trace verbatim if provided>
+
+## Environment
+<app/service, version or commit, OS/browser, anything relevant — or _not provided_>
+
+## Notes
+<links, related issues, suspected area — only if the user gave them>
+```
+
+If the user pasted a stack trace or error, quote it verbatim in a fenced block under
+**Actual**. Ask one concise follow-up only if the report is unusable without it
+(e.g. no symptom at all); otherwise draft with what you have and mark gaps.
+
+## Phase 3: Preview and Confirm
+
+Print the full drafted issue — title, body, the type/label decision, and any
+labels/assignee/milestone to apply — then stop and wait for an explicit yes. In a
+read-only or dry-run request, end here and file nothing.
+
+## Phase 4: Create the Issue
+
+Only after confirmation, write the body to a temp file (to preserve formatting) and
+create the issue.
+
+Preferred — Bug issue type:
+
+```bash
+gh issue create --title "<title>" --body-file /tmp/bug_body.md --type Bug
+```
+
+Fallback — `bug` label (create the label first only if it is missing and the user
+agreed):
+
+```bash
+gh label create bug --color d73a4a --description "Something isn't working" 2>/dev/null || true
+gh issue create --title "<title>" --body-file /tmp/bug_body.md --label bug
+```
+
+Add `--assignee`, `--label`, `--milestone`, or `--project` only for values the user
+specified. If `--type Bug` fails because the type does not exist, fall back to the
+label path and say so rather than failing the run.
+
+## Modes
+
+- `bug` / `bug <description>` — Phases 1-4. Draft, confirm, file the issue. (Default.)
+- `bug draft` — Phases 1-3. Draft and print the report only; create nothing.
+
+If the user names labels, an assignee, a milestone, or a severity, honor them. If
+they ask for a feature or task instead of a bug, say this skill files bugs and point
+them to the right issue type.
+
+## Final Status
+
+Report:
+
+- The repository and whether the issue was typed `Bug` or labelled `bug`
+- The created issue number and URL
+- Any labels, assignee, or milestone applied
+- What to do next — e.g. root-cause with `debug` / `systematic-debugging`, or fix a
+  failing check with `gh-fix-ci`

--- a/skills/bug/plugin.json
+++ b/skills/bug/plugin.json
@@ -1,0 +1,12 @@
+{
+  "name": "bug",
+  "version": "1.0.0",
+  "description": "File a GitHub issue of type Bug from a description: structures a clear bug report (summary, repro, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type, falling back to a bug label when the repo has no issue types",
+  "author": {
+    "name": "Ship Shit Dev",
+    "email": "hello@shipshit.dev",
+    "url": "https://github.com/shipshitdev"
+  },
+  "license": "MIT",
+  "skills": "."
+}


### PR DESCRIPTION
## What

New **`/bug`** skill + command: turn a description into a clean GitHub issue of type **Bug**.

- [`skills/bug/SKILL.md`](skills/bug/SKILL.md) + [`commands/bug.md`](commands/bug.md)
- Drafts a structured report — title, summary, steps to reproduce, expected vs actual, environment — from what you give it. **Never fabricates** repro steps/versions; gaps are marked `_not provided_`; pasted stack traces quoted verbatim.
- Files with `gh issue create --type Bug`; **falls back to a `bug` label** (creating it if absent) when the repo/org has no issue types.
- **Confirmation-gated**: previews the full issue before creating anything. `--type` failure degrades to the label path instead of erroring.
- Modes: `/bug <desc>` (file) · `/bug draft <desc>` (preview only). Honors user-named labels/assignee/milestone.

## Wiring
- Registered `bug` in the **github** bundle; regenerated marketplace (**181 skills**); README command table → **12**.

## Verification
- `validate:skill bug` clean (Claude + Codex) · markdownlint 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)