### PR TITLE
fix(skills): resolve GitHub review feedback

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -673,7 +673,7 @@
     {
       "name": "prd-quality-gate",
       "source": "./skills/prd-quality-gate",
-      "description": "PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) conta"
+      "description": "PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the"
     },
     {
       "name": "pricing-strategist",

--- a/.github/workflows/agent-dispatch.yml
+++ b/.github/workflows/agent-dispatch.yml
@@ -44,12 +44,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run dev-loop agent on the labeled issue
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@9dd8b95a392eb34b6f5fb56cf5a64cb735912d4b # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # project-scoped PAT: the default GITHUB_TOKEN cannot write an org board.

--- a/.github/workflows/codex-dispatch.yml
+++ b/.github/workflows/codex-dispatch.yml
@@ -41,12 +41,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run dev-loop agent (Codex) on the labeled issue
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
         env:
           # git / gh operations inside the run authenticate with this. It must be a
           # project-scoped PAT — the board Status write in step 7 needs it; the

--- a/.github/workflows/openrouter-dispatch.yml
+++ b/.github/workflows/openrouter-dispatch.yml
@@ -46,9 +46,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Configure OpenRouter provider for Codex CLI
         run: |
@@ -64,7 +65,7 @@ jobs:
           TOML
 
       - name: Run dev-loop agent (OpenRouter) on the labeled issue
-        uses: openai/codex-action@v1
+        uses: openai/codex-action@e0fdf01220eb9a88167c4898839d273e3f2609d1 # v1
         env:
           # The model call authenticates with this (read by the custom provider's
           # env_key); the in-run gh/git operations authenticate with PROJECTS_TOKEN.

--- a/bundles/dev-loop/skills/prd-quality-gate/SKILL.md
+++ b/bundles/dev-loop/skills/prd-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-quality-gate
-description: PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
+description: PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
 metadata:
   version: "1.0.0"
   tags: "prd, planning, validation, quality-gate, spec, requirements"

--- a/bundles/dev-loop/skills/writing-prds/SKILL.md
+++ b/bundles/dev-loop/skills/writing-prds/SKILL.md
@@ -4,7 +4,7 @@ disable-model-invocation: true
 description: Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews.
 metadata:
   version: "1.1.0"
-  tags: "prd, planning, requirements, spec, github-issue, scoping"
+  tags: "prd, planning, requirements, spec, scoping"
 ---
 
 # Writing PRDs
@@ -22,9 +22,8 @@ field mechanics below to whatever tracker you use.
 ## Storage Location
 
 **Prefer making the tracker issue body the PRD.** One document per work item, one
-location: the body of an issue in the project's tracker (a GitHub issue is the
-recommended default). Avoid scattering PRDs across local sidecar files that drift
-out of sync the moment work starts.
+location: the body of an issue in the project's tracker. Avoid scattering PRDs
+across local sidecar files that drift out of sync the moment work starts.
 
 - **Create** a PRD by creating an issue whose body is clean PRD markdown.
 - **Edit** a PRD by editing that issue's body.
@@ -71,7 +70,7 @@ The issue title is what the board shows most of the time. Keep it short.
 Bad:
 
 - `Open draft PR during execution and ingest PR feedback into stabilization loop`
-- `Treat CI failures as blocker state on GitHub issue tasks`
+- `Treat CI failures as blocker state on issue tasks`
 
 Better:
 
@@ -176,7 +175,7 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
    - What's the complexity gut feel (low/medium/high) and why?
    - Any hard constraints — deadlines, other projects in flight, package boundaries?
 
-3. **Check for an existing issue.** If using GitHub, run `gh issue list --search "<keywords>" --state all` in the target repo. If a matching issue already exists, ask whether to edit it or create a fresh one.
+3. **Check for an existing issue.** Search the project's tracker by keywords and state. If a matching issue already exists, ask whether to edit it or create a fresh one.
 
 4. **Kebab-case the PRD name.** If the proposed name has spaces, camelCase, or punctuation, kebab-case it: `"Notification Center"` → `notification-center`. This slug goes in the `# PRD:` heading.
 
@@ -186,13 +185,13 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
 
 7. **Run the quality gates** against the draft. If any fail, keep the issue in draft/on-hold workflow state and tell the user which gates failed. If they all pass, mark it ready through native project state.
 
-8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it — e.g. `gh issue create --title "<Human Readable Title>" --body-file -` with the PRD markdown piped on stdin.
+8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it through the tracker's native issue creation flow, using the PRD markdown as the issue body.
 
 9. **Confirm the outcome** to the user with the issue URL. Suggest the next step: "Ready to hand this to the planner? Say: plan issue #N".
 
 ### When the user says "plan the X PRD"
 
-1. Fetch the current issue body (e.g. `gh issue view <N> --json body --jq .body`). Read it fully before producing anything.
+1. Fetch the current issue body from the tracker. Read it fully before producing anything.
 2. Verify the issue is ready through native project state — never plan a draft/on-hold issue.
 3. Translate directly: Executive Summary → objective, Success Criteria → acceptance criteria, Out of Scope → out-of-scope, complexity field → estimated complexity.
 4. The plan phase owns file changes and step breakdown — do not copy those out of the PRD (there shouldn't be any).
@@ -202,7 +201,7 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
 
 1. Fetch the current issue body (prefer the tracker's live read to guarantee freshness).
 2. Make the requested edit in a scratch buffer.
-3. Write it back (e.g. `gh issue edit <N> --body-file -`). The tracker records the edit history automatically.
+3. Write it back through the tracker's native edit flow. The tracker records the edit history automatically.
 4. If the change invalidates an in-flight plan (new acceptance criterion, new out-of-scope item), flag that explicitly — the user may want to kill the thread and re-plan.
 
 ## Anti-Patterns
@@ -219,7 +218,7 @@ Observed failure modes — do not repeat:
 
 ## Minimal Example
 
-The text below is the exact issue body to push (e.g. `gh issue create --body-file -`). Tracker metadata belongs in native fields, not in this body.
+The text below is the exact issue body to publish. Tracker metadata belongs in native fields, not in this body.
 
 ```markdown
 # PRD: copy-issue-url-action

--- a/bundles/dev-workflow/skills/codebase-advisor/SKILL.md
+++ b/bundles/dev-workflow/skills/codebase-advisor/SKILL.md
@@ -4,11 +4,11 @@ description: Survey any codebase as a senior advisor and produce prioritized, se
 license: MIT
 disable-model-invocation: true
 user-invocable: true
-allowed-tools: Read, Grep, Glob, Write(plans/**), Write(advisor-plans/**), Edit(plans/**), Edit(advisor-plans/**), Task, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git merge-base:*), Bash(git branch --list:*), Bash(git branch --show-current), Bash(find:*), Bash(grep:*), Bash(rg:*), Bash(npm audit), Bash(pnpm audit), Bash(pip-audit), Bash(cargo audit), Bash(tsc --noEmit:*)
+allowed-tools: Read, Grep, Glob, Write(plans/**), Edit(plans/**), Task, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git merge-base:*), Bash(git branch --list:*), Bash(git branch --show-current), Bash(find:*), Bash(grep:*), Bash(rg:*), Bash(npm audit), Bash(pnpm audit), Bash(pip-audit), Bash(cargo audit), Bash(tsc --noEmit:*), Bash(command -v gh), Bash(gh auth status:*), Bash(gh repo view --json visibility:*), Bash(gh issue create:*)
 when_to_use: audit this codebase, code audit, find improvements, what should I build next, roadmap, product direction, generate a handoff plan, plan for another agent, security/perf/test-coverage/tech-debt review, review a plan, execute a plan, reconcile plans
 metadata:
   version: "1.0.0"
-  tags: audit, planning, codebase-review, handoff-plans, orchestration, read-only
+  tags: "audit, planning, codebase-review, handoff-plans, orchestration, read-only"
   author: Ship Shit Dev
   adapted_from: "shadcn/improve (MIT) — https://github.com/shadcn/improve"
 ---
@@ -44,7 +44,7 @@ Outputs:
 
 Creates/Modifies:
 
-- `plans/` (or `advisor-plans/` if `plans/` is already taken for another purpose) in the target repo: a `README.md` index plus `NNN-*.md` plan files. Never modifies source code.
+- `plans/` in the target repo: a `README.md` index plus `NNN-*.md` plan files. Never modifies source code.
 
 External Side Effects:
 
@@ -132,7 +132,7 @@ plans/
 
 **Excerpts come from your own reads, never from a subagent's report.** Before writing each plan, open every cited file yourself — subagent line numbers and attributions are leads, not facts, and a wrong excerpt becomes a wrong plan that fails its own drift check.
 
-Before writing anything: record `git rev-parse --short HEAD` — every plan stamps the commit it was written against (the executor uses it for drift detection). If `plans/` already exists from a previous run, **reconcile, don't duplicate**: read `plans/README.md`, keep numbering monotonic, skip findings already planned or listed as rejected, and mark superseded plans stale in the index. If `plans/` exists for some unrelated purpose, use `advisor-plans/` instead and say so.
+Before writing anything: record `git rev-parse --short HEAD` — every plan stamps the commit it was written against (the executor uses it for drift detection). If `plans/` already exists from a previous run, **reconcile, don't duplicate**: read `plans/README.md`, keep numbering monotonic, skip findings already planned or listed as rejected, and mark superseded plans stale in the index. If `plans/` exists for some unrelated purpose, stop and ask for the canonical plan directory before writing.
 
 Write each plan **for the weakest plausible executor**. That means:
 

--- a/bundles/dev-workflow/skills/deploy/SKILL.md
+++ b/bundles/dev-workflow/skills/deploy/SKILL.md
@@ -3,7 +3,7 @@ name: deploy
 description: Run deployment workflows for web applications (staging, production). Use when user says 'deploy', 'push to staging', 'release', 'ship it', or 'go live'.
 metadata:
   version: "1.0.1"
-  tags: deployment, devops, ci-cd, production, staging
+  tags: "deployment, devops, ci-cd, production, staging"
 ---
 
 # Deploy

--- a/bundles/dev-workflow/skills/release/SKILL.md
+++ b/bundles/dev-workflow/skills/release/SKILL.md
@@ -106,7 +106,28 @@ git status -sb
 ```
 
 Resolve the trunk (default branch) from `defaultBranchRef`; fall back to
-`git symbolic-ref --short refs/remotes/origin/HEAD` then `master`/`main`. Require:
+`git symbolic-ref --short refs/remotes/origin/HEAD`, then explicitly test
+`origin/master` and `origin/main` before failing:
+
+```bash
+TRUNK="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name // empty')"
+if [[ -z "$TRUNK" ]]; then
+  TRUNK="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+fi
+if [[ -z "$TRUNK" ]]; then
+  if git rev-parse --verify origin/master >/dev/null 2>&1; then
+    TRUNK="master"
+  elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+    TRUNK="main"
+  else
+    echo "ERROR: Neither origin/master nor origin/main found. Available remote branches:"
+    git branch -r
+    exit 1
+  fi
+fi
+```
+
+Require:
 
 - the local checkout is on the trunk (or check it out after confirming),
 - the working tree is clean,
@@ -187,6 +208,10 @@ override here and note it in the final status.
 Only after confirmation, tag the trunk HEAD and publish:
 
 ```bash
+if git rev-parse --verify "refs/tags/<next-version>" >/dev/null 2>&1; then
+  echo "ERROR: Tag <next-version> already exists. Stop before overwriting release history."
+  exit 1
+fi
 git tag -a "<next-version>" -m "<next-version>"
 git push origin "<next-version>"
 gh release create "<next-version>" --target "<trunk>" --title "<next-version>" --notes "<patch notes>"

--- a/bundles/github/skills/release/SKILL.md
+++ b/bundles/github/skills/release/SKILL.md
@@ -106,7 +106,28 @@ git status -sb
 ```
 
 Resolve the trunk (default branch) from `defaultBranchRef`; fall back to
-`git symbolic-ref --short refs/remotes/origin/HEAD` then `master`/`main`. Require:
+`git symbolic-ref --short refs/remotes/origin/HEAD`, then explicitly test
+`origin/master` and `origin/main` before failing:
+
+```bash
+TRUNK="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name // empty')"
+if [[ -z "$TRUNK" ]]; then
+  TRUNK="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+fi
+if [[ -z "$TRUNK" ]]; then
+  if git rev-parse --verify origin/master >/dev/null 2>&1; then
+    TRUNK="master"
+  elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+    TRUNK="main"
+  else
+    echo "ERROR: Neither origin/master nor origin/main found. Available remote branches:"
+    git branch -r
+    exit 1
+  fi
+fi
+```
+
+Require:
 
 - the local checkout is on the trunk (or check it out after confirming),
 - the working tree is clean,
@@ -187,6 +208,10 @@ override here and note it in the final status.
 Only after confirmation, tag the trunk HEAD and publish:
 
 ```bash
+if git rev-parse --verify "refs/tags/<next-version>" >/dev/null 2>&1; then
+  echo "ERROR: Tag <next-version> already exists. Stop before overwriting release history."
+  exit 1
+fi
 git tag -a "<next-version>" -m "<next-version>"
 git push origin "<next-version>"
 gh release create "<next-version>" --target "<trunk>" --title "<next-version>" --notes "<patch notes>"

--- a/bundles/planning/skills/prd-quality-gate/SKILL.md
+++ b/bundles/planning/skills/prd-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-quality-gate
-description: PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
+description: PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
 metadata:
   version: "1.0.0"
   tags: "prd, planning, validation, quality-gate, spec, requirements"

--- a/bundles/planning/skills/writing-prds/SKILL.md
+++ b/bundles/planning/skills/writing-prds/SKILL.md
@@ -4,7 +4,7 @@ disable-model-invocation: true
 description: Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews.
 metadata:
   version: "1.1.0"
-  tags: "prd, planning, requirements, spec, github-issue, scoping"
+  tags: "prd, planning, requirements, spec, scoping"
 ---
 
 # Writing PRDs
@@ -22,9 +22,8 @@ field mechanics below to whatever tracker you use.
 ## Storage Location
 
 **Prefer making the tracker issue body the PRD.** One document per work item, one
-location: the body of an issue in the project's tracker (a GitHub issue is the
-recommended default). Avoid scattering PRDs across local sidecar files that drift
-out of sync the moment work starts.
+location: the body of an issue in the project's tracker. Avoid scattering PRDs
+across local sidecar files that drift out of sync the moment work starts.
 
 - **Create** a PRD by creating an issue whose body is clean PRD markdown.
 - **Edit** a PRD by editing that issue's body.
@@ -71,7 +70,7 @@ The issue title is what the board shows most of the time. Keep it short.
 Bad:
 
 - `Open draft PR during execution and ingest PR feedback into stabilization loop`
-- `Treat CI failures as blocker state on GitHub issue tasks`
+- `Treat CI failures as blocker state on issue tasks`
 
 Better:
 
@@ -176,7 +175,7 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
    - What's the complexity gut feel (low/medium/high) and why?
    - Any hard constraints — deadlines, other projects in flight, package boundaries?
 
-3. **Check for an existing issue.** If using GitHub, run `gh issue list --search "<keywords>" --state all` in the target repo. If a matching issue already exists, ask whether to edit it or create a fresh one.
+3. **Check for an existing issue.** Search the project's tracker by keywords and state. If a matching issue already exists, ask whether to edit it or create a fresh one.
 
 4. **Kebab-case the PRD name.** If the proposed name has spaces, camelCase, or punctuation, kebab-case it: `"Notification Center"` → `notification-center`. This slug goes in the `# PRD:` heading.
 
@@ -186,13 +185,13 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
 
 7. **Run the quality gates** against the draft. If any fail, keep the issue in draft/on-hold workflow state and tell the user which gates failed. If they all pass, mark it ready through native project state.
 
-8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it — e.g. `gh issue create --title "<Human Readable Title>" --body-file -` with the PRD markdown piped on stdin.
+8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it through the tracker's native issue creation flow, using the PRD markdown as the issue body.
 
 9. **Confirm the outcome** to the user with the issue URL. Suggest the next step: "Ready to hand this to the planner? Say: plan issue #N".
 
 ### When the user says "plan the X PRD"
 
-1. Fetch the current issue body (e.g. `gh issue view <N> --json body --jq .body`). Read it fully before producing anything.
+1. Fetch the current issue body from the tracker. Read it fully before producing anything.
 2. Verify the issue is ready through native project state — never plan a draft/on-hold issue.
 3. Translate directly: Executive Summary → objective, Success Criteria → acceptance criteria, Out of Scope → out-of-scope, complexity field → estimated complexity.
 4. The plan phase owns file changes and step breakdown — do not copy those out of the PRD (there shouldn't be any).
@@ -202,7 +201,7 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
 
 1. Fetch the current issue body (prefer the tracker's live read to guarantee freshness).
 2. Make the requested edit in a scratch buffer.
-3. Write it back (e.g. `gh issue edit <N> --body-file -`). The tracker records the edit history automatically.
+3. Write it back through the tracker's native edit flow. The tracker records the edit history automatically.
 4. If the change invalidates an in-flight plan (new acceptance criterion, new out-of-scope item), flag that explicitly — the user may want to kill the thread and re-plan.
 
 ## Anti-Patterns
@@ -219,7 +218,7 @@ Observed failure modes — do not repeat:
 
 ## Minimal Example
 
-The text below is the exact issue body to push (e.g. `gh issue create --body-file -`). Tracker metadata belongs in native fields, not in this body.
+The text below is the exact issue body to publish. Tracker metadata belongs in native fields, not in this body.
 
 ```markdown
 # PRD: copy-issue-url-action

--- a/scripts/setup-dev-loop.sh
+++ b/scripts/setup-dev-loop.sh
@@ -254,7 +254,11 @@ provision_board() {
   local backlog_id in_progress_id human_review_id done_id deferred_id
   owner="${REPO%%/*}"
   repo_root="$(git rev-parse --show-toplevel 2>/dev/null || true)"
-  env_file="${repo_root:-.}/.github/agent-loop.env"
+  if [[ -z "$repo_root" ]]; then
+    err "Not inside the target repository working tree; cannot write .github/agent-loop.env"
+    return 1
+  fi
+  env_file="${repo_root}/.github/agent-loop.env"
 
   if $DRY_RUN; then
     dry "resolve-or-create project '${PROJECT_TITLE}' under ${owner} (or reuse --project ${PROJECT_NUMBER:-<auto>})"
@@ -298,6 +302,19 @@ provision_board() {
   human_review_id="$(_opt_id "Human Review")"
   done_id="$(_opt_id "Done")"
   deferred_id="$(_opt_id "Deferred")"
+
+  local missing_ids=()
+  [[ -z "$node_id" ]] && missing_ids+=("PROJECT_NODE_ID")
+  [[ -z "$status_field_id" ]] && missing_ids+=("STATUS_FIELD_ID")
+  [[ -z "$backlog_id" ]] && missing_ids+=("STATUS_BACKLOG_OPTION_ID")
+  [[ -z "$in_progress_id" ]] && missing_ids+=("STATUS_IN_PROGRESS_OPTION_ID")
+  [[ -z "$human_review_id" ]] && missing_ids+=("STATUS_HUMAN_REVIEW_OPTION_ID")
+  [[ -z "$done_id" ]] && missing_ids+=("STATUS_DONE_OPTION_ID")
+  [[ -z "$deferred_id" ]] && missing_ids+=("STATUS_DEFERRED_OPTION_ID")
+  if ((${#missing_ids[@]} > 0)); then
+    err "Failed to resolve board IDs: ${missing_ids[*]}. Aborting env file write."
+    return 1
+  fi
 
   mkdir -p "$(dirname "$env_file")"
   cat >"$env_file" <<EOF
@@ -458,6 +475,15 @@ Examples:
 USAGE
 }
 
+require_option_value() {
+  local flag="$1" value="${2-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    err "Missing value for ${flag}"
+    usage
+    exit 1
+  fi
+}
+
 # ============================================================================
 # Main
 # ============================================================================
@@ -465,8 +491,8 @@ USAGE
 main() {
   while [[ $# -gt 0 ]]; do
     case "$1" in
-      --repo)             REPO="$2"; shift 2 ;;
-      --project)          PROJECT_NUMBER="$2"; shift 2 ;;
+      --repo)             require_option_value "$1" "${2-}"; REPO="$2"; shift 2 ;;
+      --project)          require_option_value "$1" "${2-}"; PROJECT_NUMBER="$2"; shift 2 ;;
       --skip-labels)      DO_LABELS=false; shift ;;
       --skip-board)       DO_BOARD=false; shift ;;
       --skip-workflow)    DO_WORKFLOW=false; shift ;;

--- a/skills/codebase-advisor/SKILL.md
+++ b/skills/codebase-advisor/SKILL.md
@@ -4,11 +4,11 @@ description: Survey any codebase as a senior advisor and produce prioritized, se
 license: MIT
 disable-model-invocation: true
 user-invocable: true
-allowed-tools: Read, Grep, Glob, Write(plans/**), Write(advisor-plans/**), Edit(plans/**), Edit(advisor-plans/**), Task, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git merge-base:*), Bash(git branch --list:*), Bash(git branch --show-current), Bash(find:*), Bash(grep:*), Bash(rg:*), Bash(npm audit), Bash(pnpm audit), Bash(pip-audit), Bash(cargo audit), Bash(tsc --noEmit:*)
+allowed-tools: Read, Grep, Glob, Write(plans/**), Edit(plans/**), Task, Bash(git log:*), Bash(git diff:*), Bash(git status:*), Bash(git show:*), Bash(git rev-parse:*), Bash(git merge-base:*), Bash(git branch --list:*), Bash(git branch --show-current), Bash(find:*), Bash(grep:*), Bash(rg:*), Bash(npm audit), Bash(pnpm audit), Bash(pip-audit), Bash(cargo audit), Bash(tsc --noEmit:*), Bash(command -v gh), Bash(gh auth status:*), Bash(gh repo view --json visibility:*), Bash(gh issue create:*)
 when_to_use: audit this codebase, code audit, find improvements, what should I build next, roadmap, product direction, generate a handoff plan, plan for another agent, security/perf/test-coverage/tech-debt review, review a plan, execute a plan, reconcile plans
 metadata:
   version: "1.0.0"
-  tags: audit, planning, codebase-review, handoff-plans, orchestration, read-only
+  tags: "audit, planning, codebase-review, handoff-plans, orchestration, read-only"
   author: Ship Shit Dev
   adapted_from: "shadcn/improve (MIT) — https://github.com/shadcn/improve"
 ---
@@ -44,7 +44,7 @@ Outputs:
 
 Creates/Modifies:
 
-- `plans/` (or `advisor-plans/` if `plans/` is already taken for another purpose) in the target repo: a `README.md` index plus `NNN-*.md` plan files. Never modifies source code.
+- `plans/` in the target repo: a `README.md` index plus `NNN-*.md` plan files. Never modifies source code.
 
 External Side Effects:
 
@@ -132,7 +132,7 @@ plans/
 
 **Excerpts come from your own reads, never from a subagent's report.** Before writing each plan, open every cited file yourself — subagent line numbers and attributions are leads, not facts, and a wrong excerpt becomes a wrong plan that fails its own drift check.
 
-Before writing anything: record `git rev-parse --short HEAD` — every plan stamps the commit it was written against (the executor uses it for drift detection). If `plans/` already exists from a previous run, **reconcile, don't duplicate**: read `plans/README.md`, keep numbering monotonic, skip findings already planned or listed as rejected, and mark superseded plans stale in the index. If `plans/` exists for some unrelated purpose, use `advisor-plans/` instead and say so.
+Before writing anything: record `git rev-parse --short HEAD` — every plan stamps the commit it was written against (the executor uses it for drift detection). If `plans/` already exists from a previous run, **reconcile, don't duplicate**: read `plans/README.md`, keep numbering monotonic, skip findings already planned or listed as rejected, and mark superseded plans stale in the index. If `plans/` exists for some unrelated purpose, stop and ask for the canonical plan directory before writing.
 
 Write each plan **for the weakest plausible executor**. That means:
 

--- a/skills/deploy/SKILL.md
+++ b/skills/deploy/SKILL.md
@@ -3,7 +3,7 @@ name: deploy
 description: Run deployment workflows for web applications (staging, production). Use when user says 'deploy', 'push to staging', 'release', 'ship it', or 'go live'.
 metadata:
   version: "1.0.1"
-  tags: deployment, devops, ci-cd, production, staging
+  tags: "deployment, devops, ci-cd, production, staging"
 ---
 
 # Deploy

--- a/skills/prd-quality-gate/SKILL.md
+++ b/skills/prd-quality-gate/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: prd-quality-gate
-description: PRD completeness validation. Use to check that a PRD (or GitHub issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
+description: PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint.
 metadata:
   version: "1.0.0"
   tags: "prd, planning, validation, quality-gate, spec, requirements"

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -106,7 +106,28 @@ git status -sb
 ```
 
 Resolve the trunk (default branch) from `defaultBranchRef`; fall back to
-`git symbolic-ref --short refs/remotes/origin/HEAD` then `master`/`main`. Require:
+`git symbolic-ref --short refs/remotes/origin/HEAD`, then explicitly test
+`origin/master` and `origin/main` before failing:
+
+```bash
+TRUNK="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name // empty')"
+if [[ -z "$TRUNK" ]]; then
+  TRUNK="$(git symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null | sed 's#^origin/##' || true)"
+fi
+if [[ -z "$TRUNK" ]]; then
+  if git rev-parse --verify origin/master >/dev/null 2>&1; then
+    TRUNK="master"
+  elif git rev-parse --verify origin/main >/dev/null 2>&1; then
+    TRUNK="main"
+  else
+    echo "ERROR: Neither origin/master nor origin/main found. Available remote branches:"
+    git branch -r
+    exit 1
+  fi
+fi
+```
+
+Require:
 
 - the local checkout is on the trunk (or check it out after confirming),
 - the working tree is clean,
@@ -187,6 +208,10 @@ override here and note it in the final status.
 Only after confirmation, tag the trunk HEAD and publish:
 
 ```bash
+if git rev-parse --verify "refs/tags/<next-version>" >/dev/null 2>&1; then
+  echo "ERROR: Tag <next-version> already exists. Stop before overwriting release history."
+  exit 1
+fi
 git tag -a "<next-version>" -m "<next-version>"
 git push origin "<next-version>"
 gh release create "<next-version>" --target "<trunk>" --title "<next-version>" --notes "<patch notes>"

--- a/skills/writing-prds/SKILL.md
+++ b/skills/writing-prds/SKILL.md
@@ -4,7 +4,7 @@ disable-model-invocation: true
 description: Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews.
 metadata:
   version: "1.1.0"
-  tags: "prd, planning, requirements, spec, github-issue, scoping"
+  tags: "prd, planning, requirements, spec, scoping"
 ---
 
 # Writing PRDs
@@ -22,9 +22,8 @@ field mechanics below to whatever tracker you use.
 ## Storage Location
 
 **Prefer making the tracker issue body the PRD.** One document per work item, one
-location: the body of an issue in the project's tracker (a GitHub issue is the
-recommended default). Avoid scattering PRDs across local sidecar files that drift
-out of sync the moment work starts.
+location: the body of an issue in the project's tracker. Avoid scattering PRDs
+across local sidecar files that drift out of sync the moment work starts.
 
 - **Create** a PRD by creating an issue whose body is clean PRD markdown.
 - **Edit** a PRD by editing that issue's body.
@@ -71,7 +70,7 @@ The issue title is what the board shows most of the time. Keep it short.
 Bad:
 
 - `Open draft PR during execution and ingest PR feedback into stabilization loop`
-- `Treat CI failures as blocker state on GitHub issue tasks`
+- `Treat CI failures as blocker state on issue tasks`
 
 Better:
 
@@ -176,7 +175,7 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
    - What's the complexity gut feel (low/medium/high) and why?
    - Any hard constraints — deadlines, other projects in flight, package boundaries?
 
-3. **Check for an existing issue.** If using GitHub, run `gh issue list --search "<keywords>" --state all` in the target repo. If a matching issue already exists, ask whether to edit it or create a fresh one.
+3. **Check for an existing issue.** Search the project's tracker by keywords and state. If a matching issue already exists, ask whether to edit it or create a fresh one.
 
 4. **Kebab-case the PRD name.** If the proposed name has spaces, camelCase, or punctuation, kebab-case it: `"Notification Center"` → `notification-center`. This slug goes in the `# PRD:` heading.
 
@@ -186,13 +185,13 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
 
 7. **Run the quality gates** against the draft. If any fail, keep the issue in draft/on-hold workflow state and tell the user which gates failed. If they all pass, mark it ready through native project state.
 
-8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it — e.g. `gh issue create --title "<Human Readable Title>" --body-file -` with the PRD markdown piped on stdin.
+8. **Create the issue (with user approval).** Show the drafted body first. On approval, create it through the tracker's native issue creation flow, using the PRD markdown as the issue body.
 
 9. **Confirm the outcome** to the user with the issue URL. Suggest the next step: "Ready to hand this to the planner? Say: plan issue #N".
 
 ### When the user says "plan the X PRD"
 
-1. Fetch the current issue body (e.g. `gh issue view <N> --json body --jq .body`). Read it fully before producing anything.
+1. Fetch the current issue body from the tracker. Read it fully before producing anything.
 2. Verify the issue is ready through native project state — never plan a draft/on-hold issue.
 3. Translate directly: Executive Summary → objective, Success Criteria → acceptance criteria, Out of Scope → out-of-scope, complexity field → estimated complexity.
 4. The plan phase owns file changes and step breakdown — do not copy those out of the PRD (there shouldn't be any).
@@ -202,7 +201,7 @@ If any gate fails, keep it in draft/on-hold workflow state and do not mark it re
 
 1. Fetch the current issue body (prefer the tracker's live read to guarantee freshness).
 2. Make the requested edit in a scratch buffer.
-3. Write it back (e.g. `gh issue edit <N> --body-file -`). The tracker records the edit history automatically.
+3. Write it back through the tracker's native edit flow. The tracker records the edit history automatically.
 4. If the change invalidates an in-flight plan (new acceptance criterion, new out-of-scope item), flag that explicitly — the user may want to kill the thread and re-plan.
 
 ## Anti-Patterns
@@ -219,7 +218,7 @@ Observed failure modes — do not repeat:
 
 ## Minimal Example
 
-The text below is the exact issue body to push (e.g. `gh issue create --body-file -`). Tracker metadata belongs in native fields, not in this body.
+The text below is the exact issue body to publish. Tracker metadata belongs in native fields, not in this body.
 
 ```markdown
 # PRD: copy-issue-url-action


### PR DESCRIPTION
## Summary
- Addresses actionable CodeRabbit/GitHub feedback from unread `shipshitdev/skills` notifications.
- Makes PRD skill wording more platform-neutral and keeps generated bundle mirrors in sync.
- Adds release-skill safety checks, hardens dev-loop setup validation, and pins dispatch workflow actions.

## Verification
- `bunx markdownlint-cli --ignore bundles --ignore dist --ignore plugins "**/*.md"`
- `./scripts/validate-skill-sync.sh`
- `actionlint .github/workflows/agent-dispatch.yml .github/workflows/codex-dispatch.yml .github/workflows/openrouter-dispatch.yml`
- `bash -n scripts/setup-dev-loop.sh`
- `bash scripts/lint-shellcheck.sh scripts/setup-dev-loop.sh`

## Notes
- Remaining unread notifications were bot processing/usage-limit noise or comments already fixed on current `master`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced trunk branch detection in release workflows for more robust default-branch resolution.
  * Added safeguard to prevent accidental overwriting of existing release tags.

* **Chores**
  * Pinned GitHub Actions to specific commit SHAs for improved security.
  * Added credential persistence controls to checkout steps.
  * Hardened script validation for required configuration options.

* **Documentation**
  * Updated skill and workflow guidance to use platform-agnostic language.
  * Refined PRD storage and workflow instructions for better clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->