### PR TITLE
Add trigger clauses to capability-only skill descriptions

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -438,7 +438,7 @@
     {
       "name": "mcp-builder",
       "source": "./skills/mcp-builder",
-      "description": "Creates high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with external"
+      "description": "Creates MCP (Model Context Protocol) servers that enable LLMs to interact with external services thr"
     },
     {
       "name": "memory-systems",
@@ -463,7 +463,7 @@
     {
       "name": "mongodb-migration-expert",
       "source": "./skills/mongodb-migration-expert",
-      "description": "Database schema design, indexing, and migration guidance for MongoDB-based applications."
+      "description": "Database schema design, indexing, and migration guidance for MongoDB-based applications. Use when ad"
     },
     {
       "name": "monitoring-setup",
@@ -483,7 +483,7 @@
     {
       "name": "nestjs-queue-architect",
       "source": "./skills/nestjs-queue-architect",
-      "description": "Queue job management patterns, processors, and async workflows for video/image processing"
+      "description": "Queue job management patterns, processors, and async workflows for video/image processing. Use when "
     },
     {
       "name": "nextjs-validator",
@@ -503,7 +503,7 @@
     {
       "name": "package-architect",
       "source": "./skills/package-architect",
-      "description": "Design and maintain TypeScript packages in a monorepo, including exports and build configuration."
+      "description": "Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Us"
     },
     {
       "name": "performance-expert",
@@ -578,7 +578,7 @@
     {
       "name": "react-component-performance",
       "source": "./skills/react-component-performance",
-      "description": "Diagnose slow React components and suggest targeted performance fixes."
+      "description": "Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improvi"
     },
     {
       "name": "react-hook-form",
@@ -593,7 +593,7 @@
     {
       "name": "react-patterns",
       "source": "./skills/react-patterns",
-      "description": "Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices."
+      "description": "Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Us"
     },
     {
       "name": "react-refactor",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,777 +73,777 @@
     {
       "name": "accessibility",
       "source": "./skills/accessibility",
-      "description": "Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all pr"
+      "description": "Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues."
     },
     {
       "name": "advanced-evaluation",
       "source": "./skills/advanced-evaluation",
-      "description": "Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubr"
+      "description": "Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubric calibration, evaluator bias mitigation, confidence scoring, and automated quality assessment. Use when building LLM-as-judge systems, comparing model responses, calibrating rubrics, debugging inconsistent evaluations, or designing A/B tests for prompt or model changes."
     },
     {
       "name": "agent-architecture-audit",
       "source": "./skills/agent-architecture-audit",
-      "description": "Audit LLM and agent applications for wrapper regressions, prompt or memory contamination, tool disci"
+      "description": "Audit LLM and agent applications for wrapper regressions, prompt or memory contamination, tool discipline failures, hidden repair loops, and output rendering corruption. Use before shipping agent features or when an agent works in a direct model call but fails inside the product."
     },
     {
       "name": "agent-browser",
       "source": "./skills/agent-browser",
-      "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use "
+      "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages."
     },
     {
       "name": "agent-config-audit",
       "source": "./skills/agent-config-audit",
-      "description": "Audit and sync AI agent configuration files (CLAUDE.md, CODEX.md, AGENTS.md, .cursorrules, hooks, se"
+      "description": "Audit and sync AI agent configuration files (CLAUDE.md, CODEX.md, AGENTS.md, .cursorrules, hooks, settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring."
     },
     {
       "name": "agent-dispatch",
       "source": "./skills/agent-dispatch",
-      "description": "Single front door for agent/subagent architecture, config, and setup. Parses a subcommand — audit, c"
+      "description": "Single front door for agent/subagent architecture, config, and setup. Parses a subcommand — audit, config, init, or route — and routes to the right engine: agent-architecture-audit (diagnose LLM wrapper and agent failures), agent-config-audit (audit and sync AI agent config files across workspaces), agent-folder-init (add or repair .agents/ project context for a repo), or setup-agent-routing (write a machine-readable routing block in CLAUDE.md/AGENTS.md). Backs the /agent command. Use when asked to audit an agent system, check config drift, initialize agent docs, or wire up routing, and the action must be picked from an argument like \"audit\", \"config\", \"init\", or \"route\"."
     },
     {
       "name": "agent-folder-init",
       "source": "./skills/agent-folder-init",
-      "description": "Add or repair .agents/ project context for an existing repo. Use for AI agent documentation, session"
+      "description": "Add or repair .agents/ project context for an existing repo. Use for AI agent documentation, session tracking, task management, and coding standards; do not use as the primary new-product scaffold."
     },
     {
       "name": "ai-agent-cost-optimizer",
       "source": "./skills/ai-agent-cost-optimizer",
-      "description": "Audit and reduce AI agent token and inference spend through context discipline, prompt caching, mode"
+      "description": "Audit and reduce AI agent token and inference spend through context discipline, prompt caching, model routing, batching, and workflow capture. Use when discussing AI coding bills, token waste, model selection, prompt caching, or agent cost optimization."
     },
     {
       "name": "ai-loading-ux",
       "source": "./skills/ai-loading-ux",
-      "description": "Design AI loading, thinking, and progress indicator UX. Use when explicitly asked to improve AI wait"
+      "description": "Design AI loading, thinking, and progress indicator UX. Use when explicitly asked to improve AI waiting states, add thinking indicators, or design loading UX for AI interfaces. Covers reasoning display (chain-of-thought), progress steps, streaming states, and the \"elevator mirror effect\" for reducing perceived wait time."
     },
     {
       "name": "ai-regression-testing",
       "source": "./skills/ai-regression-testing",
-      "description": "Design regression tests for AI-assisted development by targeting model blind spots such as sandbox v"
+      "description": "Design regression tests for AI-assisted development by targeting model blind spots such as sandbox versus production path drift, response-shape mismatches, untested bug fixes, and same-model review failures. Use after AI-generated code changes, bug fixes, API edits, or feature-flag/sandbox changes."
     },
     {
       "name": "analyze-codebase",
       "source": "./skills/analyze-codebase",
-      "description": "Generate comprehensive codebase analysis covering architecture, security, performance, and code qual"
+      "description": "Generate comprehensive codebase analysis covering architecture, security, performance, and code quality. Use when user says 'analyze codebase', 'code audit', 'architecture review', or 'project health check'."
     },
     {
       "name": "api-design-expert",
       "source": "./skills/api-design-expert",
-      "description": "Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API bes"
+      "description": "Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications. Use when designing API endpoints, building RESTful APIs, writing OpenAPI/Swagger docs, implementing versioning, or designing error responses and DTOs."
     },
     {
       "name": "artifacts-builder",
       "source": "./skills/artifacts-builder",
-      "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern fronten"
+      "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, @agenticindiedev/ui). Use for complex artifacts requiring state management or shared UI components - not for simple single-file HTML/JSX artifacts."
     },
     {
       "name": "audit",
       "source": "./skills/audit",
-      "description": "Run technical quality checks across accessibility, performance, theming, responsive design, and anti"
+      "description": "Run technical quality checks across accessibility, performance, theming, responsive design, and anti-patterns. Generates a scored report with P0-P3 severity ratings and actionable plan. Use when the user wants an accessibility check, performance audit, or technical quality review."
     },
     {
       "name": "aws-infrastructure",
       "source": "./skills/aws-infrastructure",
-      "description": "Expert in AWS infrastructure setup including EC2, VPC, security groups, Application Load Balancers, "
+      "description": "Expert in AWS infrastructure setup including EC2, VPC, security groups, Application Load Balancers, Route53 DNS, and SSL/TLS certificates. Use this skill for AWS infrastructure configuration and deployment."
     },
     {
       "name": "biome-validator",
       "source": "./skills/biome-validator",
-      "description": "Validate Biome 2.3+ configuration and detect outdated patterns. Ensures proper schema version, domai"
+      "description": "Validate Biome 2.3+ configuration and detect outdated patterns. Ensures proper schema version, domains, assists, and recommended rules. Use before any linting work or when auditing existing projects."
     },
     {
       "name": "bug",
       "source": "./skills/bug",
-      "description": "File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps t"
+      "description": "File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug."
     },
     {
       "name": "bun-validator",
       "source": "./skills/bun-validator",
-      "description": "Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace set"
+      "description": "Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices. Use when setting up a Bun monorepo, before adding workspace dependencies, auditing an existing Bun workspace, or validating package.json in CI."
     },
     {
       "name": "changelog-generator",
       "source": "./skills/changelog-generator",
-      "description": "Automatically creates user-facing changelogs from git commits by analyzing commit history, categoriz"
+      "description": "Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation. Use when preparing release notes, summarizing product updates, or turning git commits into customer-facing changelog entries."
     },
     {
       "name": "clarify",
       "source": "./skills/clarify",
-      "description": "Improve unclear UX copy, error messages, microcopy, labels, and instructions to make interfaces easi"
+      "description": "Improve unclear UX copy, error messages, microcopy, labels, and instructions to make interfaces easier to understand. Use when the user mentions confusing text, unclear labels, bad error messages, hard-to-follow instructions, or wanting better UX writing."
     },
     {
       "name": "clerk-validator",
       "source": "./skills/clerk-validator",
-      "description": "Validate Clerk authentication configuration and detect deprecated patterns. Ensures proper proxy.ts "
+      "description": "Validate Clerk authentication configuration and detect deprecated patterns. Ensures proper proxy.ts usage (Next.js 16), ClerkProvider setup, and modern auth patterns. Use before any Clerk work or when auditing existing auth implementations."
     },
     {
       "name": "code-review",
       "source": "./skills/code-review",
-      "description": "Correctness and security gate for incoming pull requests. Auto-invoked when reviewing a diff, evalua"
+      "description": "Correctness and security gate for incoming pull requests. Auto-invoked when reviewing a diff, evaluating a PR, running /code-review at any effort level, or asked \"is this safe to merge?\" Covers bugs, TypeScript hygiene, security, database safety, test existence, devex regressions, and feature-flag leaks."
     },
     {
       "name": "codebase-advisor",
       "source": "./skills/codebase-advisor",
-      "description": "Survey any codebase as a senior advisor and produce prioritized, self-contained implementation plans"
+      "description": "Survey any codebase as a senior advisor and produce prioritized, self-contained implementation plans for OTHER models/agents to execute. Strictly read-only on source code — never implements, fixes, or refactors anything itself. Use when asked to audit a codebase, find improvement opportunities (bugs, security, performance, test coverage, tech debt, migrations, DX), suggest features or where to take the project next (roadmap, product direction), or generate handoff plans for another agent to implement. Does NOT edit code directly — it declines and hands off a plan instead."
     },
     {
       "name": "codex-image-gen",
       "source": "./skills/codex-image-gen",
-      "description": "Generate raster images (icons, illustrations, textures, app icons) from a text prompt by driving the"
+      "description": "Generate raster images (icons, illustrations, textures, app icons) from a text prompt by driving the Codex CLI's image tool, then extracting the finished PNG from the Codex session rollout. Use when an agent needs a real generated image and has no native image-generation tool. Requires the `codex` CLI, logged in."
     },
     {
       "name": "comment-mode",
       "source": "./skills/comment-mode",
-      "description": "Granular feedback on drafts without rewriting. Generates highlighted HTML with click-to-reveal inlin"
+      "description": "Granular feedback on drafts without rewriting. Generates highlighted HTML with click-to-reveal inline comments. Use when user says \"comment on this\", \"leave comments on\", \"give feedback on\", or asks for feedback on a draft. Supports multiple lenses—editor feedback, POV simulation (\"as brian would react\"), or focused angles (\"word choice only\", \"weak arguments\"). A granular alternative to rewrites that lets users review feedback incrementally without losing their voice."
     },
     {
       "name": "commit-summary",
       "source": "./skills/commit-summary",
-      "description": "Generate Conventional Commit messages from staged or unstaged git changes, split unrelated changes i"
+      "description": "Generate Conventional Commit messages from staged or unstaged git changes, split unrelated changes into logical commits, detect breaking changes, and optionally create commits after approval. Use when writing commit messages, preparing commits, or committing local work."
     },
     {
       "name": "component-library",
       "source": "./skills/component-library",
-      "description": "Expert React/Next.js component architect specializing in creating consistent, reusable, and maintain"
+      "description": "Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects. Use when creating or refactoring UI components, reviewing component architecture, or setting up shared component patterns in a monorepo."
     },
     {
       "name": "content-script-developer",
       "source": "./skills/content-script-developer",
-      "description": "Expert in browser extension content scripts, DOM integration, and safe page augmentation across mode"
+      "description": "Expert in browser extension content scripts, DOM integration, and safe page augmentation across modern web apps. Use when building or updating a browser-extension content script, injecting UI into third-party pages, or handling SPA navigation and dynamic DOM changes."
     },
     {
       "name": "context-degradation",
       "source": "./skills/context-degradation",
-      "description": "Recognize, diagnose, and mitigate patterns of context degradation in agent systems. Use when context"
+      "description": "Recognize, diagnose, and mitigate patterns of context degradation in agent systems. Use when context grows large, agent performance degrades unexpectedly, or debugging agent failures."
     },
     {
       "name": "context-engineering",
       "source": "./skills/context-engineering",
-      "description": "Supplementary context protocol for agents executing in a repo that has a CLAUDE.md / AGENTS.md (or e"
+      "description": "Supplementary context protocol for agents executing in a repo that has a CLAUDE.md / AGENTS.md (or equivalent config). Use to make an execution agent read project conventions first, treat inputs by trust level, surface plan-vs-convention conflicts instead of silently picking a side, and reuse existing patterns before writing new code."
     },
     {
       "name": "context-fundamentals",
       "source": "./skills/context-fundamentals",
-      "description": "Explain or reason about foundational context engineering concepts: what context is, the anatomy of a"
+      "description": "Explain or reason about foundational context engineering concepts: what context is, the anatomy of a context window, attention mechanics, the U-shaped attention curve, why context quality matters more than quantity, and the mental models needed to interpret context-engineering decisions. Use for conceptual explanation, onboarding, and background reading. Route operational work to context-degradation for attention failures and context-optimization for token-efficiency work."
     },
     {
       "name": "context-optimization",
       "source": "./skills/context-optimization",
-      "description": "Improve context efficiency through context budgeting, observation masking, prefix or KV-cache strate"
+      "description": "Improve context efficiency through context budgeting, observation masking, prefix or KV-cache strategy, partitioning, token-cost reduction, retrieval scoping, and extending effective context capacity without lowering answer quality. Use when token costs or context budgets constrain a task, tool outputs are verbose, cache hit rate is low, or context must be partitioned across agents."
     },
     {
       "name": "critique",
       "source": "./skills/critique",
-      "description": "Evaluate design from a UX perspective, assessing visual hierarchy, information architecture, emotion"
+      "description": "Evaluate design from a UX perspective, assessing visual hierarchy, information architecture, emotional resonance, cognitive load, and overall quality with quantitative scoring, persona-based testing, automated anti-pattern detection, and actionable feedback. Use when the user asks to review, critique, evaluate, or give feedback on a design or component."
     },
     {
       "name": "cto-advisor",
       "source": "./skills/cto-advisor",
-      "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy"
+      "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Includes tech debt analyzer, team scaling calculator, engineering metrics frameworks, technology evaluation tools, and ADR templates. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy."
     },
     {
       "name": "de-slop",
       "source": "./skills/de-slop",
-      "description": "Removes AI-generated artifacts and code sloppiness from a codebase — console statements, `any` types"
+      "description": "Removes AI-generated artifacts and code sloppiness from a codebase — console statements, `any` types, unused imports, commented-out code, debug statements, redundant comments, unnecessary defensive try-catch on trusted paths, and over-nesting that should use early returns. Can scope to only the lines introduced on the current branch (diff-only) or sweep the whole tree. Use when asked to clean up AI-generated code, remove slop, fix code quality issues, or tidy up a codebase after AI-assisted development."
     },
     {
       "name": "debug",
       "source": "./skills/debug",
-      "description": "Systematic debugging guidance for bugs, failures, unexpected behavior, and performance regressions. "
+      "description": "Systematic debugging guidance for bugs, failures, unexpected behavior, and performance regressions. Emphasizes reproducible feedback loops, hypothesis testing, instrumentation, fixes, and regression tests. Use when investigating a bug, unexpected behavior, crash, wrong output, or performance regression, or triaging incoming bug reports."
     },
     {
       "name": "deploy",
       "source": "./skills/deploy",
-      "description": "Run deployment workflows for web applications (staging, production). Use when user says 'deploy', 'p"
+      "description": "Run deployment workflows for web applications (staging, production). Use when user says 'deploy', 'push to staging', 'release', 'ship it', or 'go live'."
     },
     {
       "name": "deploy-dispatch",
       "source": "./skills/deploy-dispatch",
-      "description": "Single front door for deployment and infra provisioning. Parses a subcommand — app, compose, ec2, mo"
+      "description": "Single front door for deployment and infra provisioning. Parses a subcommand — app, compose, ec2, monitor, or devcontainer — and routes to the right engine: deploy (web app deployment to staging/production), deployment-composer (compose the smallest safe deployment workflow from repo signals), ec2-backend-deployer (CI/CD pipeline to EC2 via Docker and GitHub Actions), monitoring-setup (Sentry + Google Analytics for NestJS/Next.js), or devcontainer-setup (VS Code Dev Container scaffold). Backs the /deploy command. Use when asked to deploy, set up infra, configure monitoring, or provision a dev container, and the action must be picked from an argument like \"app\", \"compose\", \"ec2\", \"monitor\", or \"devcontainer\"."
     },
     {
       "name": "deployment-composer",
       "source": "./skills/deployment-composer",
-      "description": "Compose deployment workflows from smaller skills and repo signals, including trunk-based releases, C"
+      "description": "Compose deployment workflows from smaller skills and repo signals, including trunk-based releases, CI quality gates, provider deployment, post-deploy verification, rollback, and failed-check diagnosis. Use when the user asks for a deployment plan, release workflow, ship-to-staging/production environments, or a smart deploy process across GitHub, Vercel, EC2, Docker, or custom CI."
     },
     {
       "name": "design-consistency-auditor",
       "source": "./skills/design-consistency-auditor",
-      "description": "Audits and maintains design system consistency across frontend applications — color palettes, UI/UX "
+      "description": "Audits and maintains design system consistency across frontend applications — color palettes, UI/UX patterns, component styling, and accessibility. Triggers when asked to audit design consistency, review component styling, check color palette usage, validate accessibility compliance, or identify design debt."
     },
     {
       "name": "design-dispatch",
       "source": "./skills/design-dispatch",
-      "description": "Single front door for UI/design review and refinement. Parses a subcommand — audit, clarify, critiqu"
+      "description": "Single front door for UI/design review and refinement. Parses a subcommand — audit, clarify, critique, layout, polish, quieter, shape, or consistency — and routes to the right design engine: audit (technical quality checks with scored report), clarify (UX copy and microcopy improvement), critique (UX evaluation with quantitative scoring), layout (layout and spacing improvement), polish (final pre-ship quality pass), quieter (tone down visually aggressive designs), shape (UX/UI planning and design brief), or design-consistency-auditor (cross-app design system consistency audit). Backs the /design command. Use when asked to review, audit, polish, plan, or refine UI, and the action must be picked from an argument like \"audit\", \"critique\", \"polish\", or \"shape\"."
     },
     {
       "name": "devcontainer-setup",
       "source": "./skills/devcontainer-setup",
-      "description": "Scaffolds a complete VS Code Dev Container configuration with Docker, docker-compose, and optional C"
+      "description": "Scaffolds a complete VS Code Dev Container configuration with Docker, docker-compose, and optional Claude Code CLI support. Activates when asked to \"set up devcontainer\", \"add docker development environment\", \"configure dev container\", or containerize a development workflow."
     },
     {
       "name": "docker-expert",
       "source": "./skills/docker-expert",
-      "description": "Expert in Docker, docker-compose, Dockerfile patterns, and container orchestration for NestJS and Ne"
+      "description": "Expert in Docker, docker-compose, Dockerfile patterns, and container orchestration for NestJS and Next.js applications. Use this skill when users need Docker setup, containerization, or docker-compose configuration."
     },
     {
       "name": "docs",
       "source": "./skills/docs",
-      "description": "Creates clear, concise technical documentation for software projects, runbooks, and developer guides"
+      "description": "Creates clear, concise technical documentation for software projects, runbooks, and developer guides. Use when writing or updating a README, guide, runbook, API reference, setup instructions, or troubleshooting notes."
     },
     {
       "name": "ec2-backend-deployer",
       "source": "./skills/ec2-backend-deployer",
-      "description": "Deploys backend applications to EC2 instances using Docker, GitHub Actions CI/CD, and Tailscale for "
+      "description": "Deploys backend applications to EC2 instances using Docker, GitHub Actions CI/CD, and Tailscale for secure SSH access. Activates when setting up EC2 deployment pipelines, configuring container registries, or wiring automated deploys for NestJS, Next.js, or Express backends."
     },
     {
       "name": "error-handling-expert",
       "source": "./skills/error-handling-expert",
-      "description": "Expert in error handling patterns, exception management, error responses, logging, and error recover"
+      "description": "Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications. Use when implementing error handling, exception filters, error responses, error logging, or recovery strategies."
     },
     {
       "name": "evaluation",
       "source": "./skills/evaluation",
-      "description": "Build evaluation frameworks for agent systems. Use when testing agent performance, validating contex"
+      "description": "Build evaluation frameworks for agent systems. Use when testing agent performance, validating context engineering choices, or measuring improvements over time."
     },
     {
       "name": "executing-plans",
       "source": "./skills/executing-plans",
-      "description": "Orchestrate autonomous AI development with task-based workflow and QA gates. Use when implementing a"
+      "description": "Orchestrate autonomous AI development with task-based workflow and QA gates. Use when implementing a development plan, picking tasks from a queue, or running multi-platform parallel execution with QA gates."
     },
     {
       "name": "execution-debugging",
       "source": "./skills/execution-debugging",
-      "description": "Scoped debugging methodology for when a test or build fails during execution/stabilization. Use to d"
+      "description": "Scoped debugging methodology for when a test or build fails during execution/stabilization. Use to diagnose the failing check without scope-creeping — read the full error, reproduce in isolation, hypothesize before changing, localize, fix the root cause not the symptom, and guard with a regression test."
     },
     {
       "name": "expo-architect",
       "source": "./skills/expo-architect",
-      "description": "Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Cle"
+      "description": "Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Clerk auth. Generates complete mobile app structure that runs immediately with `bun start`. Use when scaffolding a new Expo or React Native app, setting up Expo Router navigation, or adding Clerk auth to a mobile app."
     },
     {
       "name": "feature-intake",
       "source": "./skills/feature-intake",
-      "description": "Capture a client or stakeholder feature request, turn it into a planner-ready PRD epic with scoped s"
+      "description": "Capture a client or stakeholder feature request, turn it into a planner-ready PRD epic with scoped sub-issues, check for duplicate work, and place approved issues on a GitHub Projects kanban. Use when a user invokes feature intake, asks to turn a rough client requirement into GitHub issues, or wants an idea written as a PRD and pushed to a board."
     },
     {
       "name": "finishing-a-development-branch",
       "source": "./skills/finishing-a-development-branch",
-      "description": "Structured \"done coding, now what?\" workflow: verify tests pass, detect the repository environment ("
+      "description": "Structured \"done coding, now what?\" workflow: verify tests pass, detect the repository environment (normal repo vs worktree, named branch vs detached HEAD), present exactly the right merge / PR / keep / discard options, and execute the chosen path including safe worktree cleanup. Use when implementation is complete and the branch needs to be integrated, published, or abandoned."
     },
     {
       "name": "fix-merge-conflicts",
       "source": "./skills/fix-merge-conflicts",
-      "description": "Resolve git merge conflicts correctness-first, then prove the tree still builds. Use when a merge, r"
+      "description": "Resolve git merge conflicts correctness-first, then prove the tree still builds. Use when a merge, rebase, cherry-pick, or stash pop leaves conflict markers, when git status shows unmerged paths, or when the user asks to fix conflicts, resolve a merge, or rebase onto the trunk and clear the conflicts."
     },
     {
       "name": "frontend-design",
       "source": "./skills/frontend-design",
-      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill wh"
+      "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics."
     },
     {
       "name": "full-code-review",
       "source": "./skills/full-code-review",
-      "description": "Fan-out PR review across three parallel dimension agents (structural, security, devex/flag-hygiene),"
+      "description": "Fan-out PR review across three parallel dimension agents (structural, security, devex/flag-hygiene), adversarially verify every finding, and synthesize a single prioritized verdict via an Opus judge. Use when asked for a full, comprehensive, or end-to-end review of a branch or PR — after /code-review passes correctness, this skill covers the orthogonal dimensions it does not: security depth, structural health, devex regressions, and feature-flag hygiene."
     },
     {
       "name": "fullstack-workspace-init",
       "source": "./skills/fullstack-workspace-init",
-      "description": "Initialize Shipshit.dev full-stack product workspaces through npx @shipshitdev/v0, then customize an"
+      "description": "Initialize Shipshit.dev full-stack product workspaces through npx @shipshitdev/v0, then customize and verify the generated repo. Use for new product scaffolds or post-v0 workspace setup."
     },
     {
       "name": "gh-address-comments",
       "source": "./skills/gh-address-comments",
-      "description": "Resolves GitHub PR review and issue comments by fetching threads, mapping them to code, proposing fi"
+      "description": "Resolves GitHub PR review and issue comments by fetching threads, mapping them to code, proposing fixes, and drafting replies for approval. Triggers when the user asks to address PR comments, respond to review feedback, fix review threads, or resolve GitHub comment requests."
     },
     {
       "name": "gh-fix-ci",
       "source": "./skills/gh-fix-ci",
-      "description": "Diagnoses failing GitHub Actions checks on a PR, identifies root cause, and proposes or applies targ"
+      "description": "Diagnoses failing GitHub Actions checks on a PR, identifies root cause, and proposes or applies targeted fixes. Triggers when the user asks to fix CI, diagnose failing checks, fix a failing workflow, address GitHub Actions errors, or get a green build. Can run autonomously in a loop — fix, push, recheck — until all required checks are green when the user asks to loop on CI."
     },
     {
       "name": "gh-inbox",
       "source": "./skills/gh-inbox",
-      "description": "Collect and triage a GitHub work inbox from assigned issues, review requests, mentions, authored PRs"
+      "description": "Collect and triage a GitHub work inbox from assigned issues, review requests, mentions, authored PRs with failing checks, and optional project filters. Use when checking what needs attention across GitHub or prioritizing GitHub tasks."
     },
     {
       "name": "gh-pr-publish",
       "source": "./skills/gh-pr-publish",
-      "description": "Create, update, and publish GitHub pull requests with a clean title, durable body, branch hygiene, v"
+      "description": "Create, update, and publish GitHub pull requests with a clean title, durable body, branch hygiene, validation notes, and safe push/PR gates. Use when opening a PR, updating a PR description, preparing a draft PR, or publishing local changes to GitHub."
     },
     {
       "name": "gh-project-board",
       "source": "./skills/gh-project-board",
-      "description": "Configure GitHub Projects v2 kanban boards with Ship Shit Dev defaults: the Backlog / In Progress / "
+      "description": "Configure GitHub Projects v2 kanban boards with Ship Shit Dev defaults: the Backlog / In Progress / Human Review / Done / Deferred Status columns (the dev-loop board-as-truth model) and P0-P3 Priority. Use when setting up, copying, auditing, or normalizing GitHub project boards."
     },
     {
       "name": "gh-review-suggestions",
       "source": "./skills/gh-review-suggestions",
-      "description": "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks."
+      "description": "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks. Use when asked to review a PR, leave actionable GitHub comments, propose applyable fixes, or submit review suggestions through gh."
     },
     {
       "name": "git-safety",
       "source": "./skills/git-safety",
-      "description": "Scans, cleans, and prevents secrets in git history across four modes: scan (detect sensitive files i"
+      "description": "Scans, cleans, and prevents secrets in git history across four modes: scan (detect sensitive files in the current state and history), clean (rewrite history to remove secrets using git-filter-repo or BFG), prevent (add .gitignore and pre-commit hooks), and full (all three in sequence). Use when the user asks to check for leaked credentials, scrub a secret from git history, force-push a cleaned repo, set up pre-commit secret prevention, or run a full git security audit."
     },
     {
       "name": "github-actions-author",
       "source": "./skills/github-actions-author",
-      "description": "Author, review, and harden GitHub Actions workflows using current official documentation, secure tri"
+      "description": "Author, review, and harden GitHub Actions workflows using current official documentation, secure trigger patterns, least-privilege permissions, current action versions, and CI/CD validation. Use when creating, editing, debugging, or security-reviewing workflow YAML."
     },
     {
       "name": "graphql-architect",
       "source": "./skills/graphql-architect",
-      "description": "Design and review GraphQL schemas, resolvers, mutations, pagination, and data-loading patterns. Use "
+      "description": "Design and review GraphQL schemas, resolvers, mutations, pagination, and data-loading patterns. Use when building or refactoring GraphQL APIs, adding fields, fixing resolver design, or improving GraphQL performance and safety."
     },
     {
       "name": "html-style",
       "source": "./skills/html-style",
-      "description": "Apply opinionated styling to barebones HTML. Use when user has plain/unstyled HTML and wants to appl"
+      "description": "Apply opinionated styling to barebones HTML. Use when user has plain/unstyled HTML and wants to apply consistent visual styling. Triggers: style this HTML, apply styling, make this look good, /html-style, or when user shares HTML that needs CSS. Transforms tables, lists, status indicators, buttons, and layouts into a cohesive design system."
     },
     {
       "name": "husky-test-coverage",
       "source": "./skills/husky-test-coverage",
-      "description": "Sets up or verifies Husky git hooks to enforce test coverage above 80% (configurable) for Node.js/Ty"
+      "description": "Sets up or verifies Husky git hooks to enforce test coverage above 80% (configurable) for Node.js/TypeScript projects. Activates when enforcing coverage through pre-commit hooks, verifying existing Husky/test setup, or configuring coverage thresholds for Jest, Vitest, or Mocha test runners."
     },
     {
       "name": "incremental-fetch",
       "source": "./skills/incremental-fetch",
-      "description": "Guides construction of resilient data ingestion pipelines from paginated APIs. Activates on: \"ingest"
+      "description": "Guides construction of resilient data ingestion pipelines from paginated APIs. Activates on: \"ingest data from API\", \"pull tweets\", \"fetch historical data\", \"sync from X\", \"build a data pipeline\", \"fetch without re-downloading\", \"resume the download\", \"backfill older data\". NOT for: simple one-shot API calls, websocket/streaming connections, file downloads, or APIs without pagination."
     },
     {
       "name": "interview",
       "source": "./skills/interview",
-      "description": "Conducts a repo-grounded discovery interview before PRD writing, feature intake, UX shaping, or impl"
+      "description": "Conducts a repo-grounded discovery interview before PRD writing, feature intake, UX shaping, or implementation planning. Use when a user invokes /interview, asks to be grilled, wants requirements clarified, or needs a concise handoff brief from existing docs plus focused follow-up questions."
     },
     {
       "name": "landing-page-vercel",
       "source": "./skills/landing-page-vercel",
-      "description": "Scaffolds a production-ready static landing page with working email capture form, analytics, and res"
+      "description": "Scaffolds a production-ready static landing page with working email capture form, analytics, and responsive design. Activates on \"create landing page\", \"build a landing page\", \"launch page for product\", or similar requests. Optionally deploys to Vercel on explicit request."
     },
     {
       "name": "layout",
       "source": "./skills/layout",
-      "description": "Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak v"
+      "description": "Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak visual hierarchy. Use when the user mentions layout feeling off, spacing issues, visual hierarchy, crowded UI, alignment problems, or wanting better composition."
     },
     {
       "name": "linter-formatter-init",
       "source": "./skills/linter-formatter-init",
-      "description": "Set up Biome (default) or ESLint + Prettier, Vitest testing, and pre-commit hooks for any JavaScript"
+      "description": "Set up Biome (default) or ESLint + Prettier, Vitest testing, and pre-commit hooks for any JavaScript/TypeScript project. Uses Bun as the package manager. Use this skill when initializing code quality tooling for a new project or adding linting to an existing one."
     },
     {
       "name": "llm-structured-output",
       "source": "./skills/llm-structured-output",
-      "description": "Design prompts, schemas, validation, and recovery logic for reliable machine-readable model outputs."
+      "description": "Design prompts, schemas, validation, and recovery logic for reliable machine-readable model outputs. Use when generating JSON, typed objects, extraction results, tool arguments, or any output another system must parse safely."
     },
     {
       "name": "mcp-builder",
       "source": "./skills/mcp-builder",
-      "description": "Creates MCP (Model Context Protocol) servers that enable LLMs to interact with external services thr"
+      "description": "Creates MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Activates on: \"build an MCP server\", \"create MCP tools\", \"integrate API via MCP\", \"write a FastMCP server\", \"add MCP to Claude\", or any request to wrap an external API as LLM-callable tools in Python or Node/TypeScript."
     },
     {
       "name": "memory-systems",
       "source": "./skills/memory-systems",
-      "description": "Design and implement memory architectures for agent systems that persist state across sessions, main"
+      "description": "Design and implement memory architectures for agent systems that persist state across sessions, maintain entity consistency, and reason over structured knowledge. Use when building agents that persist knowledge across sessions, choosing between memory frameworks, maintaining entity consistency, or designing memory architectures for production."
     },
     {
       "name": "merge-open-prs",
       "source": "./skills/merge-open-prs",
-      "description": "Review every open pull request targeting the default/trunk branch, merge the approved ones into the "
+      "description": "Review every open pull request targeting the default/trunk branch, merge the approved ones into the trunk, then prune the merged branches and stale worktrees left behind. Confirmation-gated and squash-merge aware via delegated cleanup. Use when the user asks to merge all open PRs, review and land the open PRs, batch-merge to the trunk and clean up afterward, or runs /merge."
     },
     {
       "name": "micro-landing-builder",
       "source": "./skills/micro-landing-builder",
-      "description": "Scaffolds, clones, and deploys config-driven NextJS landing pages that use a shared UI components pa"
+      "description": "Scaffolds, clones, and deploys config-driven NextJS landing pages that use a shared UI components package. Use when creating single or multiple startup landing pages with email capture, analytics, and modern design. Supports batch creation from templates or CSV/JSON files and Vercel deployment with custom domains. Each landing is a standalone NextJS app driven by an app.json config file."
     },
     {
       "name": "mongodb-atlas-checker",
       "source": "./skills/mongodb-atlas-checker",
-      "description": "Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, en"
+      "description": "Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, environment variables, connection pooling, and ensures proper setup for Next.js and NestJS applications. Use when verifying MongoDB Atlas setup, checking connection strings or environment variables, or troubleshooting database connection issues before deployment."
     },
     {
       "name": "mongodb-migration-expert",
       "source": "./skills/mongodb-migration-expert",
-      "description": "Database schema design, indexing, and migration guidance for MongoDB-based applications. Use when ad"
+      "description": "Database schema design, indexing, and migration guidance for MongoDB-based applications. Use when adding or changing MongoDB collections, indexes, or fields, designing schema for multi-tenant or large datasets, or planning forward-only migrations."
     },
     {
       "name": "monitoring-setup",
       "source": "./skills/monitoring-setup",
-      "description": "Sets up Sentry error tracking and Google Analytics for NestJS and Next.js applications. Activates wh"
+      "description": "Sets up Sentry error tracking and Google Analytics for NestJS and Next.js applications. Activates when users need to configure error tracking, set up production monitoring, add Google Analytics, or track application errors and user behavior."
     },
     {
       "name": "multi-agent-patterns",
       "source": "./skills/multi-agent-patterns",
-      "description": "Design multi-agent architectures for complex tasks. Use when single-agent context limits are exceede"
+      "description": "Design multi-agent architectures for complex tasks. Use when single-agent context limits are exceeded, when tasks decompose naturally into subtasks, or when specializing agents improves quality."
     },
     {
       "name": "nestjs-expert",
       "source": "./skills/nestjs-expert",
-      "description": "NestJS architecture, modules, DI, guards, interceptors, pipes, MongoDB/Mongoose integration, auth, a"
+      "description": "NestJS architecture, modules, DI, guards, interceptors, pipes, MongoDB/Mongoose integration, auth, and production patterns. Use when building NestJS APIs, designing module structure, implementing auth, handling errors, writing DTOs, or debugging NestJS-specific issues."
     },
     {
       "name": "nestjs-queue-architect",
       "source": "./skills/nestjs-queue-architect",
-      "description": "Queue job management patterns, processors, and async workflows for video/image processing. Use when "
+      "description": "Queue job management patterns, processors, and async workflows for video/image processing. Use when building BullMQ queues, job processors, or async video/image processing workflows in NestJS."
     },
     {
       "name": "nextjs-validator",
       "source": "./skills/nextjs-validator",
-      "description": "Validate Next.js 16 configuration and detect/prevent deprecated patterns. Ensures proxy.ts usage, Tu"
+      "description": "Validate Next.js 16 configuration and detect/prevent deprecated patterns. Ensures proxy.ts usage, Turbopack, Cache Components, and App Router best practices. Use before any Next.js work or when auditing existing projects."
     },
     {
       "name": "nextra-writer",
       "source": "./skills/nextra-writer",
-      "description": "Expert in creating clear, comprehensive technical documentation with Nextra (Next.js-based docs fram"
+      "description": "Expert in creating clear, comprehensive technical documentation with Nextra (Next.js-based docs framework), MDX, and modern documentation patterns. Use for documentation sites that need Next.js integration."
     },
     {
       "name": "open-source-checker",
       "source": "./skills/open-source-checker",
-      "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb"
+      "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release."
     },
     {
       "name": "package-architect",
       "source": "./skills/package-architect",
-      "description": "Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Us"
+      "description": "Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Use when creating or restructuring monorepo packages, defining package.json exports, or setting up tsconfig references."
     },
     {
       "name": "performance-expert",
       "source": "./skills/performance-expert",
-      "description": "Expert in performance optimization for React, Next.js, NestJS applications covering frontend renderi"
+      "description": "Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching."
     },
     {
       "name": "playwright-e2e-init",
       "source": "./skills/playwright-e2e-init",
-      "description": "Initialize Playwright end-to-end testing for Next.js and React projects. Sets up configuration, crea"
+      "description": "Initialize Playwright end-to-end testing for Next.js and React projects. Sets up configuration, creates example tests, and integrates with existing CI/CD. Use when adding E2E tests to a frontend project."
     },
     {
       "name": "polish",
       "source": "./skills/polish",
-      "description": "Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before"
+      "description": "Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before shipping. Use when the user mentions polish, finishing touches, pre-launch review, something looks off, or wants to go from good to great."
     },
     {
       "name": "pr-comments",
       "source": "./skills/pr-comments",
-      "description": "Fetch a pull request's review and discussion comments and return a read-only digest — grouped by thr"
+      "description": "Fetch a pull request's review and discussion comments and return a read-only digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out — without editing code or drafting replies. Use when the user asks what are the comments on my PR, summarize the review feedback, what's blocking this PR, what do I still need to address, or runs /pr comments."
     },
     {
       "name": "prd-dispatch",
       "source": "./skills/prd-dispatch",
-      "description": "Single front door for product specs, PRDs, and feature planning. Parses a subcommand — new, spec, ga"
+      "description": "Single front door for product specs, PRDs, and feature planning. Parses a subcommand — new, spec, gate, write, intake, or interview — and routes to the right planning engine: prd-task-creator (GitHub issue or local PRD), spec-first (spec → plan → execute loop), prd-quality-gate (completeness validation), prd-writer (full PRD draft), feature-intake (client requirement → kanban issues), or interview (discovery interview before PRD writing). Backs the /prd command. Use when asked to create a PRD, plan a feature, write a spec, validate a PRD, run a discovery interview, or intake a stakeholder requirement, and the action must be picked from an argument like \"new\", \"spec\", \"gate\", \"write\", \"intake\", or \"interview\"."
     },
     {
       "name": "prd-quality-gate",
       "source": "./skills/prd-quality-gate",
-      "description": "PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the"
+      "description": "PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint."
     },
     {
       "name": "prd-task-creator",
       "source": "./skills/prd-task-creator",
-      "description": "Create a well-written PRD, task, or GitHub issue/sub-issue for a feature, bug, or enhancement. Use w"
+      "description": "Create a well-written PRD, task, or GitHub issue/sub-issue for a feature, bug, or enhancement. Use when planning work, writing GitHub issues, breaking down epics into sub-issues, or creating local task files. Common prompts: create a task, write a PRD, open a GitHub issue, create a sub-issue, plan this feature, write up this bug, break this down into issues, I want to add X, implement Y."
     },
     {
       "name": "prd-writer",
       "source": "./skills/prd-writer",
-      "description": "Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one sho"
+      "description": "Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on \"write a PRD for X\", \"let's plan X\", \"scope this out\", \"what should X do\", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews."
     },
     {
       "name": "production-audit",
       "source": "./skills/production-audit",
-      "description": "Audit an application for production readiness using local evidence from code, CI, config, migrations"
+      "description": "Audit an application for production readiness using local evidence from code, CI, config, migrations, runtime checks, observability, and deployment paths. Use before launch, after risky merges, or when asked whether an app is ready to ship."
     },
     {
       "name": "project-init-orchestrator",
       "source": "./skills/project-init-orchestrator",
-      "description": "Selects the correct project initialization route and orchestrates setup. Triggers on \"initialize pro"
+      "description": "Selects the correct project initialization route and orchestrates setup. Triggers on \"initialize project\", \"set up new project\", \"bootstrap project\", or when scaffolding a new Shipshit.dev product repo. Use v0 for new Shipshit.dev product repos; use lower-level setup skills only for existing repo repair, customization, or small additions."
     },
     {
       "name": "prompt-engineering",
       "source": "./skills/prompt-engineering",
-      "description": "Expert guide on prompt engineering patterns, best practices, and optimization techniques. Use when u"
+      "description": "Expert guide on prompt engineering patterns, best practices, and optimization techniques. Use when user wants to improve prompts, learn prompting strategies, debug agent behavior, or design content generation prompts."
     },
     {
       "name": "qa-reviewer",
       "source": "./skills/qa-reviewer",
-      "description": "Runs a structured multi-phase verification pass on completed AI agent work — catching bugs, missed r"
+      "description": "Runs a structured multi-phase verification pass on completed AI agent work — catching bugs, missed requirements, and incorrect assumptions before changes are committed. Triggers on: \"check your work\", \"review this\", after complex multi-step implementations, before committing major refactors, or proactively after any task longer than five steps."
     },
     {
       "name": "quick-view",
       "source": "./skills/quick-view",
-      "description": "Generates minimal HTML pages to review structured data in a browser with maximum readability. Trigge"
+      "description": "Generates minimal HTML pages to review structured data in a browser with maximum readability. Triggers on: \"show me\", \"view this\", \"make reviewable\", \"open as webpage\", or any request to review lists, tables, drafts, or summaries that are hard to read in the terminal."
     },
     {
       "name": "quieter",
       "source": "./skills/quieter",
-      "description": "Tones down visually aggressive or overstimulating designs, reducing intensity while preserving quali"
+      "description": "Tones down visually aggressive or overstimulating designs, reducing intensity while preserving quality. Use when the user mentions too bold, too loud, overwhelming, aggressive, garish, or wants a calmer, more refined aesthetic."
     },
     {
       "name": "react-component-performance",
       "source": "./skills/react-component-performance",
-      "description": "Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improvi"
+      "description": "Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work."
     },
     {
       "name": "react-hook-form",
       "source": "./skills/react-hook-form",
-      "description": "Provides 41 prioritized performance rules for React Hook Form across form configuration, field subsc"
+      "description": "Provides 41 prioritized performance rules for React Hook Form across form configuration, field subscription, controlled components, validation, and field arrays. Invoke when writing or reviewing forms with useForm, useWatch, useController, or useFieldArray; integrating shadcn/MUI with Controller; or diagnosing unexpected re-renders in RHF-based forms. Covers client-side validation only — does not cover React Server Actions or useActionState."
     },
     {
       "name": "react-native-components",
       "source": "./skills/react-native-components",
-      "description": "Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practic"
+      "description": "Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practices with real-world examples. Use when building React Native UI components, implementing StyleSheet or dynamic styling, optimizing list performance, or creating accessible mobile interfaces."
     },
     {
       "name": "react-patterns",
       "source": "./skills/react-patterns",
-      "description": "Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Us"
+      "description": "Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Use when writing or reviewing React components, applying hooks and composition patterns, or improving React performance and TypeScript usage."
     },
     {
       "name": "react-refactor",
       "source": "./skills/react-refactor",
-      "description": "Architectural refactoring guide for React applications covering component architecture, state archit"
+      "description": "Architectural refactoring guide for React applications covering component architecture, state architecture, hook patterns, component decomposition, coupling and cohesion, data flow, and refactoring safety. Triggers when refactoring React codebases, reviewing PRs for architectural issues, decomposing oversized components, or improving module boundaries."
     },
     {
       "name": "react-testing-library",
       "source": "./skills/react-testing-library",
-      "description": "React Testing Library best practices for writing maintainable, user-centric tests. Use when writing,"
+      "description": "React Testing Library best practices for writing maintainable, user-centric tests. Use when writing, reviewing, or refactoring RTL tests. Triggers on test files, testing patterns, getBy/queryBy queries, userEvent, waitFor, and component testing."
     },
     {
       "name": "receiving-code-review",
       "source": "./skills/receiving-code-review",
-      "description": "Evaluate incoming code-review feedback with technical rigor before implementing any change. Verify e"
+      "description": "Evaluate incoming code-review feedback with technical rigor before implementing any change. Verify each point against the codebase, push back with reasoning when the reviewer is wrong, and never perform empty agreement. Use when you receive a review, before touching any code, especially when feedback seems unclear or technically questionable."
     },
     {
       "name": "redis-caching",
       "source": "./skills/redis-caching",
-      "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for Type"
+      "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications. Use when adding cache-aside or write-through caching, rate limiting, session or lock storage, pub/sub fanout, or reviewing Redis key design and TTLs."
     },
     {
       "name": "refactor-code",
       "source": "./skills/refactor-code",
-      "description": "Systematic approach to safely refactoring code with tests. Use when user says 'refactor', 'clean up "
+      "description": "Systematic approach to safely refactoring code with tests. Use when user says 'refactor', 'clean up code', 'simplify', 'reduce complexity', or 'technical debt'."
     },
     {
       "name": "release",
       "source": "./skills/release",
-      "description": "Cut a release from the trunk (default branch) and generate plain-English patch notes. Determines the"
+      "description": "Cut a release from the trunk (default branch) and generate plain-English patch notes. Determines the next semantic version from commits since the last tag, previews the release plan, then on confirmation creates an annotated tag, a GitHub release, and patch notes. Trunk-based — there is no develop/staging branch promotion. Use when the user asks to cut a release, ship a release, tag a release, release to production, generate release notes or a changelog, or runs /release."
     },
     {
       "name": "release-cleanup",
       "source": "./skills/release-cleanup",
-      "description": "Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitH"
+      "description": "Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitHub PR merge oracle, then prune merged local and remote feature branches and stale git worktrees. Squash-merge aware — uses GitHub PR merge state as the merge oracle, not commit ancestry. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, or confirm nothing stale was left behind before pruning."
     },
     {
       "name": "release-dispatch",
       "source": "./skills/release-dispatch",
-      "description": "Single front door for releases. Parses a subcommand — gates, cut, notes, or cleanup — and routes to "
+      "description": "Single front door for releases. Parses a subcommand — gates, cut, notes, or cleanup — and routes to the right release engine: release-pr-gates (verify CI green, then cut a tag/release or open a release PR), release (semver bump + plain-English patch notes), or release-cleanup (prune merged branches and stale worktrees). Backs the /release command. Use when asked to release, cut a tag, open a release PR, wait for CI to go green, generate patch notes, or clean up branches after a deploy, and the action must be picked from an argument like \"gates\", \"cut\", \"notes\", or \"cleanup\"."
     },
     {
       "name": "release-pr-gates",
       "source": "./skills/release-pr-gates",
-      "description": "Gate a release on the trunk — verify required CI checks are green, then cut a release (semver tag + "
+      "description": "Gate a release on the trunk — verify required CI checks are green, then cut a release (semver tag + GitHub release) or open a release PR into the default branch. Deployment to staging and production environments is driven by CI/CD pipelines and tags, not branch PRs. Use when the user asks to release, open a release PR, cut a tag, wait for GitHub checks to go green, or verify the trunk is ready to release."
     },
     {
       "name": "review-dispatch",
       "source": "./skills/review-dispatch",
-      "description": "Single front door for code review. Resolves a target — working-tree changes, one PR, all open PRs, t"
+      "description": "Single front door for code review. Resolves a target — working-tree changes, one PR, all open PRs, the last N commits, or a time window — into diffs, then routes to the right review engine (code-review for a quick gate, full-code-review for a deep multi-dimension pass). Backs the /review command. Use when asked to review changes, a PR, multiple PRs, or recent commits and the scope must be picked from an argument like \"prs\", \"commits 10\", or \"24h\"."
     },
     {
       "name": "roadmap-analyzer",
       "source": "./skills/roadmap-analyzer",
-      "description": "Analyze project features against ICP (Ideal Customer Profile) needs to identify gaps and recommend r"
+      "description": "Analyze project features against ICP (Ideal Customer Profile) needs to identify gaps and recommend roadmap priorities. Use this skill when asked to evaluate current product state, identify what should be built next, assess competitive positioning, or plan product roadmap based on target customer needs. Outputs gap analysis, prioritized backlog, and strategic themes. Discovers ICP and features from project documentation."
     },
     {
       "name": "rules-capture",
       "source": "./skills/rules-capture",
-      "description": "Automatically detects and documents user preferences, coding standards, and workflow rules from conv"
+      "description": "Automatically detects and documents user preferences, coding standards, and workflow rules from conversation — capturing them to `.agents/memory/captured-rules.md` for promotion to permanent project or user rules. Triggers on: \"always do X\", \"never do X\", \"from now on\", \"the rule is\", \"stop doing X\", \"I prefer\", frustration indicators, or any correction to AI behavior."
     },
     {
       "name": "scaffold",
       "source": "./skills/scaffold",
-      "description": "Generate incremental local code modules following existing codebase patterns. Use for endpoints, com"
+      "description": "Generate incremental local code modules following existing codebase patterns. Use for endpoints, components, packages, collections, or modules inside an existing repo; not for full project scaffolds."
     },
     {
       "name": "security-audit",
       "source": "./skills/security-audit",
-      "description": "Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconn"
+      "description": "Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting. Use when auditing a web app or API for security issues, reviewing auth or session handling, checking input validation and injection risk, or hardening before release."
     },
     {
       "name": "security-expert",
       "source": "./skills/security-expert",
-      "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and se"
+      "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing."
     },
     {
       "name": "session-documenter",
       "source": "./skills/session-documenter",
-      "description": "Documents work, decisions, and context from the current session by writing structured entries to `.a"
+      "description": "Documents work, decisions, and context from the current session by writing structured entries to `.agents/sessions/YYYY-MM-DD.md`. Triggers on `/start`, `/end`, \"document this session\", \"save session notes\", or automatically at session wrap-up to capture decisions, files changed, mistakes, and next steps."
     },
     {
       "name": "session-end",
       "source": "./skills/session-end",
-      "description": "Save session wrap-up documentation before clearing context by running the session-documenter workflo"
+      "description": "Save session wrap-up documentation before clearing context by running the session-documenter workflow and writing `.agents/sessions/YYYY-MM-DD.md`. Use when ending a session, preparing to run `/clear`, or asked to document what changed before context is reset."
     },
     {
       "name": "session-start",
       "source": "./skills/session-start",
-      "description": "Loads critical project context and recent session history at the start of each session or after `/cl"
+      "description": "Loads critical project context and recent session history at the start of each session or after `/clear` — reads `.agents/memory/` source-of-truth files, surfaces open next steps from the latest session log, and activates the session-documenter. Triggers on: session start, `/clear`, \"load context\", \"start session\", or first message in a new Claude Code session."
     },
     {
       "name": "setup-agent-routing",
       "source": "./skills/setup-agent-routing",
-      "description": "Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop "
+      "description": "Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop skills (executing-plans, feature-intake, prd-writer, qa-reviewer) know this repo's GitHub issue tracker, kanban label vocabulary, and domain doc layout. Run once per repo before first use of the loop, or when those skills appear to lack tracker, label, or domain context."
     },
     {
       "name": "shadcn",
       "source": "./skills/shadcn",
-      "description": "Provides shadcn/ui component library best practices and patterns. Triggers when writing, reviewing, "
+      "description": "Provides shadcn/ui component library best practices and patterns. Triggers when writing, reviewing, or refactoring shadcn/ui components; when working with Radix primitives, Tailwind styling, React Hook Form validation, data tables, theming, or component composition patterns."
     },
     {
       "name": "shadcn-setup",
       "source": "./skills/shadcn-setup",
-      "description": "Sets up shadcn/ui with Tailwind CSS v4 CSS-first configuration — installs packages, generates global"
+      "description": "Sets up shadcn/ui with Tailwind CSS v4 CSS-first configuration — installs packages, generates globals.css with @theme tokens, creates components.json, and adds the cn() utility. Use when starting a new Next.js or React project that needs a shadcn component library, or migrating from shadcn + Tailwind v3."
     },
     {
       "name": "shape",
       "source": "./skills/shape",
-      "description": "Plan the UX and UI for a feature before writing code. Runs a structured discovery interview, then pr"
+      "description": "Plan the UX and UI for a feature before writing code. Runs a structured discovery interview, then produces a design brief that guides implementation. Use during the planning phase to establish design direction, constraints, and strategy before any code is written."
     },
     {
       "name": "skill-capture",
       "source": "./skills/skill-capture",
-      "description": "Extracts valuable workflows, patterns, and domain knowledge from conversations and persists them as "
+      "description": "Extracts valuable workflows, patterns, and domain knowledge from conversations and persists them as reusable SKILL.md files. Triggers on: \"save this as a skill\", \"capture this as a skill\", \"make this reusable\", \"this workflow should be reusable\", \"this was tricky to figure out\", \"I wish I knew this earlier\", or on completion of complex multi-step procedures."
     },
     {
       "name": "skill-comply",
       "source": "./skills/skill-comply",
-      "description": "Measure whether agents actually follow a skill, rule, command, or agent definition by deriving expec"
+      "description": "Measure whether agents actually follow a skill, rule, command, or agent definition by deriving expected behaviors, running representative scenarios, and comparing observed action timelines against the spec. Use after adding or changing instructions, before publishing skills, or when rules appear to be ignored."
     },
     {
       "name": "skill-creator",
       "source": "./skills/skill-creator",
-      "description": "Guide for creating effective skills. Use when creating a new skill or updating an existing one to ex"
+      "description": "Guide for creating effective skills. Use when creating a new skill or updating an existing one to extend agent capabilities with specialized knowledge, workflows, or tool integrations."
     },
     {
       "name": "skill-dispatch",
       "source": "./skills/skill-dispatch",
-      "description": "Single front door for authoring and maintaining agent skills. Parses a subcommand — create, capture,"
+      "description": "Single front door for authoring and maintaining agent skills. Parses a subcommand — create, capture, comply, or scout — and routes to the right engine: skill-creator (guide for creating or updating a skill), skill-capture (extract a workflow from conversation into a SKILL.md), skill-comply (measure whether agents follow a skill or rule), or skill-scout (search for existing skills before building new ones). Backs the /skill command. Use when asked to create a skill, capture a pattern, test compliance of a skill, or scout for an existing skill, and the action must be picked from an argument like \"create\", \"capture\", \"comply\", or \"scout\"."
     },
     {
       "name": "skill-scout",
       "source": "./skills/skill-scout",
-      "description": "Search local, marketplace, repository, package, GitHub, and web sources before creating a new skill "
+      "description": "Search local, marketplace, repository, package, GitHub, and web sources before creating a new skill or custom implementation. Use when asked to create, fork, import, or evaluate a skill, or before writing code for functionality that likely already exists."
     },
     {
       "name": "spec-first",
       "source": "./skills/spec-first",
-      "description": "Enforces a spec → plan → execute → verify loop before writing code, preventing \"looks right\" failure"
+      "description": "Enforces a spec → plan → execute → verify loop before writing code, preventing \"looks right\" failures. Activates on \"build X\", \"implement...\", \"add a feature that...\", or any multi-file/unclear-requirements request. Creates spec.md, todo.md, and decisions.md as durable artifacts."
     },
     {
       "name": "standup",
       "source": "./skills/standup",
-      "description": "Summarize what you personally shipped over a time window from git history — an engineer standup or w"
+      "description": "Summarize what you personally shipped over a time window from git history — an engineer standup or weekly recap, not a customer changelog. Scopes commits to your git author identity, reads the diffs, and classifies each as a feature, fix, refactor, tech-debt, or docs change. Use when the user asks what did I get done, write my standup, what did I ship this week, weekly recap, or runs /standup."
     },
     {
       "name": "stripe-implementer",
       "source": "./skills/stripe-implementer",
-      "description": "Implement Stripe payment processing, subscription management, webhook handling, and customer managem"
+      "description": "Implement Stripe payment processing, subscription management, webhook handling, and customer management in Next.js and NestJS applications. Use when integrating Stripe payments, subscription billing, webhooks, customer management, or checkout and payment intents."
     },
     {
       "name": "structural-review",
       "source": "./skills/structural-review",
-      "description": "Perform a structural and maintainability review of a PR or codebase diff — covering file-size blocke"
+      "description": "Perform a structural and maintainability review of a PR or codebase diff — covering file-size blockers, abstraction quality, layer violations, type structural discipline, spaghetti branching, non-atomic mutations, stack-specific hygiene (Bun, Tailwind v4, Next.js 16, shadcn/ui), design purity (code-judo), and directness over magic (no speculative generality). Use when asked to review code quality, maintainability, structural health, or architecture of a change. Orthogonal to /code-review (which owns correctness bugs and CLAUDE.md compliance) — run after correctness passes or in parallel when a thorough PR review is requested."
     },
     {
       "name": "systematic-debugging",
       "source": "./skills/systematic-debugging",
-      "description": "Enforces root-cause investigation before any fix attempt using a rigorous four-phase methodology: in"
+      "description": "Enforces root-cause investigation before any fix attempt using a rigorous four-phase methodology: investigate, analyze patterns, hypothesize, implement. Use when encountering any bug, test failure, unexpected behavior, or performance regression — especially under time pressure or after multiple failed fix attempts."
     },
     {
       "name": "table-filters",
       "source": "./skills/table-filters",
-      "description": "Designs optimal filtering UX for data tables. Use when building a table that needs filters - analyze"
+      "description": "Designs optimal filtering UX for data tables. Use when building a table that needs filters - analyzes the data columns and determines the best filter type for each. Outputs a unified filter field with inline header filters."
     },
     {
       "name": "tailwind",
       "source": "./skills/tailwind",
-      "description": "Provides Tailwind CSS v4 performance optimization and best practices guidelines. Triggers when writi"
+      "description": "Provides Tailwind CSS v4 performance optimization and best practices guidelines. Triggers when writing, reviewing, or refactoring Tailwind CSS v4 code; when working with Tailwind configuration, @theme directive, utility classes, responsive design, dark mode, container queries, or CSS generation optimization."
     },
     {
       "name": "tailwind-validator",
       "source": "./skills/tailwind-validator",
-      "description": "Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns. Use this skill when "
+      "description": "Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns. Use this skill when setting up Tailwind, auditing CSS configuration, or when you suspect outdated Tailwind patterns are being used. Ensures CSS-first configuration with @theme blocks."
     },
     {
       "name": "tdd",
       "source": "./skills/tdd",
-      "description": "Test-driven development workflow for feature work and bug fixes. Use when the user asks for TDD, red"
+      "description": "Test-driven development workflow for feature work and bug fixes. Use when the user asks for TDD, red-green-refactor, test-first implementation, regression-first bug fixes, or vertical-slice delivery."
     },
     {
       "name": "test-dispatch",
       "source": "./skills/test-dispatch",
-      "description": "Single front door for testing. Parses a subcommand — run, qa, tdd, e2e, coverage, init, or regressio"
+      "description": "Single front door for testing. Parses a subcommand — run, qa, tdd, e2e, coverage, init, or regression — and routes to the right testing engine: test-runner (run tests, fix failures), qa-reviewer (structured verification pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init (scaffold E2E tests for frontend projects), husky-test-coverage (enforce coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions CI setup), or ai-regression-testing (design regression tests targeting AI blind spots). Backs the /test command. Use when asked to run tests, write tests, set up testing, check coverage, or start TDD, and the action must be picked from an argument like \"run\", \"qa\", \"tdd\", \"e2e\", \"coverage\", \"init\", or \"regression\"."
     },
     {
       "name": "test-runner",
       "source": "./skills/test-runner",
-      "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then, o"
+      "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then, on failure, read the output and traces, apply a minimal fix, and rerun until green or blocked. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /tests."
     },
     {
       "name": "testing-cicd-init",
       "source": "./skills/testing-cicd-init",
-      "description": "Installs Vitest testing infrastructure and GitHub Actions CI/CD for TypeScript projects (Next.js, Ne"
+      "description": "Installs Vitest testing infrastructure and GitHub Actions CI/CD for TypeScript projects (Next.js, NestJS, React). Configures 80% coverage thresholds, test setup files, and Bun-based CI workflows. Use when adding tests to a new project, migrating from Jest to Vitest, or setting up GitHub Actions CI/CD for the first time."
     },
     {
       "name": "testing-expert",
       "source": "./skills/testing-expert",
-      "description": "Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integr"
+      "description": "Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices. Use when writing unit, integration, or E2E tests, testing React components, or testing API endpoints."
     },
     {
       "name": "theme-factory",
       "source": "./skills/theme-factory",
-      "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML la"
+      "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly. Use when styling an artifact such as slides, docs, or an HTML landing page with a preset or custom theme of colors and fonts."
     },
     {
       "name": "tool-design",
       "source": "./skills/tool-design",
-      "description": "Design tools that agents can use effectively, including when to reduce tool complexity. Use when cre"
+      "description": "Design tools that agents can use effectively, including when to reduce tool complexity. Use when creating, optimizing, or reducing the set of tools available to an agent."
     },
     {
       "name": "turborepo",
       "source": "./skills/turborepo",
-      "description": "Turborepo monorepo build system guidance. Triggers on: `turbo.json`, task pipelines,\n`dependsOn`, ca"
+      "description": "Turborepo monorepo build system guidance. Triggers on: `turbo.json`, task pipelines, `dependsOn`, caching, remote cache, the `turbo` CLI, `--filter`, `--affected`, CI optimization, environment variables, internal packages, monorepo structure, and package boundaries. Use when the user configures tasks or workflows, creates packages, sets up a monorepo, shares code between apps, runs changed packages, debugs cache behavior, or works in an `apps/` plus `packages/` workspace."
     },
     {
       "name": "typescript-expert",
       "source": "./skills/typescript-expert",
-      "description": "Resolves TypeScript and JavaScript problems across type-level programming, performance, monorepo man"
+      "description": "Resolves TypeScript and JavaScript problems across type-level programming, performance, monorepo management, migration, and modern tooling. Invoke when diagnosing \"type instantiation excessively deep\" errors, migrating JS to TS, configuring strict tsconfig, debugging module resolution, or choosing between Biome/ESLint/Turborepo/Nx."
     },
     {
       "name": "typescript-refactor",
       "source": "./skills/typescript-refactor",
-      "description": "TypeScript refactoring and modernization guidelines from a principal specialist perspective. This sk"
+      "description": "TypeScript refactoring and modernization guidelines from a principal specialist perspective. This skill should be used when refactoring, reviewing, or modernizing TypeScript code to ensure type safety, compiler performance, and idiomatic patterns. Triggers on tasks involving TypeScript type architecture, narrowing, generics, error handling, or migration to modern TypeScript features."
     },
     {
       "name": "ultracode",
       "source": "./skills/ultracode",
-      "description": "Runs a Codex-only high-autonomy workflow for difficult coding tasks: inspect, plan, choose direct/wo"
+      "description": "Runs a Codex-only high-autonomy workflow for difficult coding tasks: inspect, plan, choose direct/workflow/delegated mode, use bounded subagents for independent packets, integrate in the parent thread, verify, and continue until done or genuinely blocked. Use when invoked with $ultracode, /ultracode, \"ultracode\", \"maximum-depth\", \"split across agents\", \"parallel agents\", \"deep autonomous implementation\", broad repo analysis, migrations, refactors, hard debugging, QA, or end-to-end shipping."
     },
     {
       "name": "verification-before-completion",
       "source": "./skills/verification-before-completion",
-      "description": "Enforce evidence-based completion: no success, done, fixed, or passing claim may be made without fir"
+      "description": "Enforce evidence-based completion: no success, done, fixed, or passing claim may be made without first running the verification command and reading its full output. Use when about to claim work is complete, a bug is fixed, tests pass, a build succeeds, or before committing, pushing, or opening a PR."
     },
     {
       "name": "workspace-performance-audit",
       "source": "./skills/workspace-performance-audit",
-      "description": "Orchestrates comprehensive performance audits across full-stack monorepos. Coordinates performance-e"
+      "description": "Orchestrates comprehensive performance audits across full-stack monorepos. Coordinates performance-expert, design-consistency-auditor, accessibility, security-expert, and qa-reviewer skills to audit frontend, backend, database, browser extensions, and shared packages. Use when asked for a full workspace performance review, monorepo audit, or to identify bottlenecks across frontend, backend, and extensions."
     },
     {
       "name": "worktree",
       "source": "./skills/worktree",
-      "description": "Create an isolated git worktree from the correct base branch and check it out into a clean, gitignor"
+      "description": "Create an isolated git worktree from the correct base branch and check it out into a clean, gitignored directory. Use when the user asks to make a worktree, spin up a parallel/isolated workspace, work on something without disturbing the current checkout, branch off the current work, or run multiple agents on the same repo at once. Picks the base branch smartly — the current feature branch when you are on one, otherwise the repository's default/trunk branch — so worktrees continue your in-progress work by default instead of forking from the wrong place."
     },
     {
       "name": "writing-plans",
       "source": "./skills/writing-plans",
-      "description": "Turn a spec or requirements doc into a comprehensive, bite-sized implementation plan: map every file"
+      "description": "Turn a spec or requirements doc into a comprehensive, bite-sized implementation plan: map every file, define 2-5 minute TDD tasks with complete code, and enforce DRY/YAGNI/frequent-commits discipline. Use when you have requirements ready and need a concrete execution plan before touching code, when a feature spans multiple files and needs decomposition, or when you want agentic workers to execute tasks reliably without guessing."
     }
   ]
 }

--- a/bundles/ai-agents/skills/advanced-evaluation/SKILL.md
+++ b/bundles/ai-agents/skills/advanced-evaluation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advanced-evaluation
-description: Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubric calibration, evaluator bias mitigation, confidence scoring, and automated quality assessment.
+description: Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubric calibration, evaluator bias mitigation, confidence scoring, and automated quality assessment. Use when building LLM-as-judge systems, comparing model responses, calibrating rubrics, debugging inconsistent evaluations, or designing A/B tests for prompt or model changes.
 metadata:
   version: "2.1.0"
   source: https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/advanced-evaluation/SKILL.md

--- a/bundles/ai-agents/skills/context-optimization/SKILL.md
+++ b/bundles/ai-agents/skills/context-optimization/SKILL.md
@@ -4,7 +4,9 @@ description: >-
   Improve context efficiency through context budgeting, observation masking,
   prefix or KV-cache strategy, partitioning, token-cost reduction, retrieval
   scoping, and extending effective context capacity without lowering answer
-  quality.
+  quality. Use when token costs or context budgets constrain a task, tool
+  outputs are verbose, cache hit rate is low, or context must be partitioned
+  across agents.
 metadata:
   version: "2.1.0"
   source: https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/context-optimization/SKILL.md

--- a/bundles/ai-agents/skills/memory-systems/SKILL.md
+++ b/bundles/ai-agents/skills/memory-systems/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-systems
-description: Design and implement memory architectures for agent systems that persist state across sessions, maintain entity consistency, and reason over structured knowledge.
+description: Design and implement memory architectures for agent systems that persist state across sessions, maintain entity consistency, and reason over structured knowledge. Use when building agents that persist knowledge across sessions, choosing between memory frameworks, maintaining entity consistency, or designing memory architectures for production.
 metadata:
   version: "4.1.0"
   source: https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/memory-systems/SKILL.md

--- a/bundles/backend/skills/api-design-expert/SKILL.md
+++ b/bundles/backend/skills/api-design-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-design-expert
-description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications
+description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications. Use when designing API endpoints, building RESTful APIs, writing OpenAPI/Swagger docs, implementing versioning, or designing error responses and DTOs.
 metadata:
   version: "1.0.0"
   tags: "api, rest, design"

--- a/bundles/backend/skills/error-handling-expert/SKILL.md
+++ b/bundles/backend/skills/error-handling-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: error-handling-expert
-description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications
+description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications. Use when implementing error handling, exception filters, error responses, error logging, or recovery strategies.
 metadata:
   version: "1.0.0"
   tags: "errors, reliability, architecture"

--- a/bundles/dev-workflow/skills/changelog-generator/SKILL.md
+++ b/bundles/dev-workflow/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation.
+description: Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation. Use when preparing release notes, summarizing product updates, or turning git commits into customer-facing changelog entries.
 metadata:
   version: "1.0.0"
   source: https://github.com/ComposioHQ/awesome-claude-skills/blob/master/changelog-generator/SKILL.md

--- a/bundles/dev-workflow/skills/debug/SKILL.md
+++ b/bundles/dev-workflow/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Systematic debugging guidance for bugs, failures, unexpected behavior, and performance regressions. Emphasizes reproducible feedback loops, hypothesis testing, instrumentation, fixes, and regression tests.
+description: Systematic debugging guidance for bugs, failures, unexpected behavior, and performance regressions. Emphasizes reproducible feedback loops, hypothesis testing, instrumentation, fixes, and regression tests. Use when investigating a bug, unexpected behavior, crash, wrong output, or performance regression, or triaging incoming bug reports.
 metadata:
   version: "1.1.0"
   tags: "debugging, troubleshooting, methodology"

--- a/bundles/dev-workflow/skills/docs/SKILL.md
+++ b/bundles/dev-workflow/skills/docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: Creates clear, concise technical documentation for software projects, runbooks, and developer guides.
+description: Creates clear, concise technical documentation for software projects, runbooks, and developer guides. Use when writing or updating a README, guide, runbook, API reference, setup instructions, or troubleshooting notes.
 metadata:
   version: "1.0.0"
   tags: "documentation, technical-writing, runbooks"

--- a/bundles/frontend/skills/accessibility/SKILL.md
+++ b/bundles/frontend/skills/accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone
+description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues.
 metadata:
   version: "1.0.0"
   tags: accessibility, a11y, wcag, aria, keyboard-navigation, screen-reader, inclusive-design

--- a/bundles/frontend/skills/component-library/SKILL.md
+++ b/bundles/frontend/skills/component-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-library
-description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects
+description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects. Use when creating or refactoring UI components, reviewing component architecture, or setting up shared component patterns in a monorepo.
 metadata:
   version: "1.0.0"
   tags: react, nextjs, components, design-system, typescript, performance, patterns

--- a/bundles/frontend/skills/expo-architect/SKILL.md
+++ b/bundles/frontend/skills/expo-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-architect
-description: Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Clerk auth. Generates complete mobile app structure that runs immediately with `bun start`.
+description: Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Clerk auth. Generates complete mobile app structure that runs immediately with `bun start`. Use when scaffolding a new Expo or React Native app, setting up Expo Router navigation, or adding Clerk auth to a mobile app.
 metadata:
   version: "1.0.0"
   tags: expo, react-native, mobile, scaffold, clerk

--- a/bundles/frontend/skills/react-component-performance/SKILL.md
+++ b/bundles/frontend/skills/react-component-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-component-performance
-description: Diagnose slow React components and suggest targeted performance fixes.
+description: Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work.
 metadata:
   version: "1.0.0"
   source: https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md

--- a/bundles/frontend/skills/react-native-components/SKILL.md
+++ b/bundles/frontend/skills/react-native-components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-native-components
-description: Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practices with real-world examples
+description: Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practices with real-world examples. Use when building React Native UI components, implementing StyleSheet or dynamic styling, optimizing list performance, or creating accessible mobile interfaces.
 metadata:
   version: "1.0.0"
   tags: "[react-native, components, styling, performance, ui, accessibility, hooks]"

--- a/bundles/frontend/skills/react-patterns/SKILL.md
+++ b/bundles/frontend/skills/react-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-patterns
-description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices.
+description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Use when writing or reviewing React components, applying hooks and composition patterns, or improving React performance and TypeScript usage.
 metadata:
   risk: safe
   date_added: '2026-02-27'

--- a/bundles/frontend/skills/theme-factory/SKILL.md
+++ b/bundles/frontend/skills/theme-factory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theme-factory
-description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.
+description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly. Use when styling an artifact such as slides, docs, or an HTML landing page with a preset or custom theme of colors and fonts.
 license: Complete terms in LICENSE.txt
 metadata:
   version: "1.0.0"

--- a/bundles/infrastructure/skills/mongodb-atlas-checker/SKILL.md
+++ b/bundles/infrastructure/skills/mongodb-atlas-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mongodb-atlas-checker
-description: Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, environment variables, connection pooling, and ensures proper setup for Next.js and NestJS applications.
+description: Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, environment variables, connection pooling, and ensures proper setup for Next.js and NestJS applications. Use when verifying MongoDB Atlas setup, checking connection strings or environment variables, or troubleshooting database connection issues before deployment.
 metadata:
   version: "1.0.0"
   tags: mongodb, atlas, database, backend, nestjs, nextjs

--- a/bundles/infrastructure/skills/mongodb-migration-expert/SKILL.md
+++ b/bundles/infrastructure/skills/mongodb-migration-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mongodb-migration-expert
-description: Database schema design, indexing, and migration guidance for MongoDB-based applications.
+description: Database schema design, indexing, and migration guidance for MongoDB-based applications. Use when adding or changing MongoDB collections, indexes, or fields, designing schema for multi-tenant or large datasets, or planning forward-only migrations.
 metadata:
   version: "1.0.0"
   tags: "mongodb, migration, database"

--- a/bundles/infrastructure/skills/nestjs-queue-architect/SKILL.md
+++ b/bundles/infrastructure/skills/nestjs-queue-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nestjs-queue-architect
-description: Queue job management patterns, processors, and async workflows for video/image processing
+description: Queue job management patterns, processors, and async workflows for video/image processing. Use when building BullMQ queues, job processors, or async video/image processing workflows in NestJS.
 metadata:
   version: "1.0.0"
   technology: BullMQ 5.61.0 with NestJS 11.1.7

--- a/bundles/infrastructure/skills/performance-expert/SKILL.md
+++ b/bundles/infrastructure/skills/performance-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-expert
-description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization
+description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching.
 metadata:
   version: "1.0.0"
   tags: "performance, optimization, fullstack"

--- a/bundles/infrastructure/skills/redis-caching/SKILL.md
+++ b/bundles/infrastructure/skills/redis-caching/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: redis-caching
-description: "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications."
+description: "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications. Use when adding cache-aside or write-through caching, rate limiting, session or lock storage, pub/sub fanout, or reviewing Redis key design and TTLs."
 metadata:
   version: "1.0.0"
   tags: "redis, caching, rate-limiting, sessions, prisma, nestjs, nextjs"

--- a/bundles/infrastructure/skills/security-expert/SKILL.md
+++ b/bundles/infrastructure/skills/security-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-expert
-description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications
+description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
   version: "1.0.0"
   tags: "security, owasp, application-security"

--- a/bundles/payments/skills/stripe-implementer/SKILL.md
+++ b/bundles/payments/skills/stripe-implementer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stripe-implementer
-description: Implement Stripe payment processing, subscription management, webhook handling, and customer management in Next.js and NestJS applications
+description: Implement Stripe payment processing, subscription management, webhook handling, and customer management in Next.js and NestJS applications. Use when integrating Stripe payments, subscription billing, webhooks, customer management, or checkout and payment intents.
 metadata:
   version: "1.0.0"
   tags: "stripe, payments, subscriptions"

--- a/bundles/security/skills/open-source-checker/SKILL.md
+++ b/bundles/security/skills/open-source-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing
+description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
   version: "1.0.0"
   tags: "open-source, security, secrets"

--- a/bundles/security/skills/security-audit/SKILL.md
+++ b/bundles/security/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting.
+description: Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting. Use when auditing a web app or API for security issues, reviewing auth or session handling, checking input validation and injection risk, or hardening before release.
 metadata:
   version: "1.0.0"
   tags: "security, audit, web, api, hardening"

--- a/bundles/security/skills/security-expert/SKILL.md
+++ b/bundles/security/skills/security-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-expert
-description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications
+description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
   version: "1.0.0"
   tags: "security, owasp, application-security"

--- a/bundles/testing/skills/testing-expert/SKILL.md
+++ b/bundles/testing/skills/testing-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-expert
-description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices
+description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices. Use when writing unit, integration, or E2E tests, testing React components, or testing API endpoints.
 metadata:
   version: "1.0.0"
   tags: "testing, quality, fullstack"

--- a/bundles/workspace/skills/bun-validator/SKILL.md
+++ b/bundles/workspace/skills/bun-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-validator
-description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices.
+description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices. Use when setting up a Bun monorepo, before adding workspace dependencies, auditing an existing Bun workspace, or validating package.json in CI.
 metadata:
   version: "1.0.0"
   tags: bun, monorepo, workspace, validation, package-manager

--- a/bundles/workspace/skills/content-script-developer/SKILL.md
+++ b/bundles/workspace/skills/content-script-developer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: content-script-developer
-description: Expert in browser extension content scripts, DOM integration, and safe page augmentation across modern web apps.
+description: Expert in browser extension content scripts, DOM integration, and safe page augmentation across modern web apps. Use when building or updating a browser-extension content script, injecting UI into third-party pages, or handling SPA navigation and dynamic DOM changes.
 metadata:
   version: "1.0.0"
   tags: "browser-extension, content-script, dom"

--- a/bundles/workspace/skills/open-source-checker/SKILL.md
+++ b/bundles/workspace/skills/open-source-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing
+description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
   version: "1.0.0"
   tags: "open-source, security, secrets"

--- a/bundles/workspace/skills/package-architect/SKILL.md
+++ b/bundles/workspace/skills/package-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-architect
-description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration.
+description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Use when creating or restructuring monorepo packages, defining package.json exports, or setting up tsconfig references.
 metadata:
   version: "1.0.0"
   tags: "packages, monorepo, typescript"

--- a/scripts/generate-marketplace-json.js
+++ b/scripts/generate-marketplace-json.js
@@ -82,7 +82,12 @@ for (const skillName of skills) {
   plugins.push({
     name: skillName,
     source: `./skills/${skillName}`,
-    description: description.slice(0, 100), // Truncate long descriptions
+    // Mirror the full SKILL.md description so the "Use when …" trigger clause
+    // is discoverable in the catalog. The source frontmatter is already length-
+    // capped (1024/1536); the previous slice(0, 100) cut clauses off mid-word.
+    // Collapse whitespace so literal (`|`) block scalars render as a single-line
+    // blurb instead of leaking embedded newlines into the catalog card.
+    description: description.replace(/\s+/g, ' ').trim(),
   });
   includedSkillCount += 1;
 }

--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: accessibility
-description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone
+description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues.
 metadata:
   version: "1.0.0"
   tags: accessibility, a11y, wcag, aria, keyboard-navigation, screen-reader, inclusive-design

--- a/skills/advanced-evaluation/SKILL.md
+++ b/skills/advanced-evaluation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: advanced-evaluation
-description: Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubric calibration, evaluator bias mitigation, confidence scoring, and automated quality assessment.
+description: Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubric calibration, evaluator bias mitigation, confidence scoring, and automated quality assessment. Use when building LLM-as-judge systems, comparing model responses, calibrating rubrics, debugging inconsistent evaluations, or designing A/B tests for prompt or model changes.
 metadata:
   version: "2.1.0"
   source: https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/advanced-evaluation/SKILL.md

--- a/skills/api-design-expert/SKILL.md
+++ b/skills/api-design-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: api-design-expert
-description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications
+description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications. Use when designing API endpoints, building RESTful APIs, writing OpenAPI/Swagger docs, implementing versioning, or designing error responses and DTOs.
 metadata:
   version: "1.0.0"
   tags: "api, rest, design"

--- a/skills/bun-validator/SKILL.md
+++ b/skills/bun-validator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: bun-validator
-description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices.
+description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices. Use when setting up a Bun monorepo, before adding workspace dependencies, auditing an existing Bun workspace, or validating package.json in CI.
 metadata:
   version: "1.0.0"
   tags: bun, monorepo, workspace, validation, package-manager

--- a/skills/changelog-generator/SKILL.md
+++ b/skills/changelog-generator/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: changelog-generator
-description: Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation.
+description: Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation. Use when preparing release notes, summarizing product updates, or turning git commits into customer-facing changelog entries.
 metadata:
   version: "1.0.0"
   source: https://github.com/ComposioHQ/awesome-claude-skills/blob/master/changelog-generator/SKILL.md

--- a/skills/component-library/SKILL.md
+++ b/skills/component-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-library
-description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects
+description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects. Use when creating or refactoring UI components, reviewing component architecture, or setting up shared component patterns in a monorepo.
 metadata:
   version: "1.0.0"
   tags: react, nextjs, components, design-system, typescript, performance, patterns

--- a/skills/content-script-developer/SKILL.md
+++ b/skills/content-script-developer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: content-script-developer
-description: Expert in browser extension content scripts, DOM integration, and safe page augmentation across modern web apps.
+description: Expert in browser extension content scripts, DOM integration, and safe page augmentation across modern web apps. Use when building or updating a browser-extension content script, injecting UI into third-party pages, or handling SPA navigation and dynamic DOM changes.
 metadata:
   version: "1.0.0"
   tags: "browser-extension, content-script, dom"

--- a/skills/context-optimization/SKILL.md
+++ b/skills/context-optimization/SKILL.md
@@ -4,7 +4,9 @@ description: >-
   Improve context efficiency through context budgeting, observation masking,
   prefix or KV-cache strategy, partitioning, token-cost reduction, retrieval
   scoping, and extending effective context capacity without lowering answer
-  quality.
+  quality. Use when token costs or context budgets constrain a task, tool
+  outputs are verbose, cache hit rate is low, or context must be partitioned
+  across agents.
 metadata:
   version: "2.1.0"
   source: https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/context-optimization/SKILL.md

--- a/skills/debug/SKILL.md
+++ b/skills/debug/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: debug
-description: Systematic debugging guidance for bugs, failures, unexpected behavior, and performance regressions. Emphasizes reproducible feedback loops, hypothesis testing, instrumentation, fixes, and regression tests.
+description: Systematic debugging guidance for bugs, failures, unexpected behavior, and performance regressions. Emphasizes reproducible feedback loops, hypothesis testing, instrumentation, fixes, and regression tests. Use when investigating a bug, unexpected behavior, crash, wrong output, or performance regression, or triaging incoming bug reports.
 metadata:
   version: "1.1.0"
   tags: "debugging, troubleshooting, methodology"

--- a/skills/docs/SKILL.md
+++ b/skills/docs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: docs
-description: Creates clear, concise technical documentation for software projects, runbooks, and developer guides.
+description: Creates clear, concise technical documentation for software projects, runbooks, and developer guides. Use when writing or updating a README, guide, runbook, API reference, setup instructions, or troubleshooting notes.
 metadata:
   version: "1.0.0"
   tags: "documentation, technical-writing, runbooks"

--- a/skills/error-handling-expert/SKILL.md
+++ b/skills/error-handling-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: error-handling-expert
-description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications
+description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications. Use when implementing error handling, exception filters, error responses, error logging, or recovery strategies.
 metadata:
   version: "1.0.0"
   tags: "errors, reliability, architecture"

--- a/skills/expo-architect/SKILL.md
+++ b/skills/expo-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: expo-architect
-description: Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Clerk auth. Generates complete mobile app structure that runs immediately with `bun start`.
+description: Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Clerk auth. Generates complete mobile app structure that runs immediately with `bun start`. Use when scaffolding a new Expo or React Native app, setting up Expo Router navigation, or adding Clerk auth to a mobile app.
 metadata:
   version: "1.0.0"
   tags: expo, react-native, mobile, scaffold, clerk

--- a/skills/memory-systems/SKILL.md
+++ b/skills/memory-systems/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: memory-systems
-description: Design and implement memory architectures for agent systems that persist state across sessions, maintain entity consistency, and reason over structured knowledge.
+description: Design and implement memory architectures for agent systems that persist state across sessions, maintain entity consistency, and reason over structured knowledge. Use when building agents that persist knowledge across sessions, choosing between memory frameworks, maintaining entity consistency, or designing memory architectures for production.
 metadata:
   version: "4.1.0"
   source: https://github.com/muratcankoylan/Agent-Skills-for-Context-Engineering/blob/main/skills/memory-systems/SKILL.md

--- a/skills/mongodb-atlas-checker/SKILL.md
+++ b/skills/mongodb-atlas-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mongodb-atlas-checker
-description: Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, environment variables, connection pooling, and ensures proper setup for Next.js and NestJS applications.
+description: Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, environment variables, connection pooling, and ensures proper setup for Next.js and NestJS applications. Use when verifying MongoDB Atlas setup, checking connection strings or environment variables, or troubleshooting database connection issues before deployment.
 metadata:
   version: "1.0.0"
   tags: mongodb, atlas, database, backend, nestjs, nextjs

--- a/skills/mongodb-migration-expert/SKILL.md
+++ b/skills/mongodb-migration-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mongodb-migration-expert
-description: Database schema design, indexing, and migration guidance for MongoDB-based applications.
+description: Database schema design, indexing, and migration guidance for MongoDB-based applications. Use when adding or changing MongoDB collections, indexes, or fields, designing schema for multi-tenant or large datasets, or planning forward-only migrations.
 metadata:
   version: "1.0.0"
   tags: "mongodb, migration, database"

--- a/skills/nestjs-queue-architect/SKILL.md
+++ b/skills/nestjs-queue-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nestjs-queue-architect
-description: Queue job management patterns, processors, and async workflows for video/image processing
+description: Queue job management patterns, processors, and async workflows for video/image processing. Use when building BullMQ queues, job processors, or async video/image processing workflows in NestJS.
 metadata:
   version: "1.0.0"
   technology: BullMQ 5.61.0 with NestJS 11.1.7

--- a/skills/open-source-checker/SKILL.md
+++ b/skills/open-source-checker/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing
+description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
   version: "1.0.0"
   tags: "open-source, security, secrets"

--- a/skills/package-architect/SKILL.md
+++ b/skills/package-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-architect
-description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration.
+description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Use when creating or restructuring monorepo packages, defining package.json exports, or setting up tsconfig references.
 metadata:
   version: "1.0.0"
   tags: "packages, monorepo, typescript"

--- a/skills/performance-expert/SKILL.md
+++ b/skills/performance-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: performance-expert
-description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization
+description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching.
 metadata:
   version: "1.0.0"
   tags: "performance, optimization, fullstack"

--- a/skills/react-component-performance/SKILL.md
+++ b/skills/react-component-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-component-performance
-description: Diagnose slow React components and suggest targeted performance fixes.
+description: Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work.
 metadata:
   version: "1.0.0"
   source: https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md

--- a/skills/react-native-components/SKILL.md
+++ b/skills/react-native-components/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-native-components
-description: Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practices with real-world examples
+description: Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practices with real-world examples. Use when building React Native UI components, implementing StyleSheet or dynamic styling, optimizing list performance, or creating accessible mobile interfaces.
 metadata:
   version: "1.0.0"
   tags: "[react-native, components, styling, performance, ui, accessibility, hooks]"

--- a/skills/react-patterns/SKILL.md
+++ b/skills/react-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-patterns
-description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices.
+description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Use when writing or reviewing React components, applying hooks and composition patterns, or improving React performance and TypeScript usage.
 metadata:
   risk: safe
   date_added: '2026-02-27'

--- a/skills/redis-caching/SKILL.md
+++ b/skills/redis-caching/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: redis-caching
-description: "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications."
+description: "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications. Use when adding cache-aside or write-through caching, rate limiting, session or lock storage, pub/sub fanout, or reviewing Redis key design and TTLs."
 metadata:
   version: "1.0.0"
   tags: "redis, caching, rate-limiting, sessions, prisma, nestjs, nextjs"

--- a/skills/security-audit/SKILL.md
+++ b/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting.
+description: Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting. Use when auditing a web app or API for security issues, reviewing auth or session handling, checking input validation and injection risk, or hardening before release.
 metadata:
   version: "1.0.0"
   tags: "security, audit, web, api, hardening"

--- a/skills/security-expert/SKILL.md
+++ b/skills/security-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-expert
-description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications
+description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
   version: "1.0.0"
   tags: "security, owasp, application-security"

--- a/skills/stripe-implementer/SKILL.md
+++ b/skills/stripe-implementer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: stripe-implementer
-description: Implement Stripe payment processing, subscription management, webhook handling, and customer management in Next.js and NestJS applications
+description: Implement Stripe payment processing, subscription management, webhook handling, and customer management in Next.js and NestJS applications. Use when integrating Stripe payments, subscription billing, webhooks, customer management, or checkout and payment intents.
 metadata:
   version: "1.0.0"
   tags: "stripe, payments, subscriptions"

--- a/skills/testing-expert/SKILL.md
+++ b/skills/testing-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-expert
-description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices
+description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices. Use when writing unit, integration, or E2E tests, testing React components, or testing API endpoints.
 metadata:
   version: "1.0.0"
   tags: "testing, quality, fullstack"

--- a/skills/theme-factory/SKILL.md
+++ b/skills/theme-factory/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: theme-factory
-description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly.
+description: Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly. Use when styling an artifact such as slides, docs, or an HTML landing page with a preset or custom theme of colors and fonts.
 license: Complete terms in LICENSE.txt
 metadata:
   version: "1.0.0"


### PR DESCRIPTION
**Stacked on #46** (base = `chore/prune-skill-no-ops`; retarget to `master` once #46 merges).

## What

28 skill descriptions stated only *what* the skill does, with no *when to use it* — so they wouldn't auto-activate reliably. This appends a `Use when <triggers>.` clause to each, matching both **Matt Pocock's house style** and this repo's own `.agents/memory/system/skill-standards.md` ("front-load the capability, follow with the trigger context").

## How (safety)

- Triggers are pulled from **each skill's own `When to Use` body** — nothing invented, no routing guessed.
- Existing capability text kept **verbatim**; the clause is purely additive (strictly more discoverable, never less).
- Handled plain, double-quoted, and folded (`>-`) YAML scalars; all stay within the 1024 / 1536-char caps and pass the repo's unquoted-`": "` rule.
- Frontmatter otherwise byte-identical. `markdownlint` clean. `bundles/` + `marketplace.json` regenerated.

## Dropped from scope

The planned **frontmatter slim** (drop `tags`/`author`) was abandoned: `skill-standards.md` explicitly prescribes `metadata.{version, tags, author}` as the correct pattern and lists top-level `version`/`tags` as mistakes to fix *into* metadata. Removing them would contradict the repo's own documented standard. Matt ships lean frontmatter only because his repo has no marketplace/provenance tooling; ours does. **Bucket folders** were also ruled out — marketplace gen references `./skills/${name}` and bundles already provide grouping; a reorg would break every path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)