### PR TITLE
feat(skills): route deslop ui to deslop-ui

### DIFF
--- a/bundles/dev-workflow/skills/de-slop/SKILL.md
+++ b/bundles/dev-workflow/skills/de-slop/SKILL.md
@@ -6,11 +6,12 @@ description: >-
   needless defensive try-catch on trusted paths, over-nesting. Product slop (with
   --product) — marketing-filler copy, generic AI phrasing, default-shadcn look,
   unstyled loading/error states, dead buttons and half-wired flows that make an app
-  feel unfinished. Can scope to the current branch's diff or sweep the whole tree.
-  Use when asked to clean up AI-generated code, remove slop, or make an app feel
-  finished before shipping to customers.
+  feel unfinished. UI slop (`ui`) delegates to deslop-ui for design-system primitive
+  enforcement. Can scope to the current branch's diff or sweep the whole tree. Use
+  when asked to clean up AI-generated code, remove slop, or make an app feel finished
+  before shipping to customers.
 disable-model-invocation: true
-argument-hint: "[--changed | all | dry-run | --product]"
+argument-hint: "[ui | --changed | all | dry-run | --product]"
 metadata:
   version: "1.1.0"
   tags: "code-quality, cleanup, ai-artifacts, product-polish, maintenance"
@@ -31,7 +32,7 @@ diff. For a read-only pass that only flags, use `structural-review` / `/review`.
 Inputs:
 
 - A package or repo to clean; optional scope (`--changed`, `all`, `dry-run`) and
-  dimension (`--product` to add the product pass).
+  dimension (`--product` to add the product pass, `ui` to route to `deslop-ui`).
 
 Outputs:
 
@@ -48,7 +49,8 @@ External Side Effects:
 
 Delegates To:
 
-- `design-consistency-auditor` when product slop is mostly visual inconsistency.
+- `deslop-ui` when invoked with `ui`, or when product slop is primarily design-system,
+  component primitive, or UI consistency drift.
 - `polish` for the final micro-detail pass after the structural slop is gone.
 - `refactor-code` when a fix is a real refactor, not a mechanical strip.
 
@@ -83,11 +85,22 @@ Correct catalog; the three families:
 Product slop needs judgment, not just deletion — flag anything ambiguous rather than
 guessing at intended copy or behavior.
 
+## UI slop (`ui`)
+
+When the first argument is `ui`, stop routing through the code-slop workflow and
+delegate to `deslop-ui`. Pass any remaining target or flags through unchanged.
+
+Use this for design-system primitive enforcement, component consistency, raw UI
+primitive replacement, card/surface drift, arbitrary Tailwind values, duplicate local
+components, visual hierarchy issues, and UI-specific AI slop.
+
 ## Workflow
 
-1. **Detect structure** — monorepo vs single package (`ls packages/ 2>/dev/null`).
+1. **Route UI mode** — if the first argument is `ui`, apply `deslop-ui` and do not
+   run the code cleanup steps below.
+2. **Detect structure** — monorepo vs single package (`ls packages/ 2>/dev/null`).
    Process each package separately.
-2. **Scope** — in `--changed`, limit edits to the branch diff:
+3. **Scope** — in `--changed`, limit edits to the branch diff:
 
    ```bash
    BASE="$(git merge-base HEAD origin/HEAD 2>/dev/null || git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)"
@@ -95,20 +108,21 @@ guessing at intended copy or behavior.
    ```
 
    Touch only those files/hunks; do not clean pre-existing slop elsewhere in this mode.
-3. **Strip code slop** by the categories above; add the product pass if `--product`.
-4. **Verify** — the change must still build and pass:
+4. **Strip code slop** by the categories above; add the product pass if `--product`.
+5. **Verify** — the change must still build and pass:
 
    ```bash
    bun run type-check || bunx tsc --noEmit
    bun run test
    ```
 
-5. **Document** — log packages cleaned and per-type counts in
+6. **Document** — log packages cleaned and per-type counts in
    `.agents/sessions/YYYY-MM-DD.md`.
 
 ## Modes
 
 - **default** — code slop, current package, edits applied.
+- **`ui`** — route to `deslop-ui` for UI/design-system slop.
 - **`--changed`** — only the files/hunks this branch introduced (safest for a PR).
 - **`--product`** — add the product-slop pass (copy/UI/UX).
 - **`all`** — sweep every package in a monorepo, each processed separately.

--- a/bundles/dev-workflow/skills/de-slop/references/product-slop.md
+++ b/bundles/dev-workflow/skills/de-slop/references/product-slop.md
@@ -70,7 +70,7 @@ Default shadcn components + a purple/indigo gradient hero = "an AI made this."
 - **Incorrect:** `p-4` here, `p-5` there, `rounded-md` next to `rounded-xl`, ad hoc
   per component.
 - **Correct:** a spacing/radius scale in `@theme`, used consistently. Cross-check with
-  `design-consistency-auditor`.
+  `deslop-ui`.
 
 ### U3 — Missing loading states
 

--- a/commands/deslop.md
+++ b/commands/deslop.md
@@ -9,6 +9,7 @@ copy, default-shadcn UI, missing loading/error states, dead buttons and half-wir
 
 ```bash
 /deslop              # clean code slop in the current package/project
+/deslop ui           # audit/fix UI slop through the deslop-ui skill
 /deslop --changed    # clean only the lines this branch introduced (diff-only)
 /deslop --product    # also strip product slop (copy / UI / UX)
 /deslop all          # sweep every package in a monorepo
@@ -19,18 +20,21 @@ Also reachable as `/refactor deslop`.
 
 ## Workflow
 
-Use the `de-slop` skill.
+Use the `de-slop` skill unless the first argument is `ui`; in that case use
+the `deslop-ui` skill and pass the remaining target or flags through.
 
-1. Detect project structure (monorepo vs single package); in `--changed` mode,
+1. If invoked as `/deslop ui`, route directly to `deslop-ui`. Do not run the
+   code-slop cleanup first.
+2. Detect project structure (monorepo vs single package); in `--changed` mode,
    compute the branch diff (`git diff <merge-base>...HEAD`) and limit edits to those
    files/hunks.
-2. Identify artifacts: console statements, `any`, unused imports/vars, commented-out
+3. Identify artifacts: console statements, `any`, unused imports/vars, commented-out
    code, debug code, redundant comments, defensive try-catch on trusted paths,
    over-nesting. With `--product`, also the copy/UI/UX slop from the skill's
    `references/product-slop.md` catalog.
-3. Apply cleanup, replacing console with the project logger and `any` with real
+4. Apply cleanup, replacing console with the project logger and `any` with real
    types; collapse deep nesting into early returns matching the file's style.
-4. Verify: `bun run type-check || bunx tsc --noEmit`, then `bun run test`.
+5. Verify: `bun run type-check || bunx tsc --noEmit`, then `bun run test`.
 
 ## Gates
 

--- a/skills/de-slop/SKILL.md
+++ b/skills/de-slop/SKILL.md
@@ -6,11 +6,12 @@ description: >-
   needless defensive try-catch on trusted paths, over-nesting. Product slop (with
   --product) — marketing-filler copy, generic AI phrasing, default-shadcn look,
   unstyled loading/error states, dead buttons and half-wired flows that make an app
-  feel unfinished. Can scope to the current branch's diff or sweep the whole tree.
-  Use when asked to clean up AI-generated code, remove slop, or make an app feel
-  finished before shipping to customers.
+  feel unfinished. UI slop (`ui`) delegates to deslop-ui for design-system primitive
+  enforcement. Can scope to the current branch's diff or sweep the whole tree. Use
+  when asked to clean up AI-generated code, remove slop, or make an app feel finished
+  before shipping to customers.
 disable-model-invocation: true
-argument-hint: "[--changed | all | dry-run | --product]"
+argument-hint: "[ui | --changed | all | dry-run | --product]"
 metadata:
   version: "1.1.0"
   tags: "code-quality, cleanup, ai-artifacts, product-polish, maintenance"
@@ -31,7 +32,7 @@ diff. For a read-only pass that only flags, use `structural-review` / `/review`.
 Inputs:
 
 - A package or repo to clean; optional scope (`--changed`, `all`, `dry-run`) and
-  dimension (`--product` to add the product pass).
+  dimension (`--product` to add the product pass, `ui` to route to `deslop-ui`).
 
 Outputs:
 
@@ -48,7 +49,8 @@ External Side Effects:
 
 Delegates To:
 
-- `design-consistency-auditor` when product slop is mostly visual inconsistency.
+- `deslop-ui` when invoked with `ui`, or when product slop is primarily design-system,
+  component primitive, or UI consistency drift.
 - `polish` for the final micro-detail pass after the structural slop is gone.
 - `refactor-code` when a fix is a real refactor, not a mechanical strip.
 
@@ -83,11 +85,22 @@ Correct catalog; the three families:
 Product slop needs judgment, not just deletion — flag anything ambiguous rather than
 guessing at intended copy or behavior.
 
+## UI slop (`ui`)
+
+When the first argument is `ui`, stop routing through the code-slop workflow and
+delegate to `deslop-ui`. Pass any remaining target or flags through unchanged.
+
+Use this for design-system primitive enforcement, component consistency, raw UI
+primitive replacement, card/surface drift, arbitrary Tailwind values, duplicate local
+components, visual hierarchy issues, and UI-specific AI slop.
+
 ## Workflow
 
-1. **Detect structure** — monorepo vs single package (`ls packages/ 2>/dev/null`).
+1. **Route UI mode** — if the first argument is `ui`, apply `deslop-ui` and do not
+   run the code cleanup steps below.
+2. **Detect structure** — monorepo vs single package (`ls packages/ 2>/dev/null`).
    Process each package separately.
-2. **Scope** — in `--changed`, limit edits to the branch diff:
+3. **Scope** — in `--changed`, limit edits to the branch diff:
 
    ```bash
    BASE="$(git merge-base HEAD origin/HEAD 2>/dev/null || git merge-base HEAD main 2>/dev/null || git merge-base HEAD master)"
@@ -95,20 +108,21 @@ guessing at intended copy or behavior.
    ```
 
    Touch only those files/hunks; do not clean pre-existing slop elsewhere in this mode.
-3. **Strip code slop** by the categories above; add the product pass if `--product`.
-4. **Verify** — the change must still build and pass:
+4. **Strip code slop** by the categories above; add the product pass if `--product`.
+5. **Verify** — the change must still build and pass:
 
    ```bash
    bun run type-check || bunx tsc --noEmit
    bun run test
    ```
 
-5. **Document** — log packages cleaned and per-type counts in
+6. **Document** — log packages cleaned and per-type counts in
    `.agents/sessions/YYYY-MM-DD.md`.
 
 ## Modes
 
 - **default** — code slop, current package, edits applied.
+- **`ui`** — route to `deslop-ui` for UI/design-system slop.
 - **`--changed`** — only the files/hunks this branch introduced (safest for a PR).
 - **`--product`** — add the product-slop pass (copy/UI/UX).
 - **`all`** — sweep every package in a monorepo, each processed separately.

--- a/skills/de-slop/references/product-slop.md
+++ b/skills/de-slop/references/product-slop.md
@@ -70,7 +70,7 @@ Default shadcn components + a purple/indigo gradient hero = "an AI made this."
 - **Incorrect:** `p-4` here, `p-5` there, `rounded-md` next to `rounded-xl`, ad hoc
   per component.
 - **Correct:** a spacing/radius scale in `@theme`, used consistently. Cross-check with
-  `design-consistency-auditor`.
+  `deslop-ui`.
 
 ### U3 — Missing loading states
 


### PR DESCRIPTION
## Summary
- document `/deslop ui` as the UI-specific deslop entrypoint
- make `de-slop` route `ui` mode directly to `deslop-ui` before code cleanup
- update the product slop catalog to point UI consistency drift at `deslop-ui`
- regenerate the dev-workflow bundle snapshot

## Audit notes
- `design-consistency-auditor` exists, but its detailed guide is stale and product-specific, so it should not be the UI slop engine
- `design-dispatch` is still useful as `/design` routing, but `/deslop ui` should stay under the deslop category

## Verification
- `bun run validate:skill de-slop`
- `bunx markdownlint-cli --ignore bundles --ignore dist --ignore plugins commands/deslop.md skills/de-slop/SKILL.md skills/de-slop/references/product-slop.md`
- `git diff --check`
- commit hooks: markdownlint + changed skill validation
