### PR TITLE
fix(open-source-checker): make connection-string regexes scanner-safe

### DIFF
--- a/bundles/security/skills/open-source-checker/SKILL.md
+++ b/bundles/security/skills/open-source-checker/SKILL.md
@@ -2,7 +2,7 @@
 name: open-source-checker
 description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "open-source, security, secrets"
 ---
 

--- a/bundles/security/skills/open-source-checker/plugin.json
+++ b/bundles/security/skills/open-source-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/security/skills/open-source-checker/references/full-guide.md
+++ b/bundles/security/skills/open-source-checker/references/full-guide.md
@@ -191,17 +191,21 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
+# NOTE: schemes are written as `scheme[:]//` (semantically identical to
+# `scheme://`) so this file itself never contains a URI-shaped literal that
+# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+
 # MongoDB
-mongodb(\+srv)?://[^:]+:[^@]+@[^/]+
+mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
 
 # PostgreSQL
-postgres(ql)?://[^:]+:[^@]+@[^/]+
+postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
 
 # MySQL
-mysql://[^:]+:[^@]+@[^/]+
+mysql[:]//[^:]+:[^@]+@[^/]+
 
 # Redis
-redis://:[^@]+@[^/]+
+redis[:]//:[^@]+@[^/]+
 
 # Generic database URL
 DATABASE_URL.*[=:].*['\"][^'\"]+['\"]

--- a/bundles/workspace/skills/open-source-checker/SKILL.md
+++ b/bundles/workspace/skills/open-source-checker/SKILL.md
@@ -2,7 +2,7 @@
 name: open-source-checker
 description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "open-source, security, secrets"
 ---
 

--- a/bundles/workspace/skills/open-source-checker/plugin.json
+++ b/bundles/workspace/skills/open-source-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/workspace/skills/open-source-checker/references/full-guide.md
+++ b/bundles/workspace/skills/open-source-checker/references/full-guide.md
@@ -191,17 +191,21 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
+# NOTE: schemes are written as `scheme[:]//` (semantically identical to
+# `scheme://`) so this file itself never contains a URI-shaped literal that
+# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+
 # MongoDB
-mongodb(\+srv)?://[^:]+:[^@]+@[^/]+
+mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
 
 # PostgreSQL
-postgres(ql)?://[^:]+:[^@]+@[^/]+
+postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
 
 # MySQL
-mysql://[^:]+:[^@]+@[^/]+
+mysql[:]//[^:]+:[^@]+@[^/]+
 
 # Redis
-redis://:[^@]+@[^/]+
+redis[:]//:[^@]+@[^/]+
 
 # Generic database URL
 DATABASE_URL.*[=:].*['\"][^'\"]+['\"]

--- a/skills/open-source-checker/SKILL.md
+++ b/skills/open-source-checker/SKILL.md
@@ -2,7 +2,7 @@
 name: open-source-checker
 description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "open-source, security, secrets"
 ---
 

--- a/skills/open-source-checker/plugin.json
+++ b/skills/open-source-checker/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/open-source-checker/references/full-guide.md
+++ b/skills/open-source-checker/references/full-guide.md
@@ -191,17 +191,21 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
+# NOTE: schemes are written as `scheme[:]//` (semantically identical to
+# `scheme://`) so this file itself never contains a URI-shaped literal that
+# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+
 # MongoDB
-mongodb(\+srv)?://[^:]+:[^@]+@[^/]+
+mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
 
 # PostgreSQL
-postgres(ql)?://[^:]+:[^@]+@[^/]+
+postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
 
 # MySQL
-mysql://[^:]+:[^@]+@[^/]+
+mysql[:]//[^:]+:[^@]+@[^/]+
 
 # Redis
-redis://:[^@]+@[^/]+
+redis[:]//:[^@]+@[^/]+
 
 # Generic database URL
 DATABASE_URL.*[=:].*['\"][^'\"]+['\"]


### PR DESCRIPTION
The reference guide's example detection regexes (`mysql://[^:]+:[^@]+@[^/]+` etc.) are themselves shaped like live connection URIs, so secret scanners (secretlint, gitleaks) in consuming repos flag the installed skill file and block commits — hit in genfeed.ai's pre-commit secretlint today.

Schemes are now written `scheme[:]//` (semantically identical regex, no URI-shaped literal), with a note explaining why. Version bumped, bundles regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated connection-string pattern examples for MongoDB, PostgreSQL, MySQL, and Redis to avoid triggering secret scanners when included in documentation.
  - Added guidance explaining the revised notation and its equivalence to standard connection-string syntax.

- **Chores**
  - Updated the open-source checker skill and plugin metadata to version 1.0.1 across all supported bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->