### PR TITLE
fix: align Codex instruction surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "agent-config-audit",
       "source": "./skills/agent-config-audit",
-      "description": "Audit and sync AI agent configuration files (CLAUDE.md, CODEX.md, AGENTS.md, .cursorrules, hooks, settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring."
+      "description": "Audit and sync AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring."
     },
     {
       "name": "agent-dispatch",

--- a/bundles/ai-agents/skills/agent-dispatch/SKILL.md
+++ b/bundles/ai-agents/skills/agent-dispatch/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   drift, initialize agent docs, or wire up routing, and the action must be picked
   from an argument like "audit", "config", "init", or "route".
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "agents, dispatcher, architecture, config, setup, routing, orchestration"
   author: Ship Shit Dev
 when_to_use: "/agent, agent audit, config audit, init agent folder, setup agent routing, audit LLM wrappers, check agent config drift, add .agents/ folder, wire up dev-loop routing"
@@ -32,8 +32,9 @@ Outputs:
 
 - For `audit`: a severity-ranked findings report diagnosing LLM wrapper and agent
   failures, with a layer-by-layer fix plan.
-- For `config`: an audit report covering CLAUDE.md, CODEX.md, AGENTS.md,
-  .cursorrules, hooks, and settings, with proposed fixes.
+- For `config`: an audit report covering AGENTS.override.md, AGENTS.md,
+  configured fallbacks, CLAUDE.md, .cursorrules, hooks, and settings, with
+  proposed fixes.
 - For `init`: a scaffolded `.agents/` folder structure plus root agent entry
   files, with a summary of files created versus skipped.
 - For `route`: a drafted `## Agent skills` routing block in CLAUDE.md/AGENTS.md
@@ -92,7 +93,7 @@ the Usage block — do not guess a mode.
 ```bash
 /agent              # status: one-line domain summary + usage
 /agent audit        # diagnose LLM wrapper regressions, prompt/memory contamination, tool discipline failures
-/agent config       # audit and sync CLAUDE.md, CODEX.md, AGENTS.md, hooks, settings across workspaces
+/agent config       # audit and sync AGENTS.md, overrides, fallbacks, CLAUDE.md, hooks, and settings
 /agent init         # scaffold or repair the .agents/ folder and root agent entry files for a repo
 /agent route        # write the ## Agent skills routing block in CLAUDE.md/AGENTS.md + docs/agents/
 ```

--- a/bundles/ai-agents/skills/agent-dispatch/plugin.json
+++ b/bundles/ai-agents/skills/agent-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dispatch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Front door for agent work \u2014 routes audit/config/init/route to the right engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-loop/skills/interview/SKILL.md
+++ b/bundles/dev-loop/skills/interview/SKILL.md
@@ -4,7 +4,7 @@ description: Conducts a repo-grounded discovery interview before PRD writing, fe
 user-invocable: true
 argument-hint: "[topic, feature, issue, or decision]"
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "interview, discovery, requirements, planning"
   author: Ship Shit Dev
 when_to_use: "interview me, grill me, grill-me, grill me with docs, discovery interview, requirements interview, before PRD, clarify requirements, /interview"
@@ -89,8 +89,9 @@ Read repo context before asking questions:
   docs.
 - Check recent `.agents/sessions/` entries only when they are relevant to the
   topic.
-- Read root agent entry files such as `AGENTS.md`, `CLAUDE.md`, or `CODEX.md`
-  for routing and repo rules.
+- Read the applicable `AGENTS.override.md` / `AGENTS.md` chain for routing and
+  repo rules, plus any fallback filename explicitly configured for Codex. Read
+  `CLAUDE.md` when the active workflow is Claude-specific.
 - Search docs, README files, source code, and issues for the topic before
   asking the user to repeat known context.
 

--- a/bundles/dev-loop/skills/interview/plugin.json
+++ b/bundles/dev-loop/skills/interview/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interview",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Repo-grounded discovery interview before PRD, planning, or implementation.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-loop/skills/qa-reviewer/SKILL.md
+++ b/bundles/dev-loop/skills/qa-reviewer/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   multi-step implementations, before committing major refactors, or proactively
   after any task longer than five steps.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "quality-assurance, verification, code-review, accuracy, completeness"
 ---
 
@@ -32,7 +32,9 @@ Structured framework for reviewing AI agent work before finalizing changes. Catc
 
 - Review original task and requirements
 - List all deliverables (files created/modified/deleted)
-- Check critical rules (agent instruction files — `AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global)
+- Check critical rules in the applicable `AGENTS.override.md` / `AGENTS.md`
+  chain and explicitly configured fallback files; include `CLAUDE.md` for
+  Claude-specific rules
 
 ### 2. Requirement Verification
 
@@ -83,7 +85,8 @@ grep -r ": any" <files>
 - [ ] No console.log (use logger)
 - [ ] No `any` types
 - [ ] No inline interfaces
-- [ ] AGENTS/CLAUDE/CODEX files intact
+- [ ] Applicable AGENTS files intact and scoped overrides intentional
+- [ ] Configured fallback instruction files exist and are nonempty
 - [ ] .agents/ folders untouched
 - [ ] Multi-tenancy preserved
 

--- a/bundles/dev-loop/skills/qa-reviewer/plugin.json
+++ b/bundles/dev-loop/skills/qa-reviewer/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-reviewer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Systematically review AI agent work for quality, accuracy, and completeness. Catches bugs, verifies ",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-loop/skills/qa-reviewer/references/full-guide.md
+++ b/bundles/dev-loop/skills/qa-reviewer/references/full-guide.md
@@ -33,7 +33,11 @@ List all changes made:
 
 **1.3 Check Critical Rules**
 
-For projects, ALWAYS verify against repo-level agent instructions (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`, or equivalent) and the user's platform-level instruction file. These are the canonical sources for project rules and "never do" constraints. The harness loads them automatically; read them if you need to reference specific rules during review.
+For projects, ALWAYS verify against the applicable `AGENTS.override.md` /
+`AGENTS.md` chain and the user's platform-level instruction file. Include any
+fallback filename explicitly configured by the active harness and read
+`CLAUDE.md` for Claude-specific rules. These are the canonical sources for
+project rules and "never do" constraints.
 
 ### Phase 2: Requirement Verification
 
@@ -137,7 +141,8 @@ Look for:
 
 **4.3 Project-Specific Violations**
 
-Check against the rules in CLAUDE.md (repo-level and global):
+Check against the applicable `AGENTS.override.md` / `AGENTS.md` chain and
+Claude-specific `CLAUDE.md` when relevant:
 
 ```
 Violations to check:
@@ -148,7 +153,8 @@ Violations to check:
 [ ] No serializers in API repo
 [ ] No test execution locally
 [ ] Multi-tenancy enforced
-[ ] AGENTS.md/CLAUDE.md/CODEX.md not deleted
+[ ] Applicable AGENTS.md / AGENTS.override.md files not deleted
+[ ] Explicitly configured fallback instruction files exist and are nonempty
 [ ] .agents/ folders not deleted
 ```
 
@@ -257,7 +263,7 @@ Minor:
 
 ## Project Rules Compliance
 
-CLAUDE.md rules checked:
+Applicable project instructions checked:
 
 - No console.log violations
 - No `any` types added

--- a/bundles/dev-workflow/skills/agent-config-audit/SKILL.md
+++ b/bundles/dev-workflow/skills/agent-config-audit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agent-config-audit
-description: Audit and sync AI agent configuration files (CLAUDE.md, CODEX.md, AGENTS.md, .cursorrules, hooks, settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring.
+description: Audit and sync AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring.
 metadata:
-  version: "1.0.0"
-  tags: audit, claude-md, codex-md, agents-md, config, documentation, maintenance
-  triggers: audit CLAUDE.md, agent config audit, sync agent configs, check CLAUDE.md, docs out of date, rules duplicated, config drift, stale cursorrules, CODEX.md outdated, agent config maintenance
+  version: "1.1.0"
+  tags: audit, claude-md, agents-md, config, documentation, maintenance
+  triggers: audit AGENTS.md, audit CLAUDE.md, agent config audit, sync agent configs, check AGENTS.md, docs out of date, rules duplicated, config drift, stale cursorrules, agent config maintenance
 allowed-tools:
 - Read
 - Write
@@ -22,7 +22,7 @@ allowed-tools:
 Inputs:
 
 - Workspace root
-- Scope: full, dedup, stale, codex, cursor, settings, or fix
+- Scope: full, dedup, stale, instructions, cursor, settings, or fix
 - Optional list of repos/config files to include
 
 Outputs:
@@ -74,7 +74,7 @@ Delegates To:
 | Input | Required | Description |
 |-------|----------|-------------|
 | Workspace root | Yes | Path to the workspace containing repos (auto-detected from cwd) |
-| Scope | No | `full` (all checks) or specific: `dedup`, `stale`, `codex`, `cursor`, `settings` |
+| Scope | No | `full` (all checks) or specific: `dedup`, `stale`, `instructions`, `cursor`, `settings` |
 | Fix mode | No | `report` (default, read-only) or `fix` (apply recommended changes) |
 
 ## Workflow
@@ -86,7 +86,7 @@ Scan the workspace for every agent config file:
 ```bash
 # Find all agent config files across workspace (including sub-repos)
 glob "**/CLAUDE.md"
-glob "**/CODEX.md"
+glob "**/AGENTS.override.md"
 glob "**/AGENTS.md"
 glob "**/.cursorrules"
 glob "**/.cursor/rules"
@@ -102,8 +102,9 @@ Build an inventory table:
 | Layer           | Files Found | Total Lines |
 |-----------------|-------------|-------------|
 | CLAUDE.md       | N           | N           |
-| CODEX.md        | N           | N           |
+| AGENTS.override.md | N        | N           |
 | AGENTS.md       | N           | N           |
+| Configured fallbacks | N      | N           |
 | .cursorrules    | N           | N           |
 | .claude/ config | N           | N           |
 | .agents/memory/ | N           | N           |
@@ -115,14 +116,14 @@ These rules commonly appear in multiple places. Search for each across ALL confi
 
 **Rules to check:**
 
-- `any` types / `No any` — should be in CLAUDE.md + hooks only
-- `console.log` / logger — should be in CLAUDE.md only
-- Conventional commits — should be in CLAUDE.md only
-- AbortController — should be in CLAUDE_RULES.md / repo CLAUDE.md only
+- `any` types / `No any` — should be in AGENTS.md + hooks only
+- `console.log` / logger — should be in AGENTS.md only
+- Conventional commits — should be in AGENTS.md only
+- AbortController — should be in AGENTS.md or a linked `.agents/memory/` topic only
 - Session file naming — should be in hooks.json + one doc reference only
-- Import order — should be in CLAUDE_RULES.md only
-- Soft delete (`isDeleted`) — should be in CRITICAL-NEVER-DO.md only
-- Multi-tenancy (`organization: orgId`) — should be in CRITICAL-NEVER-DO.md only
+- Import order — should be in AGENTS.md or `.agents/memory/coding-standards.md` only
+- Soft delete (`isDeleted`) — should be in `.agents/memory/data-guardrails.md` only
+- Multi-tenancy (`organization: orgId`) — should be in `.agents/memory/security.md` only
 
 For each rule, count occurrences:
 
@@ -153,19 +154,22 @@ grep -r "/Users/" across .agents/ config files
 **Flag**: Any hardcoded absolute path in config files.
 **Flag**: Any reference to a directory that doesn't exist.
 
-### Step 4: CODEX.md Value Check
+### Step 4: Codex Instruction Resolution Check
 
-For each CODEX.md, check if it has:
+For each workspace, check the instruction chain Codex actually resolves:
 
-- [ ] Codex-specific constraints (sandbox, no network, no interactive)
-- [ ] Repo-specific entry points (key files to read first)
-- [ ] NOT just "read CLAUDE.md" (that's a zero-value redirect stub)
+- [ ] Each directory resolves at most one nonempty instruction file in this order: `AGENTS.override.md`, `AGENTS.md`, then configured fallback filenames
+- [ ] The instruction chain is read from the project root down to the working directory
+- [ ] `AGENTS.override.md` is used only where a subtree intentionally replaces the same-directory `AGENTS.md`
+- [ ] `AGENTS.md` contains repo-specific rules and entry points
+- [ ] Any fallback filenames are explicitly declared in the effective `.codex/config.toml`
+- [ ] Runtime approval, sandbox, and network policy lives in the effective `.codex/config.toml` or hooks, not in assumed prose
 
-```bash
-grep -l "Codex-Specific\|sandbox\|no network\|No network" across all CODEX.md files
-```
+Read the effective Codex configuration and record
+`project_doc_fallback_filenames` plus any runtime policy before judging the
+instruction chain.
 
-**Flag**: Any CODEX.md without Codex-specific guidance.
+**Flag**: Undocumented fallback files, accidental overrides, or instruction files that contradict runtime configuration.
 
 ### Step 5: AGENTS.md Consistency Check
 
@@ -219,9 +223,9 @@ Output format:
 | File | Last Updated | Days Stale |
 |------|-------------|------------|
 
-## Moderate: Low-Value CODEX.md
-| File | Lines | Has Codex Constraints | Has Entry Points |
-|------|-------|----------------------|------------------|
+## Moderate: Instruction Resolution Drift
+| Workspace | Override | AGENTS.md | Configured Fallbacks | Runtime Policy Location |
+|-----------|----------|-----------|----------------------|-------------------------|
 
 ## Moderate: Stub AGENTS.md
 | File | Lines | Has Repo Context |
@@ -245,7 +249,8 @@ If user requested `fix` mode, apply changes following these principles:
 - Strip emoji from all config files
 - Update all "Last Updated" dates
 - Replace hardcoded paths with relative references
-- Expand zero-value CODEX.md stubs with Codex-specific constraints
+- Consolidate project instructions into AGENTS.md and scoped AGENTS.override.md files
+- Move runtime approval, sandbox, and network policy into the effective `.codex/config.toml` or hooks
 
 ## Reference Files
 
@@ -256,12 +261,12 @@ If user requested `fix` mode, apply changes following these principles:
 
 | DON'T | DO | Why |
 |-------|-----|-----|
-| Repeat the same rule in CLAUDE.md, RULES.md, CRITICAL-NEVER-DO.md, and hooks | Put the rule in ONE canonical file; others reference it | Duplication wastes context tokens and creates drift when one copy gets updated but others don't |
+| Repeat the same rule in AGENTS.md, CLAUDE.md, `.agents/memory/`, and hooks | Put the rule in ONE canonical file; others reference it | Duplication wastes context tokens and creates drift when one copy gets updated but others don't |
 | Leave "Last Updated: 2025-10-07" in a file touched in 2026 | Update dates when modifying any config file | Stale dates signal neglect and erode trust in the config system |
-| Write CODEX.md that just says "read CLAUDE.md" | Add Codex-specific constraints (sandbox, no network) and key entry points | Codex runs sandboxed — it needs different guidance than Claude Code |
+| Create an extra instruction filename without configuring it | Put shared project guidance in AGENTS.md; use AGENTS.override.md for scoped overrides and configure any genuine fallback in the effective `.codex/config.toml` | Codex resolves native instruction names plus explicitly configured fallbacks |
 | Use emoji in config headers | Use plain text headers | Emoji waste tokens on every context load and violate "no emoji unless requested" |
 | Hardcode `/Users/username/path/` in config files | Use relative paths or describe location generically | Hardcoded paths break when workspace moves or another developer joins |
-| Add new rules to CRITICAL-NEVER-DO.md that are positive standards | Keep CRITICAL-NEVER-DO.md for violations only; positive standards go in CLAUDE.md or RULES.md | Mixing positive and negative rules in the same file dilutes the "NEVER DO" signal |
+| Recreate a parallel legacy instruction tree under `.agents/` | Put durable guardrails in topic files under `.agents/memory/`; put shared actionable rules in AGENTS.md | The current memory layout keeps durable context discoverable without parallel hierarchies |
 
 ## Validation
 
@@ -269,7 +274,8 @@ After running the audit:
 
 - [ ] No rule appears in more than 2 config files
 - [ ] All `.cursorrules` files have "Last Updated" within 90 days
-- [ ] Every CODEX.md has Codex-specific sandbox guidance
+- [ ] Every Codex instruction file is native (`AGENTS.override.md` or `AGENTS.md`) or an explicitly configured fallback
+- [ ] Runtime approval, sandbox, and network claims match the effective `.codex/config.toml` or hooks
 - [ ] No hardcoded absolute paths in any config file
 - [ ] No emoji in `.cursorrules` or `.cursor/rules` headers
 - [ ] Denied skills in settings.json have documented rationale

--- a/bundles/dev-workflow/skills/agent-config-audit/plugin.json
+++ b/bundles/dev-workflow/skills/agent-config-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-config-audit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Audit and sync AI agent config files, hooks, settings, and workspace rules.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/agent-config-audit/references/canonical-ownership.md
+++ b/bundles/dev-workflow/skills/agent-config-audit/references/canonical-ownership.md
@@ -6,37 +6,35 @@ Each rule should live in ONE file. Other files may reference it but should not r
 
 | Rule | Canonical Home | May Reference | Runtime Enforcement |
 |------|---------------|---------------|---------------------|
-| No `any` types | `CLAUDE.md` (cross-repo rules) | Per-repo CLAUDE.md (brief mention OK) | hooks.json |
-| No `console.log` | `CLAUDE.md` (cross-repo rules) | Per-repo CLAUDE.md (brief mention OK) | — |
-| Path aliases over relative imports | `CLAUDE.md` (cross-repo rules) | — | — |
-| Conventional commits | `CLAUDE.md` (cross-repo rules) | — | — |
-| Never commit secrets | `CLAUDE.md` (cross-repo rules) | — | — |
-| Import order (detailed) | `CLAUDE_RULES.md` (global rules) | — | — |
-| AbortController in useEffect | `CLAUDE_RULES.md` (global rules) | CRITICAL-NEVER-DO.md (one-liner) | — |
-| Session file naming | hooks.json (runtime) | CRITICAL-NEVER-DO.md (one mention) | hooks.json |
-| Multi-tenancy (org filter) | `CRITICAL-NEVER-DO.md` | Per-repo CLAUDE.md (brief mention OK) | — |
-| Soft delete (isDeleted) | `CRITICAL-NEVER-DO.md` | — | — |
-| Serializer location | `CRITICAL-NEVER-DO.md` | Per-repo CLAUDE.md (brief mention OK) | — |
-| No inline interfaces | `CRITICAL-NEVER-DO.md` | — | — |
-| Naming conventions | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
-| Function declaration style | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
-| Testing standards | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
-| Performance patterns | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
+| No `any` types | `AGENTS.md` (cross-agent rule) | Scoped AGENTS.md (brief mention OK) | hooks.json |
+| No `console.log` | `AGENTS.md` (cross-agent rule) | Scoped AGENTS.md (brief mention OK) | — |
+| Path aliases over relative imports | `AGENTS.md` (cross-agent rule) | — | — |
+| Conventional commits | `AGENTS.md` (cross-agent rule) | — | — |
+| Never commit secrets | `AGENTS.md` (cross-agent rule) | `.agents/memory/security.md` (detail) | hooks.json |
+| Import order (detailed) | `.agents/memory/coding-standards.md` | AGENTS.md (brief mention OK) | — |
+| AbortController in useEffect | `.agents/memory/coding-standards.md` | AGENTS.md (brief mention OK) | — |
+| Session file naming | hooks.json (runtime) | AGENTS.md (one mention) | hooks.json |
+| Multi-tenancy (org filter) | `.agents/memory/security.md` | AGENTS.md (brief mention OK) | — |
+| Soft delete (isDeleted) | `.agents/memory/data-guardrails.md` | AGENTS.md (brief mention OK) | — |
+| Serializer location | `.agents/memory/architecture.md` | AGENTS.md (brief mention OK) | — |
+| No inline interfaces | `.agents/memory/coding-standards.md` | AGENTS.md (brief mention OK) | — |
+| Naming conventions | `AGENTS.md` (repo-level) | `.agents/memory/coding-standards.md` (detail) | — |
+| Function declaration style | `AGENTS.md` (repo-level) | `.agents/memory/coding-standards.md` (detail) | — |
+| Testing standards | `AGENTS.md` (repo-level) | `.agents/memory/testing.md` (detail) | — |
+| Performance patterns | `AGENTS.md` (repo-level) | `.agents/memory/performance.md` (detail) | — |
 
 ## File Roles
 
 | File | Role | Contains |
 |------|------|----------|
-| `CLAUDE.md` (root) | Workspace overview | Cross-repo "do this" rules, repo table, agent behavior |
-| `CLAUDE.md` (per-repo) | Repo-specific guide | Tech stack, commands, repo-specific rules, architecture |
-| `CLAUDE_RULES.md` (global) | Behavioral preferences | Tool usage, code standards detail, session management |
-| `CRITICAL-NEVER-DO.md` | Violations only | "NEVER do X" rules with examples of what breaks |
-| `.agents/memory/*.md` | Durable project facts | Architecture, naming conventions, gotchas, extended standards — details beyond CLAUDE.md |
-| `CODEX.md` | Codex-specific | Sandbox constraints, key entry points, no-network notes |
-| `AGENTS.md` | Generic agent nav | Entry points for any AI agent (Cursor, Copilot, etc.) |
+| `AGENTS.md` (root or scoped) | Native shared instructions | Workspace overview, commands, repo rules, navigation |
+| `AGENTS.override.md` | Native scoped override | Intentional replacement guidance for one subtree |
+| `CLAUDE.md` | Claude-specific additions | Claude-only behavior that does not belong in shared instructions |
+| `.agents/memory/*.md` | Durable project facts | Architecture, naming conventions, gotchas, and extended standards linked from AGENTS.md |
 | `.cursorrules` | Cursor-specific | Project navigation, reading order, .agents/ structure |
 | `hooks.json` | Runtime enforcement | Catches violations at tool-call time (session files, any types, tests) |
-| `settings.json` | Permission control | Denied skills, MCP config |
+| Effective `.codex/config.toml` | Codex runtime configuration | Fallback instruction filenames, approvals, sandbox and network policy |
+| `settings.json` | Claude permission control | Denied skills, MCP config |
 
 ## Referencing vs Repeating
 

--- a/bundles/dev-workflow/skills/agent-config-audit/references/healthy-config-example.md
+++ b/bundles/dev-workflow/skills/agent-config-audit/references/healthy-config-example.md
@@ -4,7 +4,7 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 
 ## Root Level
 
-### CLAUDE.md (~80 lines)
+### AGENTS.md (~80 lines)
 
 - Workspace overview (repo table)
 - Cross-repo rules (5-7 rules, one line each)
@@ -12,17 +12,20 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 - Self-correction protocol
 - Learned Rules section (seeded, actively used)
 
-### CODEX.md (~30-40 lines)
+### AGENTS.override.md (only when needed)
 
-- Codex-specific constraints (sandbox, no network, no interactive)
-- Quick nav to critical docs
-- Cross-repo rules (brief, for context since Codex can't load CLAUDE.md hierarchy)
+- Scoped replacement guidance for a subtree with genuinely different rules
+- Omitted when normal AGENTS.md inheritance is sufficient
 
-### AGENTS.md (~15-20 lines)
+### CLAUDE.md (optional)
 
-- Brief workspace description
-- Navigation to `.agents/README.md` and CLAUDE.md
-- Links to priority reading
+- Claude-specific additions only
+- References AGENTS.md instead of repeating shared project rules
+
+### Effective .codex/config.toml (when runtime customization is needed)
+
+- Explicit fallback instruction filenames, if any
+- Approval, sandbox, and network policy for this runtime
 
 ### .cursor/rules (~100-130 lines)
 
@@ -46,7 +49,7 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 
 ## Per-Repo Level
 
-### CLAUDE.md (~50-150 lines)
+### AGENTS.md (~50-150 lines)
 
 - Tech stack
 - Commands (dev, build, test, lint)
@@ -55,16 +58,10 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 - Learned Rules section (seeded)
 - Does NOT repeat full cross-repo rules from root
 
-### CODEX.md (~20-30 lines)
+### CLAUDE.md (optional, concise)
 
-- Codex-specific notes (what won't work in sandbox)
-- Key entry points (3-5 most important files)
-- Links to CLAUDE.md and .agents/
-
-### AGENTS.md (~15-30 lines)
-
-- Repo description with tech context (not just "docs in .agents/")
-- Links to project `.agents/` and workspace `.agents/`
+- Claude-specific additions not shared by other agents
+- Links to AGENTS.md and `.agents/memory/`
 
 ### .cursorrules (~60-70 lines)
 
@@ -79,7 +76,7 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 |--------|---------|---------|----------|
 | Max rule occurrences | 2 | 3 | 4+ |
 | Stale files (> 90 days) | 0 | 1-2 | 3+ |
-| Zero-value CODEX.md stubs | 0 | 1-2 | 3+ |
+| Unconfigured instruction fallbacks | 0 | 1 | 2+ |
 | Emoji in config headers | 0 | 1-5 | 6+ |
 | Hardcoded absolute paths | 0 | 1 | 2+ |
 | Undocumented denied skills | 0 | 1-3 | 4+ |

--- a/bundles/infrastructure/skills/security-expert/SKILL.md
+++ b/bundles/infrastructure/skills/security-expert/SKILL.md
@@ -2,7 +2,7 @@
 name: security-expert
 description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "security, owasp, application-security"
 ---
 
@@ -22,7 +22,7 @@ metadata:
 ## Project Context Discovery
 
 1. Check `.agents/memory/` for security architecture notes and project facts
-2. Review the agent instruction files (`AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global) for security rules and "never do" constraints
+2. Review the applicable `AGENTS.override.md` / `AGENTS.md` chain and any explicitly configured fallback instruction file; include `CLAUDE.md` only for Claude-specific rules
 3. Identify security patterns and tools
 4. Check for `[project]-security-expert` skill
 

--- a/bundles/infrastructure/skills/security-expert/plugin.json
+++ b/bundles/infrastructure/skills/security-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-expert",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and se",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/planning/skills/interview/SKILL.md
+++ b/bundles/planning/skills/interview/SKILL.md
@@ -4,7 +4,7 @@ description: Conducts a repo-grounded discovery interview before PRD writing, fe
 user-invocable: true
 argument-hint: "[topic, feature, issue, or decision]"
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "interview, discovery, requirements, planning"
   author: Ship Shit Dev
 when_to_use: "interview me, grill me, grill-me, grill me with docs, discovery interview, requirements interview, before PRD, clarify requirements, /interview"
@@ -89,8 +89,9 @@ Read repo context before asking questions:
   docs.
 - Check recent `.agents/sessions/` entries only when they are relevant to the
   topic.
-- Read root agent entry files such as `AGENTS.md`, `CLAUDE.md`, or `CODEX.md`
-  for routing and repo rules.
+- Read the applicable `AGENTS.override.md` / `AGENTS.md` chain for routing and
+  repo rules, plus any fallback filename explicitly configured for Codex. Read
+  `CLAUDE.md` when the active workflow is Claude-specific.
 - Search docs, README files, source code, and issues for the topic before
   asking the user to repeat known context.
 

--- a/bundles/planning/skills/interview/plugin.json
+++ b/bundles/planning/skills/interview/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interview",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Repo-grounded discovery interview before PRD, planning, or implementation.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/planning/skills/rules-capture/SKILL.md
+++ b/bundles/planning/skills/rules-capture/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   rule is", "stop doing X", "I prefer", frustration indicators, or any
   correction to AI behavior.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "preferences, rules, documentation, automation"
 ---
 
@@ -154,7 +154,9 @@ Should I add this to the permanent rules? [Yes/No/Modify]
 
 ### 5. On Confirmation
 - **Personal preferences** → append to the user's platform-level instruction file under the appropriate section
-- **Project coding standards** → append to the repo-level agent instruction file (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`, or equivalent)
+- **Shared project coding standards** → append to the applicable `AGENTS.md`
+- **Scoped project overrides** → use `AGENTS.override.md` only when inherited guidance must be replaced for a subtree
+- **Claude-specific behavior** → append to `CLAUDE.md`
 - **Durable project facts** (architecture, deployment notes, gotchas) → add/update a file in `.agents/memory/`
 - Remove the entry from `.agents/memory/captured-rules.md` (or mark it PROCESSED)
 

--- a/bundles/planning/skills/rules-capture/plugin.json
+++ b/bundles/planning/skills/rules-capture/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rules-capture",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Automatically detects and documents user preferences, coding rules, and style guidelines when expres",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/security/skills/security-expert/SKILL.md
+++ b/bundles/security/skills/security-expert/SKILL.md
@@ -2,7 +2,7 @@
 name: security-expert
 description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "security, owasp, application-security"
 ---
 
@@ -22,7 +22,7 @@ metadata:
 ## Project Context Discovery
 
 1. Check `.agents/memory/` for security architecture notes and project facts
-2. Review the agent instruction files (`AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global) for security rules and "never do" constraints
+2. Review the applicable `AGENTS.override.md` / `AGENTS.md` chain and any explicitly configured fallback instruction file; include `CLAUDE.md` only for Claude-specific rules
 3. Identify security patterns and tools
 4. Check for `[project]-security-expert` skill
 

--- a/bundles/security/skills/security-expert/plugin.json
+++ b/bundles/security/skills/security-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-expert",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and se",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/session/skills/agent-folder-init/SKILL.md
+++ b/bundles/session/skills/agent-folder-init/SKILL.md
@@ -2,7 +2,7 @@
 name: agent-folder-init
 description: Add or repair .agents/ project context for an existing repo. Use for AI agent documentation, session tracking, task management, and coding standards; do not use as the primary new-product scaffold.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "agents, setup, documentation"
 ---
 
@@ -19,7 +19,7 @@ Inputs:
 Outputs:
 
 - `.agents/` documentation structure
-- Root agent entry files such as `AGENTS.md`, `CLAUDE.md`, and `CODEX.md`
+- Root `AGENTS.md` for shared project instructions and `CLAUDE.md` for Claude-specific additions
 - Summary of files created and files skipped because they already existed
 
 Creates/Modifies:
@@ -94,7 +94,10 @@ python3 scripts/scaffold.py \
     └── TEMPLATE.md              # Session file template
 ```
 
-**Rules and coding standards** go in the repo's agent entry file (`AGENTS.md`, `CLAUDE.md`, or `CODEX.md`) and the user's platform-level instruction file — not inside `.agents/`.
+**Shared rules and coding standards** go in the applicable `AGENTS.md`. Use
+`AGENTS.override.md` only for an intentional subtree override and `CLAUDE.md`
+only for Claude-specific additions. Durable supporting detail belongs in
+`.agents/memory/`.
 
 **Task tracking** uses GitHub Issues (`gh issue list`, `gh issue create`) — not local task files.
 
@@ -132,9 +135,8 @@ python3 scripts/scaffold.py \
 
 ### Root Files
 
-- `AGENTS.md` - Points to `.agents/README.md`
-- `CLAUDE.md` - Claude-specific entry point
-- `CODEX.md` - Codex-specific entry point
+- `AGENTS.md` - Shared project instructions and `.agents/` navigation
+- `CLAUDE.md` - Claude-specific additions that reference `AGENTS.md`
 - `.editorconfig` - Editor configuration
 
 ## Key Patterns

--- a/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/README.md
+++ b/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/README.md
@@ -114,7 +114,8 @@ All commands assume this lean structure:
 └── sessions/    ← daily logs YYYY-MM-DD.md
 ```
 
-**Rules are in CLAUDE.md** (repo-level + global `~/.claude/CLAUDE.md`), loaded automatically.
+**Shared rules are in AGENTS.md**; `AGENTS.override.md` is a scoped replacement
+and `CLAUDE.md` contains only Claude-specific additions.
 **Tasks live in GitHub Issues** (`gh issue list`, `gh issue create`).
 **No SYSTEM/, TASKS/, PRDS/, SOP/, or EXAMPLES/ directories.**
 
@@ -161,7 +162,7 @@ Follow the naming convention:
 
 - Commands use the lean `.agents/` structure (memory/ + sessions/ only)
 - Task management goes through GitHub Issues — no local task files
-- Project rules and preferences live in CLAUDE.md (repo-level + global)
+- Shared project rules and preferences live in AGENTS.md; Claude-only additions live in CLAUDE.md
 - Only project paths need adaptation (`[frontend-project]`, `[backend-project]`)
 - Security checks in `/code-review` are configurable — adapt to your requirements
 

--- a/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/docs-update.md
+++ b/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/docs-update.md
@@ -8,11 +8,10 @@ This command ensures comprehensive tracking of all work, decisions, and context 
 
 **NEVER CREATE .MD FILES AT WORKSPACE ROOT LEVEL**
 
-**ONLY 4 files allowed at root:**
+**ONLY 3 files allowed at root:**
 
 - `AGENTS.md` - Navigation file
-- `CLAUDE.md` - AI agent config
-- `CODEX.md` - AI agent config
+- `CLAUDE.md` - Claude-specific additions
 - `README.md` - Project README
 
 **FORBIDDEN at root:**
@@ -33,7 +32,7 @@ This command ensures comprehensive tracking of all work, decisions, and context 
 
 **BEFORE creating ANY .md file, ask yourself:**
 
-1. Is this AGENTS.md, CLAUDE.md, CODEX.md, or README.md?
+1. Is this AGENTS.md, CLAUDE.md, or README.md?
    - NO → It goes in `.agents/` folder
    - YES → Only update, never recreate
 

--- a/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/new-cmd.md
+++ b/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/new-cmd.md
@@ -513,7 +513,7 @@ gh run watch
 ## Monorepo Structure
 
 Protected files across ALL projects:
-- `AGENTS.md`, `CLAUDE.md`, `CODEX.md` (MANDATORY in each project root)
+- `AGENTS.md` (shared instructions) and `CLAUDE.md` when Claude-specific additions are needed
 - `**/.agents/**` (All documentation)
 - `**/README.md` (Standard docs)
 
@@ -597,7 +597,7 @@ ls .cursor/commands/
 
 **Common patterns used:**
 
-1. **Check CRITICAL rules first** - Always reference CLAUDE.md (repo + global)
+1. **Check critical rules first** - Read the applicable AGENTS.md chain and Claude-specific CLAUDE.md when relevant
 2. **Never run tests locally** - Push to GitHub Actions instead
 3. **Monorepo-aware** - Handle multiple packages correctly
 4. **GitHub Actions integration** - Use `gh` CLI for CI/CD

--- a/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/scaffold.md
+++ b/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/scaffold.md
@@ -79,7 +79,7 @@ If components were scaffolded, verify:
 
 - Files were created successfully
 - Directory structure is correct
-- Entry files (AGENTS.md, CLAUDE.md, CODEX.md) exist
+- Shared `AGENTS.md` exists; `CLAUDE.md` exists when Claude-specific additions are requested
 
 ## Example Workflow
 

--- a/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/start.md
+++ b/bundles/session/skills/agent-folder-init/assets/agent-configs/cursor/commands/start.md
@@ -12,7 +12,9 @@ Scan `.agents/memory/` to load durable project context. Each file covers one top
 ls .agents/memory/
 ```
 
-Read the files most relevant to today's work. Rules and preferences are already loaded from CLAUDE.md (repo-level) and the global `~/.claude/CLAUDE.md`; no separate preferences file needed.
+Read the files most relevant to today's work. Shared rules and preferences live
+in the applicable `AGENTS.md` chain; read `CLAUDE.md` only for Claude-specific
+additions. No separate preferences file is needed.
 
 ### 2. Read Today's Session File
 

--- a/bundles/session/skills/agent-folder-init/assets/templates/README.md
+++ b/bundles/session/skills/agent-folder-init/assets/templates/README.md
@@ -26,7 +26,7 @@ This is the `.agents/` folder — source of truth for AI agent context, session 
 
 ### During Work
 
-- Follow coding standards in `CLAUDE.md` (repo root) and `~/.claude/CLAUDE.md`
+- Follow shared coding standards in the applicable `AGENTS.md`; include `CLAUDE.md` only for Claude-specific additions
 - Document significant decisions in `.agents/memory/<topic>.md`
 - Track new work items as GitHub Issues
 
@@ -46,8 +46,9 @@ Multiple sessions on the same day go in the same file as Session 1, Session 2, e
 
 Coding standards, "never do" rules, and user preferences live in:
 
-- `CLAUDE.md` (repo root) — project-specific rules
-- `~/.claude/CLAUDE.md` — global rules (all projects)
+- `AGENTS.md` (repo root or nearest parent) — shared project instructions
+- `AGENTS.override.md` — scoped replacement instructions, only where intentionally present
+- `CLAUDE.md` — Claude-specific additions
 
 Do not duplicate rules inside `.agents/`.
 

--- a/bundles/session/skills/agent-folder-init/plugin.json
+++ b/bundles/session/skills/agent-folder-init/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-folder-init",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Initialize a project .agents folder for AI-first development workflows.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/session/skills/agent-folder-init/scripts/scaffold.py
+++ b/bundles/session/skills/agent-folder-init/scripts/scaffold.py
@@ -109,7 +109,7 @@ This is the `.agents/` folder — source of truth for AI agent context, session 
 
 ## For AI Agents
 
-- **Rules / coding standards:** see `CLAUDE.md` (repo root + global `~/.claude/CLAUDE.md`)
+- **Shared rules / coding standards:** see `AGENTS.md`; read `CLAUDE.md` only for Claude-specific additions
 - **Task tracking:** GitHub Issues (`gh issue list`)
 - **Durable context:** read `.agents/memory/` files before starting work
 
@@ -125,11 +125,11 @@ This is the `.agents/` folder — source of truth for AI agent context, session 
 
 
 def create_entry_files(root: Path, project_name: str) -> None:
-    """Create AGENTS.md, CLAUDE.md, CODEX.md at project root."""
+    """Create AGENTS.md and CLAUDE.md at project root."""
 
     agents_content = f"""# {project_name}
 
-This file provides entry points for AI agents.
+Shared project instructions for AI agents, including Codex.
 
 ## Documentation
 
@@ -141,7 +141,7 @@ All durable project context is in `.agents/memory/`. Session logs are in `.agent
 
 ## Rules & Standards
 
-Coding standards and "never do" rules live in `CLAUDE.md` (this file) and the global `~/.claude/CLAUDE.md`. Do not duplicate them in `.agents/`.
+Shared coding standards and "never do" rules live in this file. Durable supporting detail belongs in `.agents/memory/`; runtime policy belongs in agent configuration or hooks.
 
 ## Task Tracking
 
@@ -154,7 +154,7 @@ Document all work in `.agents/sessions/YYYY-MM-DD.md` (one file per day).
 
     claude_content = f"""# {project_name}
 
-Claude-specific entry point.
+Claude-specific additions. Read `AGENTS.md` first for shared project instructions.
 
 ## Context
 
@@ -169,28 +169,11 @@ Document all work in `.agents/sessions/YYYY-MM-DD.md` (one file per day).
 Use GitHub Issues: `gh issue list`, `gh issue create`.
 """
 
-    codex_content = f"""# {project_name}
-
-Codex-specific entry point.
-
-## Documentation
-
-- `.agents/README.md` - Start here
-- `.agents/memory/` - Durable project facts (source of truth)
-- `.agents/sessions/` - Daily session history
-
-## Task Tracking
-
-Use GitHub Issues: `gh issue list`.
-"""
-
     (root / "AGENTS.md").write_text(agents_content)
     (root / "CLAUDE.md").write_text(claude_content)
-    (root / "CODEX.md").write_text(codex_content)
 
     print(f"Created: {root}/AGENTS.md")
     print(f"Created: {root}/CLAUDE.md")
-    print(f"Created: {root}/CODEX.md")
 
 
 def copy_root_files(root: Path) -> None:

--- a/bundles/testing/skills/qa-reviewer/SKILL.md
+++ b/bundles/testing/skills/qa-reviewer/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   multi-step implementations, before committing major refactors, or proactively
   after any task longer than five steps.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "quality-assurance, verification, code-review, accuracy, completeness"
 ---
 
@@ -32,7 +32,9 @@ Structured framework for reviewing AI agent work before finalizing changes. Catc
 
 - Review original task and requirements
 - List all deliverables (files created/modified/deleted)
-- Check critical rules (agent instruction files — `AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global)
+- Check critical rules in the applicable `AGENTS.override.md` / `AGENTS.md`
+  chain and explicitly configured fallback files; include `CLAUDE.md` for
+  Claude-specific rules
 
 ### 2. Requirement Verification
 
@@ -83,7 +85,8 @@ grep -r ": any" <files>
 - [ ] No console.log (use logger)
 - [ ] No `any` types
 - [ ] No inline interfaces
-- [ ] AGENTS/CLAUDE/CODEX files intact
+- [ ] Applicable AGENTS files intact and scoped overrides intentional
+- [ ] Configured fallback instruction files exist and are nonempty
 - [ ] .agents/ folders untouched
 - [ ] Multi-tenancy preserved
 

--- a/bundles/testing/skills/qa-reviewer/plugin.json
+++ b/bundles/testing/skills/qa-reviewer/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-reviewer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Systematically review AI agent work for quality, accuracy, and completeness. Catches bugs, verifies ",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/testing/skills/qa-reviewer/references/full-guide.md
+++ b/bundles/testing/skills/qa-reviewer/references/full-guide.md
@@ -33,7 +33,11 @@ List all changes made:
 
 **1.3 Check Critical Rules**
 
-For projects, ALWAYS verify against repo-level agent instructions (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`, or equivalent) and the user's platform-level instruction file. These are the canonical sources for project rules and "never do" constraints. The harness loads them automatically; read them if you need to reference specific rules during review.
+For projects, ALWAYS verify against the applicable `AGENTS.override.md` /
+`AGENTS.md` chain and the user's platform-level instruction file. Include any
+fallback filename explicitly configured by the active harness and read
+`CLAUDE.md` for Claude-specific rules. These are the canonical sources for
+project rules and "never do" constraints.
 
 ### Phase 2: Requirement Verification
 
@@ -137,7 +141,8 @@ Look for:
 
 **4.3 Project-Specific Violations**
 
-Check against the rules in CLAUDE.md (repo-level and global):
+Check against the applicable `AGENTS.override.md` / `AGENTS.md` chain and
+Claude-specific `CLAUDE.md` when relevant:
 
 ```
 Violations to check:
@@ -148,7 +153,8 @@ Violations to check:
 [ ] No serializers in API repo
 [ ] No test execution locally
 [ ] Multi-tenancy enforced
-[ ] AGENTS.md/CLAUDE.md/CODEX.md not deleted
+[ ] Applicable AGENTS.md / AGENTS.override.md files not deleted
+[ ] Explicitly configured fallback instruction files exist and are nonempty
 [ ] .agents/ folders not deleted
 ```
 
@@ -257,7 +263,7 @@ Minor:
 
 ## Project Rules Compliance
 
-CLAUDE.md rules checked:
+Applicable project instructions checked:
 
 - No console.log violations
 - No `any` types added

--- a/bundles/workspace/skills/fullstack-workspace-init/SKILL.md
+++ b/bundles/workspace/skills/fullstack-workspace-init/SKILL.md
@@ -2,7 +2,7 @@
 name: fullstack-workspace-init
 description: Initialize Shipshit.dev full-stack product workspaces through npx @shipshitdev/v0, then customize and verify the generated repo. Use for new product scaffolds or post-v0 workspace setup.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "fullstack, workspace, v0"
 ---
 

--- a/bundles/workspace/skills/fullstack-workspace-init/plugin.json
+++ b/bundles/workspace/skills/fullstack-workspace-init/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-workspace-init",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Scaffold a production-ready full-stack monorepo with working MVP features, tests, and CI/CD. Generat",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/workspace/skills/fullstack-workspace-init/scripts/init-workspace.py
+++ b/bundles/workspace/skills/fullstack-workspace-init/scripts/init-workspace.py
@@ -176,7 +176,7 @@ def create_agents_md(name: str) -> str:
     return dedent(f"""\
         # {name}
 
-        AI agent entry point. Documentation in `.agents/`.
+        Shared project instructions for AI agents, including Codex. Documentation in `.agents/`.
 
         ## Projects
 
@@ -195,7 +195,7 @@ def create_claude_md(name: str) -> str:
     return dedent(f"""\
         # {name}
 
-        Claude entry point. Rules and coding standards are defined in this file and `~/.claude/CLAUDE.md`.
+        Claude-specific additions. Read `AGENTS.md` first for shared project instructions.
 
         ## Commands
 
@@ -208,14 +208,6 @@ def create_claude_md(name: str) -> str:
         ## Project Context
 
         Durable project facts live in `.agents/memory/`. Session logs are in `.agents/sessions/`.
-    """)
-
-
-def create_codex_md(name: str) -> str:
-    return dedent(f"""\
-        # {name}
-
-        Codex entry point. Documentation in `.agents/`.
     """)
 
 
@@ -1858,7 +1850,6 @@ def scaffold_workspace(
         root / "README.md": create_readme(name),
         root / "AGENTS.md": create_agents_md(name),
         root / "CLAUDE.md": create_claude_md(name),
-        root / "CODEX.md": create_codex_md(name),
 
         # GitHub Actions CI
         root / ".github" / "workflows" / "ci.yml": generate_github_actions_ci(),
@@ -1874,7 +1865,6 @@ def scaffold_workspace(
         root / "api" / "apps" / "api" / "src" / "app.module.ts": app_module_content,
         root / "api" / "AGENTS.md": create_agents_md(f"{name} API"),
         root / "api" / "CLAUDE.md": create_claude_md(f"{name} API"),
-        root / "api" / "CODEX.md": create_codex_md(f"{name} API"),
 
         # Auth files (always generated)
         root / "api" / "apps" / "api" / "src" / "auth" / "guards" / "clerk-auth.guard.ts": generate_clerk_auth_guard(),
@@ -1893,7 +1883,6 @@ def scaffold_workspace(
         root / "frontend" / "apps" / "dashboard" / "app" / "globals.scss": create_frontend_globals_scss(),
         root / "frontend" / "AGENTS.md": create_agents_md(f"{name} Frontend"),
         root / "frontend" / "CLAUDE.md": create_claude_md(f"{name} Frontend"),
-        root / "frontend" / "CODEX.md": create_codex_md(f"{name} Frontend"),
 
         # Mobile
         root / "mobile" / "package.json": create_mobile_package_json(org),
@@ -1903,14 +1892,12 @@ def scaffold_workspace(
         root / "mobile" / "app" / "index.tsx": create_mobile_index_tsx(),
         root / "mobile" / "AGENTS.md": create_agents_md(f"{name} Mobile"),
         root / "mobile" / "CLAUDE.md": create_claude_md(f"{name} Mobile"),
-        root / "mobile" / "CODEX.md": create_codex_md(f"{name} Mobile"),
 
         # Packages
         root / "packages" / "package.json": create_packages_package_json(org),
         root / "packages" / "tsconfig.json": create_packages_tsconfig(),
         root / "packages" / "AGENTS.md": create_agents_md(f"{name} Packages"),
         root / "packages" / "CLAUDE.md": create_claude_md(f"{name} Packages"),
-        root / "packages" / "CODEX.md": create_codex_md(f"{name} Packages"),
     }
 
     for filepath, content in files.items():

--- a/commands/agent.md
+++ b/commands/agent.md
@@ -9,7 +9,7 @@ the `.agents/` folder, or wire up dev-loop routing.
 ```bash
 /agent              # status: one-line domain summary + usage
 /agent audit        # diagnose LLM wrapper regressions, prompt/memory contamination, tool discipline failures
-/agent config       # audit and sync CLAUDE.md, CODEX.md, AGENTS.md, hooks, settings across workspaces
+/agent config       # audit and sync AGENTS.md, overrides, fallbacks, CLAUDE.md, hooks, and settings
 /agent init         # scaffold or repair the .agents/ folder and root agent entry files for a repo
 /agent route        # write the ## Agent skills routing block in CLAUDE.md/AGENTS.md + docs/agents/
 ```
@@ -22,13 +22,13 @@ the `.agents/` folder, or wire up dev-loop routing.
   rendering corruption. Produces a severity-ranked findings report and an ordered
   fix plan.
 - **`config`** — the `agent-config-audit` skill: audit and sync AI agent
-  configuration files (CLAUDE.md, CODEX.md, AGENTS.md, .cursorrules, hooks,
-  settings) across workspaces. Use when agent configs drift, rules duplicate, files
-  go stale, or after workspace restructuring.
+  instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks,
+  CLAUDE.md, .cursorrules, hooks, and settings) across workspaces. Use when agent
+  configs drift, rules duplicate, files go stale, or after workspace restructuring.
 - **`init`** — the `agent-folder-init` skill: add or repair the `.agents/` project
   context for an existing repo. Creates the `.agents/` folder structure plus root
-  agent entry files (AGENTS.md, CLAUDE.md, CODEX.md) without touching application
-  source code.
+  shared AGENTS.md and optional Claude-specific CLAUDE.md without touching
+  application source code.
 - **`route`** — the `setup-agent-routing` skill: write a machine-readable
   `## Agent skills` routing block in CLAUDE.md/AGENTS.md and seed `docs/agents/`
   reference files so the dev-loop skills (executing-plans, feature-intake,

--- a/skills/agent-config-audit/SKILL.md
+++ b/skills/agent-config-audit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: agent-config-audit
-description: Audit and sync AI agent configuration files (CLAUDE.md, CODEX.md, AGENTS.md, .cursorrules, hooks, settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring.
+description: Audit and sync AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring.
 metadata:
-  version: "1.0.0"
-  tags: audit, claude-md, codex-md, agents-md, config, documentation, maintenance
-  triggers: audit CLAUDE.md, agent config audit, sync agent configs, check CLAUDE.md, docs out of date, rules duplicated, config drift, stale cursorrules, CODEX.md outdated, agent config maintenance
+  version: "1.1.0"
+  tags: audit, claude-md, agents-md, config, documentation, maintenance
+  triggers: audit AGENTS.md, audit CLAUDE.md, agent config audit, sync agent configs, check AGENTS.md, docs out of date, rules duplicated, config drift, stale cursorrules, agent config maintenance
 allowed-tools:
 - Read
 - Write
@@ -22,7 +22,7 @@ allowed-tools:
 Inputs:
 
 - Workspace root
-- Scope: full, dedup, stale, codex, cursor, settings, or fix
+- Scope: full, dedup, stale, instructions, cursor, settings, or fix
 - Optional list of repos/config files to include
 
 Outputs:
@@ -74,7 +74,7 @@ Delegates To:
 | Input | Required | Description |
 |-------|----------|-------------|
 | Workspace root | Yes | Path to the workspace containing repos (auto-detected from cwd) |
-| Scope | No | `full` (all checks) or specific: `dedup`, `stale`, `codex`, `cursor`, `settings` |
+| Scope | No | `full` (all checks) or specific: `dedup`, `stale`, `instructions`, `cursor`, `settings` |
 | Fix mode | No | `report` (default, read-only) or `fix` (apply recommended changes) |
 
 ## Workflow
@@ -86,7 +86,7 @@ Scan the workspace for every agent config file:
 ```bash
 # Find all agent config files across workspace (including sub-repos)
 glob "**/CLAUDE.md"
-glob "**/CODEX.md"
+glob "**/AGENTS.override.md"
 glob "**/AGENTS.md"
 glob "**/.cursorrules"
 glob "**/.cursor/rules"
@@ -102,8 +102,9 @@ Build an inventory table:
 | Layer           | Files Found | Total Lines |
 |-----------------|-------------|-------------|
 | CLAUDE.md       | N           | N           |
-| CODEX.md        | N           | N           |
+| AGENTS.override.md | N        | N           |
 | AGENTS.md       | N           | N           |
+| Configured fallbacks | N      | N           |
 | .cursorrules    | N           | N           |
 | .claude/ config | N           | N           |
 | .agents/memory/ | N           | N           |
@@ -115,14 +116,14 @@ These rules commonly appear in multiple places. Search for each across ALL confi
 
 **Rules to check:**
 
-- `any` types / `No any` — should be in CLAUDE.md + hooks only
-- `console.log` / logger — should be in CLAUDE.md only
-- Conventional commits — should be in CLAUDE.md only
-- AbortController — should be in CLAUDE_RULES.md / repo CLAUDE.md only
+- `any` types / `No any` — should be in AGENTS.md + hooks only
+- `console.log` / logger — should be in AGENTS.md only
+- Conventional commits — should be in AGENTS.md only
+- AbortController — should be in AGENTS.md or a linked `.agents/memory/` topic only
 - Session file naming — should be in hooks.json + one doc reference only
-- Import order — should be in CLAUDE_RULES.md only
-- Soft delete (`isDeleted`) — should be in CRITICAL-NEVER-DO.md only
-- Multi-tenancy (`organization: orgId`) — should be in CRITICAL-NEVER-DO.md only
+- Import order — should be in AGENTS.md or `.agents/memory/coding-standards.md` only
+- Soft delete (`isDeleted`) — should be in `.agents/memory/data-guardrails.md` only
+- Multi-tenancy (`organization: orgId`) — should be in `.agents/memory/security.md` only
 
 For each rule, count occurrences:
 
@@ -153,19 +154,22 @@ grep -r "/Users/" across .agents/ config files
 **Flag**: Any hardcoded absolute path in config files.
 **Flag**: Any reference to a directory that doesn't exist.
 
-### Step 4: CODEX.md Value Check
+### Step 4: Codex Instruction Resolution Check
 
-For each CODEX.md, check if it has:
+For each workspace, check the instruction chain Codex actually resolves:
 
-- [ ] Codex-specific constraints (sandbox, no network, no interactive)
-- [ ] Repo-specific entry points (key files to read first)
-- [ ] NOT just "read CLAUDE.md" (that's a zero-value redirect stub)
+- [ ] Each directory resolves at most one nonempty instruction file in this order: `AGENTS.override.md`, `AGENTS.md`, then configured fallback filenames
+- [ ] The instruction chain is read from the project root down to the working directory
+- [ ] `AGENTS.override.md` is used only where a subtree intentionally replaces the same-directory `AGENTS.md`
+- [ ] `AGENTS.md` contains repo-specific rules and entry points
+- [ ] Any fallback filenames are explicitly declared in the effective `.codex/config.toml`
+- [ ] Runtime approval, sandbox, and network policy lives in the effective `.codex/config.toml` or hooks, not in assumed prose
 
-```bash
-grep -l "Codex-Specific\|sandbox\|no network\|No network" across all CODEX.md files
-```
+Read the effective Codex configuration and record
+`project_doc_fallback_filenames` plus any runtime policy before judging the
+instruction chain.
 
-**Flag**: Any CODEX.md without Codex-specific guidance.
+**Flag**: Undocumented fallback files, accidental overrides, or instruction files that contradict runtime configuration.
 
 ### Step 5: AGENTS.md Consistency Check
 
@@ -219,9 +223,9 @@ Output format:
 | File | Last Updated | Days Stale |
 |------|-------------|------------|
 
-## Moderate: Low-Value CODEX.md
-| File | Lines | Has Codex Constraints | Has Entry Points |
-|------|-------|----------------------|------------------|
+## Moderate: Instruction Resolution Drift
+| Workspace | Override | AGENTS.md | Configured Fallbacks | Runtime Policy Location |
+|-----------|----------|-----------|----------------------|-------------------------|
 
 ## Moderate: Stub AGENTS.md
 | File | Lines | Has Repo Context |
@@ -245,7 +249,8 @@ If user requested `fix` mode, apply changes following these principles:
 - Strip emoji from all config files
 - Update all "Last Updated" dates
 - Replace hardcoded paths with relative references
-- Expand zero-value CODEX.md stubs with Codex-specific constraints
+- Consolidate project instructions into AGENTS.md and scoped AGENTS.override.md files
+- Move runtime approval, sandbox, and network policy into the effective `.codex/config.toml` or hooks
 
 ## Reference Files
 
@@ -256,12 +261,12 @@ If user requested `fix` mode, apply changes following these principles:
 
 | DON'T | DO | Why |
 |-------|-----|-----|
-| Repeat the same rule in CLAUDE.md, RULES.md, CRITICAL-NEVER-DO.md, and hooks | Put the rule in ONE canonical file; others reference it | Duplication wastes context tokens and creates drift when one copy gets updated but others don't |
+| Repeat the same rule in AGENTS.md, CLAUDE.md, `.agents/memory/`, and hooks | Put the rule in ONE canonical file; others reference it | Duplication wastes context tokens and creates drift when one copy gets updated but others don't |
 | Leave "Last Updated: 2025-10-07" in a file touched in 2026 | Update dates when modifying any config file | Stale dates signal neglect and erode trust in the config system |
-| Write CODEX.md that just says "read CLAUDE.md" | Add Codex-specific constraints (sandbox, no network) and key entry points | Codex runs sandboxed — it needs different guidance than Claude Code |
+| Create an extra instruction filename without configuring it | Put shared project guidance in AGENTS.md; use AGENTS.override.md for scoped overrides and configure any genuine fallback in the effective `.codex/config.toml` | Codex resolves native instruction names plus explicitly configured fallbacks |
 | Use emoji in config headers | Use plain text headers | Emoji waste tokens on every context load and violate "no emoji unless requested" |
 | Hardcode `/Users/username/path/` in config files | Use relative paths or describe location generically | Hardcoded paths break when workspace moves or another developer joins |
-| Add new rules to CRITICAL-NEVER-DO.md that are positive standards | Keep CRITICAL-NEVER-DO.md for violations only; positive standards go in CLAUDE.md or RULES.md | Mixing positive and negative rules in the same file dilutes the "NEVER DO" signal |
+| Recreate a parallel legacy instruction tree under `.agents/` | Put durable guardrails in topic files under `.agents/memory/`; put shared actionable rules in AGENTS.md | The current memory layout keeps durable context discoverable without parallel hierarchies |
 
 ## Validation
 
@@ -269,7 +274,8 @@ After running the audit:
 
 - [ ] No rule appears in more than 2 config files
 - [ ] All `.cursorrules` files have "Last Updated" within 90 days
-- [ ] Every CODEX.md has Codex-specific sandbox guidance
+- [ ] Every Codex instruction file is native (`AGENTS.override.md` or `AGENTS.md`) or an explicitly configured fallback
+- [ ] Runtime approval, sandbox, and network claims match the effective `.codex/config.toml` or hooks
 - [ ] No hardcoded absolute paths in any config file
 - [ ] No emoji in `.cursorrules` or `.cursor/rules` headers
 - [ ] Denied skills in settings.json have documented rationale

--- a/skills/agent-config-audit/plugin.json
+++ b/skills/agent-config-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-config-audit",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Audit and sync AI agent config files, hooks, settings, and workspace rules.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/agent-config-audit/references/canonical-ownership.md
+++ b/skills/agent-config-audit/references/canonical-ownership.md
@@ -6,37 +6,35 @@ Each rule should live in ONE file. Other files may reference it but should not r
 
 | Rule | Canonical Home | May Reference | Runtime Enforcement |
 |------|---------------|---------------|---------------------|
-| No `any` types | `CLAUDE.md` (cross-repo rules) | Per-repo CLAUDE.md (brief mention OK) | hooks.json |
-| No `console.log` | `CLAUDE.md` (cross-repo rules) | Per-repo CLAUDE.md (brief mention OK) | — |
-| Path aliases over relative imports | `CLAUDE.md` (cross-repo rules) | — | — |
-| Conventional commits | `CLAUDE.md` (cross-repo rules) | — | — |
-| Never commit secrets | `CLAUDE.md` (cross-repo rules) | — | — |
-| Import order (detailed) | `CLAUDE_RULES.md` (global rules) | — | — |
-| AbortController in useEffect | `CLAUDE_RULES.md` (global rules) | CRITICAL-NEVER-DO.md (one-liner) | — |
-| Session file naming | hooks.json (runtime) | CRITICAL-NEVER-DO.md (one mention) | hooks.json |
-| Multi-tenancy (org filter) | `CRITICAL-NEVER-DO.md` | Per-repo CLAUDE.md (brief mention OK) | — |
-| Soft delete (isDeleted) | `CRITICAL-NEVER-DO.md` | — | — |
-| Serializer location | `CRITICAL-NEVER-DO.md` | Per-repo CLAUDE.md (brief mention OK) | — |
-| No inline interfaces | `CRITICAL-NEVER-DO.md` | — | — |
-| Naming conventions | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
-| Function declaration style | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
-| Testing standards | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
-| Performance patterns | `CLAUDE.md` (repo-level) | .agents/memory/ (detail doc) | — |
+| No `any` types | `AGENTS.md` (cross-agent rule) | Scoped AGENTS.md (brief mention OK) | hooks.json |
+| No `console.log` | `AGENTS.md` (cross-agent rule) | Scoped AGENTS.md (brief mention OK) | — |
+| Path aliases over relative imports | `AGENTS.md` (cross-agent rule) | — | — |
+| Conventional commits | `AGENTS.md` (cross-agent rule) | — | — |
+| Never commit secrets | `AGENTS.md` (cross-agent rule) | `.agents/memory/security.md` (detail) | hooks.json |
+| Import order (detailed) | `.agents/memory/coding-standards.md` | AGENTS.md (brief mention OK) | — |
+| AbortController in useEffect | `.agents/memory/coding-standards.md` | AGENTS.md (brief mention OK) | — |
+| Session file naming | hooks.json (runtime) | AGENTS.md (one mention) | hooks.json |
+| Multi-tenancy (org filter) | `.agents/memory/security.md` | AGENTS.md (brief mention OK) | — |
+| Soft delete (isDeleted) | `.agents/memory/data-guardrails.md` | AGENTS.md (brief mention OK) | — |
+| Serializer location | `.agents/memory/architecture.md` | AGENTS.md (brief mention OK) | — |
+| No inline interfaces | `.agents/memory/coding-standards.md` | AGENTS.md (brief mention OK) | — |
+| Naming conventions | `AGENTS.md` (repo-level) | `.agents/memory/coding-standards.md` (detail) | — |
+| Function declaration style | `AGENTS.md` (repo-level) | `.agents/memory/coding-standards.md` (detail) | — |
+| Testing standards | `AGENTS.md` (repo-level) | `.agents/memory/testing.md` (detail) | — |
+| Performance patterns | `AGENTS.md` (repo-level) | `.agents/memory/performance.md` (detail) | — |
 
 ## File Roles
 
 | File | Role | Contains |
 |------|------|----------|
-| `CLAUDE.md` (root) | Workspace overview | Cross-repo "do this" rules, repo table, agent behavior |
-| `CLAUDE.md` (per-repo) | Repo-specific guide | Tech stack, commands, repo-specific rules, architecture |
-| `CLAUDE_RULES.md` (global) | Behavioral preferences | Tool usage, code standards detail, session management |
-| `CRITICAL-NEVER-DO.md` | Violations only | "NEVER do X" rules with examples of what breaks |
-| `.agents/memory/*.md` | Durable project facts | Architecture, naming conventions, gotchas, extended standards — details beyond CLAUDE.md |
-| `CODEX.md` | Codex-specific | Sandbox constraints, key entry points, no-network notes |
-| `AGENTS.md` | Generic agent nav | Entry points for any AI agent (Cursor, Copilot, etc.) |
+| `AGENTS.md` (root or scoped) | Native shared instructions | Workspace overview, commands, repo rules, navigation |
+| `AGENTS.override.md` | Native scoped override | Intentional replacement guidance for one subtree |
+| `CLAUDE.md` | Claude-specific additions | Claude-only behavior that does not belong in shared instructions |
+| `.agents/memory/*.md` | Durable project facts | Architecture, naming conventions, gotchas, and extended standards linked from AGENTS.md |
 | `.cursorrules` | Cursor-specific | Project navigation, reading order, .agents/ structure |
 | `hooks.json` | Runtime enforcement | Catches violations at tool-call time (session files, any types, tests) |
-| `settings.json` | Permission control | Denied skills, MCP config |
+| Effective `.codex/config.toml` | Codex runtime configuration | Fallback instruction filenames, approvals, sandbox and network policy |
+| `settings.json` | Claude permission control | Denied skills, MCP config |
 
 ## Referencing vs Repeating
 

--- a/skills/agent-config-audit/references/healthy-config-example.md
+++ b/skills/agent-config-audit/references/healthy-config-example.md
@@ -4,7 +4,7 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 
 ## Root Level
 
-### CLAUDE.md (~80 lines)
+### AGENTS.md (~80 lines)
 
 - Workspace overview (repo table)
 - Cross-repo rules (5-7 rules, one line each)
@@ -12,17 +12,20 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 - Self-correction protocol
 - Learned Rules section (seeded, actively used)
 
-### CODEX.md (~30-40 lines)
+### AGENTS.override.md (only when needed)
 
-- Codex-specific constraints (sandbox, no network, no interactive)
-- Quick nav to critical docs
-- Cross-repo rules (brief, for context since Codex can't load CLAUDE.md hierarchy)
+- Scoped replacement guidance for a subtree with genuinely different rules
+- Omitted when normal AGENTS.md inheritance is sufficient
 
-### AGENTS.md (~15-20 lines)
+### CLAUDE.md (optional)
 
-- Brief workspace description
-- Navigation to `.agents/README.md` and CLAUDE.md
-- Links to priority reading
+- Claude-specific additions only
+- References AGENTS.md instead of repeating shared project rules
+
+### Effective .codex/config.toml (when runtime customization is needed)
+
+- Explicit fallback instruction filenames, if any
+- Approval, sandbox, and network policy for this runtime
 
 ### .cursor/rules (~100-130 lines)
 
@@ -46,7 +49,7 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 
 ## Per-Repo Level
 
-### CLAUDE.md (~50-150 lines)
+### AGENTS.md (~50-150 lines)
 
 - Tech stack
 - Commands (dev, build, test, lint)
@@ -55,16 +58,10 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 - Learned Rules section (seeded)
 - Does NOT repeat full cross-repo rules from root
 
-### CODEX.md (~20-30 lines)
+### CLAUDE.md (optional, concise)
 
-- Codex-specific notes (what won't work in sandbox)
-- Key entry points (3-5 most important files)
-- Links to CLAUDE.md and .agents/
-
-### AGENTS.md (~15-30 lines)
-
-- Repo description with tech context (not just "docs in .agents/")
-- Links to project `.agents/` and workspace `.agents/`
+- Claude-specific additions not shared by other agents
+- Links to AGENTS.md and `.agents/memory/`
 
 ### .cursorrules (~60-70 lines)
 
@@ -79,7 +76,7 @@ What a well-maintained agent config stack looks like for a monorepo workspace.
 |--------|---------|---------|----------|
 | Max rule occurrences | 2 | 3 | 4+ |
 | Stale files (> 90 days) | 0 | 1-2 | 3+ |
-| Zero-value CODEX.md stubs | 0 | 1-2 | 3+ |
+| Unconfigured instruction fallbacks | 0 | 1 | 2+ |
 | Emoji in config headers | 0 | 1-5 | 6+ |
 | Hardcoded absolute paths | 0 | 1 | 2+ |
 | Undocumented denied skills | 0 | 1-3 | 4+ |

--- a/skills/agent-dispatch/SKILL.md
+++ b/skills/agent-dispatch/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   drift, initialize agent docs, or wire up routing, and the action must be picked
   from an argument like "audit", "config", "init", or "route".
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "agents, dispatcher, architecture, config, setup, routing, orchestration"
   author: Ship Shit Dev
 when_to_use: "/agent, agent audit, config audit, init agent folder, setup agent routing, audit LLM wrappers, check agent config drift, add .agents/ folder, wire up dev-loop routing"
@@ -32,8 +32,9 @@ Outputs:
 
 - For `audit`: a severity-ranked findings report diagnosing LLM wrapper and agent
   failures, with a layer-by-layer fix plan.
-- For `config`: an audit report covering CLAUDE.md, CODEX.md, AGENTS.md,
-  .cursorrules, hooks, and settings, with proposed fixes.
+- For `config`: an audit report covering AGENTS.override.md, AGENTS.md,
+  configured fallbacks, CLAUDE.md, .cursorrules, hooks, and settings, with
+  proposed fixes.
 - For `init`: a scaffolded `.agents/` folder structure plus root agent entry
   files, with a summary of files created versus skipped.
 - For `route`: a drafted `## Agent skills` routing block in CLAUDE.md/AGENTS.md
@@ -92,7 +93,7 @@ the Usage block — do not guess a mode.
 ```bash
 /agent              # status: one-line domain summary + usage
 /agent audit        # diagnose LLM wrapper regressions, prompt/memory contamination, tool discipline failures
-/agent config       # audit and sync CLAUDE.md, CODEX.md, AGENTS.md, hooks, settings across workspaces
+/agent config       # audit and sync AGENTS.md, overrides, fallbacks, CLAUDE.md, hooks, and settings
 /agent init         # scaffold or repair the .agents/ folder and root agent entry files for a repo
 /agent route        # write the ## Agent skills routing block in CLAUDE.md/AGENTS.md + docs/agents/
 ```

--- a/skills/agent-dispatch/plugin.json
+++ b/skills/agent-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-dispatch",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Front door for agent work \u2014 routes audit/config/init/route to the right engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/agent-folder-init/SKILL.md
+++ b/skills/agent-folder-init/SKILL.md
@@ -2,7 +2,7 @@
 name: agent-folder-init
 description: Add or repair .agents/ project context for an existing repo. Use for AI agent documentation, session tracking, task management, and coding standards; do not use as the primary new-product scaffold.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "agents, setup, documentation"
 ---
 
@@ -19,7 +19,7 @@ Inputs:
 Outputs:
 
 - `.agents/` documentation structure
-- Root agent entry files such as `AGENTS.md`, `CLAUDE.md`, and `CODEX.md`
+- Root `AGENTS.md` for shared project instructions and `CLAUDE.md` for Claude-specific additions
 - Summary of files created and files skipped because they already existed
 
 Creates/Modifies:
@@ -94,7 +94,10 @@ python3 scripts/scaffold.py \
     └── TEMPLATE.md              # Session file template
 ```
 
-**Rules and coding standards** go in the repo's agent entry file (`AGENTS.md`, `CLAUDE.md`, or `CODEX.md`) and the user's platform-level instruction file — not inside `.agents/`.
+**Shared rules and coding standards** go in the applicable `AGENTS.md`. Use
+`AGENTS.override.md` only for an intentional subtree override and `CLAUDE.md`
+only for Claude-specific additions. Durable supporting detail belongs in
+`.agents/memory/`.
 
 **Task tracking** uses GitHub Issues (`gh issue list`, `gh issue create`) — not local task files.
 
@@ -132,9 +135,8 @@ python3 scripts/scaffold.py \
 
 ### Root Files
 
-- `AGENTS.md` - Points to `.agents/README.md`
-- `CLAUDE.md` - Claude-specific entry point
-- `CODEX.md` - Codex-specific entry point
+- `AGENTS.md` - Shared project instructions and `.agents/` navigation
+- `CLAUDE.md` - Claude-specific additions that reference `AGENTS.md`
 - `.editorconfig` - Editor configuration
 
 ## Key Patterns

--- a/skills/agent-folder-init/assets/agent-configs/cursor/commands/README.md
+++ b/skills/agent-folder-init/assets/agent-configs/cursor/commands/README.md
@@ -114,7 +114,8 @@ All commands assume this lean structure:
 └── sessions/    ← daily logs YYYY-MM-DD.md
 ```
 
-**Rules are in CLAUDE.md** (repo-level + global `~/.claude/CLAUDE.md`), loaded automatically.
+**Shared rules are in AGENTS.md**; `AGENTS.override.md` is a scoped replacement
+and `CLAUDE.md` contains only Claude-specific additions.
 **Tasks live in GitHub Issues** (`gh issue list`, `gh issue create`).
 **No SYSTEM/, TASKS/, PRDS/, SOP/, or EXAMPLES/ directories.**
 
@@ -161,7 +162,7 @@ Follow the naming convention:
 
 - Commands use the lean `.agents/` structure (memory/ + sessions/ only)
 - Task management goes through GitHub Issues — no local task files
-- Project rules and preferences live in CLAUDE.md (repo-level + global)
+- Shared project rules and preferences live in AGENTS.md; Claude-only additions live in CLAUDE.md
 - Only project paths need adaptation (`[frontend-project]`, `[backend-project]`)
 - Security checks in `/code-review` are configurable — adapt to your requirements
 

--- a/skills/agent-folder-init/assets/agent-configs/cursor/commands/docs-update.md
+++ b/skills/agent-folder-init/assets/agent-configs/cursor/commands/docs-update.md
@@ -8,11 +8,10 @@ This command ensures comprehensive tracking of all work, decisions, and context 
 
 **NEVER CREATE .MD FILES AT WORKSPACE ROOT LEVEL**
 
-**ONLY 4 files allowed at root:**
+**ONLY 3 files allowed at root:**
 
 - `AGENTS.md` - Navigation file
-- `CLAUDE.md` - AI agent config
-- `CODEX.md` - AI agent config
+- `CLAUDE.md` - Claude-specific additions
 - `README.md` - Project README
 
 **FORBIDDEN at root:**
@@ -33,7 +32,7 @@ This command ensures comprehensive tracking of all work, decisions, and context 
 
 **BEFORE creating ANY .md file, ask yourself:**
 
-1. Is this AGENTS.md, CLAUDE.md, CODEX.md, or README.md?
+1. Is this AGENTS.md, CLAUDE.md, or README.md?
    - NO → It goes in `.agents/` folder
    - YES → Only update, never recreate
 

--- a/skills/agent-folder-init/assets/agent-configs/cursor/commands/new-cmd.md
+++ b/skills/agent-folder-init/assets/agent-configs/cursor/commands/new-cmd.md
@@ -513,7 +513,7 @@ gh run watch
 ## Monorepo Structure
 
 Protected files across ALL projects:
-- `AGENTS.md`, `CLAUDE.md`, `CODEX.md` (MANDATORY in each project root)
+- `AGENTS.md` (shared instructions) and `CLAUDE.md` when Claude-specific additions are needed
 - `**/.agents/**` (All documentation)
 - `**/README.md` (Standard docs)
 
@@ -597,7 +597,7 @@ ls .cursor/commands/
 
 **Common patterns used:**
 
-1. **Check CRITICAL rules first** - Always reference CLAUDE.md (repo + global)
+1. **Check critical rules first** - Read the applicable AGENTS.md chain and Claude-specific CLAUDE.md when relevant
 2. **Never run tests locally** - Push to GitHub Actions instead
 3. **Monorepo-aware** - Handle multiple packages correctly
 4. **GitHub Actions integration** - Use `gh` CLI for CI/CD

--- a/skills/agent-folder-init/assets/agent-configs/cursor/commands/scaffold.md
+++ b/skills/agent-folder-init/assets/agent-configs/cursor/commands/scaffold.md
@@ -79,7 +79,7 @@ If components were scaffolded, verify:
 
 - Files were created successfully
 - Directory structure is correct
-- Entry files (AGENTS.md, CLAUDE.md, CODEX.md) exist
+- Shared `AGENTS.md` exists; `CLAUDE.md` exists when Claude-specific additions are requested
 
 ## Example Workflow
 

--- a/skills/agent-folder-init/assets/agent-configs/cursor/commands/start.md
+++ b/skills/agent-folder-init/assets/agent-configs/cursor/commands/start.md
@@ -12,7 +12,9 @@ Scan `.agents/memory/` to load durable project context. Each file covers one top
 ls .agents/memory/
 ```
 
-Read the files most relevant to today's work. Rules and preferences are already loaded from CLAUDE.md (repo-level) and the global `~/.claude/CLAUDE.md`; no separate preferences file needed.
+Read the files most relevant to today's work. Shared rules and preferences live
+in the applicable `AGENTS.md` chain; read `CLAUDE.md` only for Claude-specific
+additions. No separate preferences file is needed.
 
 ### 2. Read Today's Session File
 

--- a/skills/agent-folder-init/assets/templates/README.md
+++ b/skills/agent-folder-init/assets/templates/README.md
@@ -26,7 +26,7 @@ This is the `.agents/` folder — source of truth for AI agent context, session 
 
 ### During Work
 
-- Follow coding standards in `CLAUDE.md` (repo root) and `~/.claude/CLAUDE.md`
+- Follow shared coding standards in the applicable `AGENTS.md`; include `CLAUDE.md` only for Claude-specific additions
 - Document significant decisions in `.agents/memory/<topic>.md`
 - Track new work items as GitHub Issues
 
@@ -46,8 +46,9 @@ Multiple sessions on the same day go in the same file as Session 1, Session 2, e
 
 Coding standards, "never do" rules, and user preferences live in:
 
-- `CLAUDE.md` (repo root) — project-specific rules
-- `~/.claude/CLAUDE.md` — global rules (all projects)
+- `AGENTS.md` (repo root or nearest parent) — shared project instructions
+- `AGENTS.override.md` — scoped replacement instructions, only where intentionally present
+- `CLAUDE.md` — Claude-specific additions
 
 Do not duplicate rules inside `.agents/`.
 

--- a/skills/agent-folder-init/plugin.json
+++ b/skills/agent-folder-init/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-folder-init",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Initialize a project .agents folder for AI-first development workflows.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/agent-folder-init/scripts/scaffold.py
+++ b/skills/agent-folder-init/scripts/scaffold.py
@@ -109,7 +109,7 @@ This is the `.agents/` folder — source of truth for AI agent context, session 
 
 ## For AI Agents
 
-- **Rules / coding standards:** see `CLAUDE.md` (repo root + global `~/.claude/CLAUDE.md`)
+- **Shared rules / coding standards:** see `AGENTS.md`; read `CLAUDE.md` only for Claude-specific additions
 - **Task tracking:** GitHub Issues (`gh issue list`)
 - **Durable context:** read `.agents/memory/` files before starting work
 
@@ -125,11 +125,11 @@ This is the `.agents/` folder — source of truth for AI agent context, session 
 
 
 def create_entry_files(root: Path, project_name: str) -> None:
-    """Create AGENTS.md, CLAUDE.md, CODEX.md at project root."""
+    """Create AGENTS.md and CLAUDE.md at project root."""
 
     agents_content = f"""# {project_name}
 
-This file provides entry points for AI agents.
+Shared project instructions for AI agents, including Codex.
 
 ## Documentation
 
@@ -141,7 +141,7 @@ All durable project context is in `.agents/memory/`. Session logs are in `.agent
 
 ## Rules & Standards
 
-Coding standards and "never do" rules live in `CLAUDE.md` (this file) and the global `~/.claude/CLAUDE.md`. Do not duplicate them in `.agents/`.
+Shared coding standards and "never do" rules live in this file. Durable supporting detail belongs in `.agents/memory/`; runtime policy belongs in agent configuration or hooks.
 
 ## Task Tracking
 
@@ -154,7 +154,7 @@ Document all work in `.agents/sessions/YYYY-MM-DD.md` (one file per day).
 
     claude_content = f"""# {project_name}
 
-Claude-specific entry point.
+Claude-specific additions. Read `AGENTS.md` first for shared project instructions.
 
 ## Context
 
@@ -169,28 +169,11 @@ Document all work in `.agents/sessions/YYYY-MM-DD.md` (one file per day).
 Use GitHub Issues: `gh issue list`, `gh issue create`.
 """
 
-    codex_content = f"""# {project_name}
-
-Codex-specific entry point.
-
-## Documentation
-
-- `.agents/README.md` - Start here
-- `.agents/memory/` - Durable project facts (source of truth)
-- `.agents/sessions/` - Daily session history
-
-## Task Tracking
-
-Use GitHub Issues: `gh issue list`.
-"""
-
     (root / "AGENTS.md").write_text(agents_content)
     (root / "CLAUDE.md").write_text(claude_content)
-    (root / "CODEX.md").write_text(codex_content)
 
     print(f"Created: {root}/AGENTS.md")
     print(f"Created: {root}/CLAUDE.md")
-    print(f"Created: {root}/CODEX.md")
 
 
 def copy_root_files(root: Path) -> None:

--- a/skills/fullstack-workspace-init/SKILL.md
+++ b/skills/fullstack-workspace-init/SKILL.md
@@ -2,7 +2,7 @@
 name: fullstack-workspace-init
 description: Initialize Shipshit.dev full-stack product workspaces through npx @shipshitdev/v0, then customize and verify the generated repo. Use for new product scaffolds or post-v0 workspace setup.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "fullstack, workspace, v0"
 ---
 

--- a/skills/fullstack-workspace-init/plugin.json
+++ b/skills/fullstack-workspace-init/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "fullstack-workspace-init",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Scaffold a production-ready full-stack monorepo with working MVP features, tests, and CI/CD. Generat",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/fullstack-workspace-init/scripts/init-workspace.py
+++ b/skills/fullstack-workspace-init/scripts/init-workspace.py
@@ -176,7 +176,7 @@ def create_agents_md(name: str) -> str:
     return dedent(f"""\
         # {name}
 
-        AI agent entry point. Documentation in `.agents/`.
+        Shared project instructions for AI agents, including Codex. Documentation in `.agents/`.
 
         ## Projects
 
@@ -195,7 +195,7 @@ def create_claude_md(name: str) -> str:
     return dedent(f"""\
         # {name}
 
-        Claude entry point. Rules and coding standards are defined in this file and `~/.claude/CLAUDE.md`.
+        Claude-specific additions. Read `AGENTS.md` first for shared project instructions.
 
         ## Commands
 
@@ -208,14 +208,6 @@ def create_claude_md(name: str) -> str:
         ## Project Context
 
         Durable project facts live in `.agents/memory/`. Session logs are in `.agents/sessions/`.
-    """)
-
-
-def create_codex_md(name: str) -> str:
-    return dedent(f"""\
-        # {name}
-
-        Codex entry point. Documentation in `.agents/`.
     """)
 
 
@@ -1858,7 +1850,6 @@ def scaffold_workspace(
         root / "README.md": create_readme(name),
         root / "AGENTS.md": create_agents_md(name),
         root / "CLAUDE.md": create_claude_md(name),
-        root / "CODEX.md": create_codex_md(name),
 
         # GitHub Actions CI
         root / ".github" / "workflows" / "ci.yml": generate_github_actions_ci(),
@@ -1874,7 +1865,6 @@ def scaffold_workspace(
         root / "api" / "apps" / "api" / "src" / "app.module.ts": app_module_content,
         root / "api" / "AGENTS.md": create_agents_md(f"{name} API"),
         root / "api" / "CLAUDE.md": create_claude_md(f"{name} API"),
-        root / "api" / "CODEX.md": create_codex_md(f"{name} API"),
 
         # Auth files (always generated)
         root / "api" / "apps" / "api" / "src" / "auth" / "guards" / "clerk-auth.guard.ts": generate_clerk_auth_guard(),
@@ -1893,7 +1883,6 @@ def scaffold_workspace(
         root / "frontend" / "apps" / "dashboard" / "app" / "globals.scss": create_frontend_globals_scss(),
         root / "frontend" / "AGENTS.md": create_agents_md(f"{name} Frontend"),
         root / "frontend" / "CLAUDE.md": create_claude_md(f"{name} Frontend"),
-        root / "frontend" / "CODEX.md": create_codex_md(f"{name} Frontend"),
 
         # Mobile
         root / "mobile" / "package.json": create_mobile_package_json(org),
@@ -1903,14 +1892,12 @@ def scaffold_workspace(
         root / "mobile" / "app" / "index.tsx": create_mobile_index_tsx(),
         root / "mobile" / "AGENTS.md": create_agents_md(f"{name} Mobile"),
         root / "mobile" / "CLAUDE.md": create_claude_md(f"{name} Mobile"),
-        root / "mobile" / "CODEX.md": create_codex_md(f"{name} Mobile"),
 
         # Packages
         root / "packages" / "package.json": create_packages_package_json(org),
         root / "packages" / "tsconfig.json": create_packages_tsconfig(),
         root / "packages" / "AGENTS.md": create_agents_md(f"{name} Packages"),
         root / "packages" / "CLAUDE.md": create_claude_md(f"{name} Packages"),
-        root / "packages" / "CODEX.md": create_codex_md(f"{name} Packages"),
     }
 
     for filepath, content in files.items():

--- a/skills/interview/SKILL.md
+++ b/skills/interview/SKILL.md
@@ -4,7 +4,7 @@ description: Conducts a repo-grounded discovery interview before PRD writing, fe
 user-invocable: true
 argument-hint: "[topic, feature, issue, or decision]"
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "interview, discovery, requirements, planning"
   author: Ship Shit Dev
 when_to_use: "interview me, grill me, grill-me, grill me with docs, discovery interview, requirements interview, before PRD, clarify requirements, /interview"
@@ -89,8 +89,9 @@ Read repo context before asking questions:
   docs.
 - Check recent `.agents/sessions/` entries only when they are relevant to the
   topic.
-- Read root agent entry files such as `AGENTS.md`, `CLAUDE.md`, or `CODEX.md`
-  for routing and repo rules.
+- Read the applicable `AGENTS.override.md` / `AGENTS.md` chain for routing and
+  repo rules, plus any fallback filename explicitly configured for Codex. Read
+  `CLAUDE.md` when the active workflow is Claude-specific.
 - Search docs, README files, source code, and issues for the topic before
   asking the user to repeat known context.
 

--- a/skills/interview/plugin.json
+++ b/skills/interview/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "interview",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Repo-grounded discovery interview before PRD, planning, or implementation.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/qa-reviewer/SKILL.md
+++ b/skills/qa-reviewer/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   multi-step implementations, before committing major refactors, or proactively
   after any task longer than five steps.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "quality-assurance, verification, code-review, accuracy, completeness"
 ---
 
@@ -32,7 +32,9 @@ Structured framework for reviewing AI agent work before finalizing changes. Catc
 
 - Review original task and requirements
 - List all deliverables (files created/modified/deleted)
-- Check critical rules (agent instruction files — `AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global)
+- Check critical rules in the applicable `AGENTS.override.md` / `AGENTS.md`
+  chain and explicitly configured fallback files; include `CLAUDE.md` for
+  Claude-specific rules
 
 ### 2. Requirement Verification
 
@@ -83,7 +85,8 @@ grep -r ": any" <files>
 - [ ] No console.log (use logger)
 - [ ] No `any` types
 - [ ] No inline interfaces
-- [ ] AGENTS/CLAUDE/CODEX files intact
+- [ ] Applicable AGENTS files intact and scoped overrides intentional
+- [ ] Configured fallback instruction files exist and are nonempty
 - [ ] .agents/ folders untouched
 - [ ] Multi-tenancy preserved
 

--- a/skills/qa-reviewer/plugin.json
+++ b/skills/qa-reviewer/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "qa-reviewer",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Systematically review AI agent work for quality, accuracy, and completeness. Catches bugs, verifies ",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/qa-reviewer/references/full-guide.md
+++ b/skills/qa-reviewer/references/full-guide.md
@@ -33,7 +33,11 @@ List all changes made:
 
 **1.3 Check Critical Rules**
 
-For projects, ALWAYS verify against repo-level agent instructions (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`, or equivalent) and the user's platform-level instruction file. These are the canonical sources for project rules and "never do" constraints. The harness loads them automatically; read them if you need to reference specific rules during review.
+For projects, ALWAYS verify against the applicable `AGENTS.override.md` /
+`AGENTS.md` chain and the user's platform-level instruction file. Include any
+fallback filename explicitly configured by the active harness and read
+`CLAUDE.md` for Claude-specific rules. These are the canonical sources for
+project rules and "never do" constraints.
 
 ### Phase 2: Requirement Verification
 
@@ -137,7 +141,8 @@ Look for:
 
 **4.3 Project-Specific Violations**
 
-Check against the rules in CLAUDE.md (repo-level and global):
+Check against the applicable `AGENTS.override.md` / `AGENTS.md` chain and
+Claude-specific `CLAUDE.md` when relevant:
 
 ```
 Violations to check:
@@ -148,7 +153,8 @@ Violations to check:
 [ ] No serializers in API repo
 [ ] No test execution locally
 [ ] Multi-tenancy enforced
-[ ] AGENTS.md/CLAUDE.md/CODEX.md not deleted
+[ ] Applicable AGENTS.md / AGENTS.override.md files not deleted
+[ ] Explicitly configured fallback instruction files exist and are nonempty
 [ ] .agents/ folders not deleted
 ```
 
@@ -257,7 +263,7 @@ Minor:
 
 ## Project Rules Compliance
 
-CLAUDE.md rules checked:
+Applicable project instructions checked:
 
 - No console.log violations
 - No `any` types added

--- a/skills/rules-capture/SKILL.md
+++ b/skills/rules-capture/SKILL.md
@@ -8,7 +8,7 @@ description: >-
   rule is", "stop doing X", "I prefer", frustration indicators, or any
   correction to AI behavior.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "preferences, rules, documentation, automation"
 ---
 
@@ -154,7 +154,9 @@ Should I add this to the permanent rules? [Yes/No/Modify]
 
 ### 5. On Confirmation
 - **Personal preferences** → append to the user's platform-level instruction file under the appropriate section
-- **Project coding standards** → append to the repo-level agent instruction file (`AGENTS.md`, `CLAUDE.md`, `CODEX.md`, or equivalent)
+- **Shared project coding standards** → append to the applicable `AGENTS.md`
+- **Scoped project overrides** → use `AGENTS.override.md` only when inherited guidance must be replaced for a subtree
+- **Claude-specific behavior** → append to `CLAUDE.md`
 - **Durable project facts** (architecture, deployment notes, gotchas) → add/update a file in `.agents/memory/`
 - Remove the entry from `.agents/memory/captured-rules.md` (or mark it PROCESSED)
 

--- a/skills/rules-capture/plugin.json
+++ b/skills/rules-capture/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "rules-capture",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Automatically detects and documents user preferences, coding rules, and style guidelines when expres",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/security-expert/SKILL.md
+++ b/skills/security-expert/SKILL.md
@@ -2,7 +2,7 @@
 name: security-expert
 description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "security, owasp, application-security"
 ---
 
@@ -22,7 +22,7 @@ metadata:
 ## Project Context Discovery
 
 1. Check `.agents/memory/` for security architecture notes and project facts
-2. Review the agent instruction files (`AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global) for security rules and "never do" constraints
+2. Review the applicable `AGENTS.override.md` / `AGENTS.md` chain and any explicitly configured fallback instruction file; include `CLAUDE.md` only for Claude-specific rules
 3. Identify security patterns and tools
 4. Check for `[project]-security-expert` skill
 

--- a/skills/security-expert/plugin.json
+++ b/skills/security-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-expert",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and se",
   "author": {
     "name": "Ship Shit Dev",


### PR DESCRIPTION
## Summary

- remove the legacy Codex instruction filename from generators, audits, routing, QA, security, interviews, rules capture, and documentation templates
- make AGENTS.override.md, AGENTS.md, and explicitly configured fallbacks the Codex instruction model; keep CLAUDE.md for Claude-specific additions
- move durable guardrail ownership to topic files under .agents/memory and keep runtime sandbox, approval, and network policy in effective Codex config or hooks
- regenerate all 13 marketplace bundle snapshots and marketplace metadata from canonical skills

## Validation

- exact repository scan: zero residual legacy instruction filename references
- exact repository scan: zero .agents/SYSTEM/critical references
- canonical/bundle identity checks passed for agent-folder-init, fullstack-workspace-init, and agent-config-audit
- Markdown lint passed
- scripts/validate-skill-sync.sh passed; only the pre-existing unrelated codex-image-gen home-path compatibility warning remains
- git diff --check passed

No local tests, typechecks, or builds were run per workstation policy; PR CI provides broad verification.