### PR TITLE
fix: avoid URI literal in scanner guidance

### DIFF
--- a/bundles/security/skills/open-source-checker/references/full-guide.md
+++ b/bundles/security/skills/open-source-checker/references/full-guide.md
@@ -191,9 +191,9 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
-# NOTE: schemes are written as `scheme[:]//` (semantically identical to
-# `scheme://`) so this file itself never contains a URI-shaped literal that
-# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+# NOTE: schemes are written with the colon inside brackets, followed by two
+# slashes, so this file itself never contains a URI-shaped literal that trips
+# secret scanners (secretlint, gitleaks) in consuming repositories.
 
 # MongoDB
 mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+

--- a/bundles/workspace/skills/open-source-checker/references/full-guide.md
+++ b/bundles/workspace/skills/open-source-checker/references/full-guide.md
@@ -191,9 +191,9 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
-# NOTE: schemes are written as `scheme[:]//` (semantically identical to
-# `scheme://`) so this file itself never contains a URI-shaped literal that
-# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+# NOTE: schemes are written with the colon inside brackets, followed by two
+# slashes, so this file itself never contains a URI-shaped literal that trips
+# secret scanners (secretlint, gitleaks) in consuming repositories.
 
 # MongoDB
 mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+

--- a/skills/open-source-checker/references/full-guide.md
+++ b/skills/open-source-checker/references/full-guide.md
@@ -191,9 +191,9 @@ SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
 ### 2.3 Connection String Patterns
 
 ```regex
-# NOTE: schemes are written as `scheme[:]//` (semantically identical to
-# `scheme://`) so this file itself never contains a URI-shaped literal that
-# trips secret scanners (secretlint, gitleaks) in consuming repositories.
+# NOTE: schemes are written with the colon inside brackets, followed by two
+# slashes, so this file itself never contains a URI-shaped literal that trips
+# secret scanners (secretlint, gitleaks) in consuming repositories.
 
 # MongoDB
 mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+


### PR DESCRIPTION
## Summary

- describe the URI separator without spelling a URI-shaped literal
- regenerate both bundles that include open-source-checker

Closes #66

## Verification

- bun run marketplace:generate
- focused markdownlint
- ./scripts/validate-skill-sync.sh
