### PR TITLE
fix: harden project governance fallbacks

### DIFF
--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -57,16 +57,57 @@ jobs:
           FLAGS=""
 
           # --- 1. ensure the issue is on the board ---
-          ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json -L 800)
-          ITEM=$(echo "$ITEMS" | jq -r --arg u "$IURL" '.items[]|select(.content.url==$u).id' | head -1)
-          if [ -z "$ITEM" ]; then
-            ITEM=$(gh project item-add "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --url "$IURL" --format json | jq -r '.id')
-            FLAGS="${FLAGS}added to board; "
-            ITEMS=$(gh project item-list "$PROJECT_NUMBER" --owner "$PROJECT_OWNER" --format json -L 800)
+          find_item_json() {
+            gh api graphql --paginate --slurp \
+              -F projectId="$NODE" \
+              -f query='query($projectId: ID!, $endCursor: String) {
+                node(id: $projectId) {
+                  ... on ProjectV2 {
+                    items(first: 100, after: $endCursor) {
+                      nodes {
+                        id
+                        content { ... on Issue { url } }
+                        fieldValues(first: 50) {
+                          nodes {
+                            ... on ProjectV2ItemFieldSingleSelectValue {
+                              name
+                              field { ... on ProjectV2SingleSelectField { name } }
+                            }
+                          }
+                        }
+                      }
+                      pageInfo { hasNextPage endCursor }
+                    }
+                  }
+                }
+              }' \
+              | jq -c --arg u "$IURL" \
+                '[.[] | .data.node.items.nodes[] | select(.content.url == $u)][0] // empty'
+          }
+
+          ITEM_JSON=$(find_item_json)
+          if [ -z "$ITEM_JSON" ]; then
+            if ADD_OUTPUT=$(gh project item-add "$PROJECT_NUMBER" \
+              --owner "$PROJECT_OWNER" --url "$IURL" --format json 2>&1); then
+              FLAGS="${FLAGS}added to board; "
+            else
+              # A concurrent run or an item beyond a fixed list limit may have
+              # added it already. Re-query every page before treating this as fatal.
+              ITEM_JSON=$(find_item_json)
+              if [ -z "$ITEM_JSON" ]; then
+                printf '::error::Unable to add project item: %s\n' "$ADD_OUTPUT"
+                exit 1
+              fi
+            fi
           fi
-          IV=$(echo "$ITEMS" | jq -r --arg u "$IURL" '.items[]|select(.content.url==$u)')
-          CUR_STATUS=$(echo "$IV" | jq -r '.status // ""')
-          CUR_PRI=$(echo "$IV" | jq -r '.priority // ""')
+          if [ -z "$ITEM_JSON" ]; then
+            ITEM_JSON=$(find_item_json)
+          fi
+          ITEM=$(echo "$ITEM_JSON" | jq -r '.id')
+          CUR_STATUS=$(echo "$ITEM_JSON" | jq -r \
+            '[.fieldValues.nodes[] | select(.field.name == "Status") | .name][0] // ""')
+          CUR_PRI=$(echo "$ITEM_JSON" | jq -r \
+            '[.fieldValues.nodes[] | select(.field.name == "Priority") | .name][0] // ""')
 
           # --- 2. Status default ---
           if [ -z "$CUR_STATUS" ]; then

--- a/bundles/dev-workflow/skills/release-dispatch/SKILL.md
+++ b/bundles/dev-workflow/skills/release-dispatch/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   up branches after a deploy, and the action must be picked from an argument like
   "gates", "cut", "notes", or "cleanup".
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "release, dispatcher, ci-cd, semver, github, orchestration"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -85,8 +85,9 @@ the Usage block — do not guess a mode (a wrong guess could tag or delete).
 
 ```bash
 TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null \
-  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' \
-  || echo main)
+  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+TRUNK=${TRUNK#origin/}
+TRUNK=${TRUNK:-main}
 git rev-parse --verify --quiet "origin/$TRUNK" >/dev/null || TRUNK=""
 ```
 

--- a/bundles/dev-workflow/skills/release-dispatch/plugin.json
+++ b/bundles/dev-workflow/skills/release-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release-dispatch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Single front door for releases — routes gates/cut/notes/cleanup to the right release engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/github/skills/release-dispatch/SKILL.md
+++ b/bundles/github/skills/release-dispatch/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   up branches after a deploy, and the action must be picked from an argument like
   "gates", "cut", "notes", or "cleanup".
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "release, dispatcher, ci-cd, semver, github, orchestration"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -85,8 +85,9 @@ the Usage block — do not guess a mode (a wrong guess could tag or delete).
 
 ```bash
 TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null \
-  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' \
-  || echo main)
+  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+TRUNK=${TRUNK#origin/}
+TRUNK=${TRUNK:-main}
 git rev-parse --verify --quiet "origin/$TRUNK" >/dev/null || TRUNK=""
 ```
 

--- a/bundles/github/skills/release-dispatch/plugin.json
+++ b/bundles/github/skills/release-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release-dispatch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Single front door for releases — routes gates/cut/notes/cleanup to the right release engine.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/release-dispatch/SKILL.md
+++ b/skills/release-dispatch/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   up branches after a deploy, and the action must be picked from an argument like
   "gates", "cut", "notes", or "cleanup".
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "release, dispatcher, ci-cd, semver, github, orchestration"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -85,8 +85,9 @@ the Usage block — do not guess a mode (a wrong guess could tag or delete).
 
 ```bash
 TRUNK=$(gh repo view --json defaultBranchRef --jq .defaultBranchRef.name 2>/dev/null \
-  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null | sed 's@^origin/@@' \
-  || echo main)
+  || git symbolic-ref --short refs/remotes/origin/HEAD 2>/dev/null)
+TRUNK=${TRUNK#origin/}
+TRUNK=${TRUNK:-main}
 git rev-parse --verify --quiet "origin/$TRUNK" >/dev/null || TRUNK=""
 ```
 

--- a/skills/release-dispatch/plugin.json
+++ b/skills/release-dispatch/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release-dispatch",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Single front door for releases — routes gates/cut/notes/cleanup to the right release engine.",
   "author": {
     "name": "Ship Shit Dev",


### PR DESCRIPTION
## Summary

- resolve issue board membership through paginated Projects GraphQL data
- recover idempotently when a concurrent or duplicate add fails
- preserve genuine project-add failures
- remove undeclared sed usage from release trunk detection

Closes #49

## Verification

- bun run marketplace:generate
- focused markdownlint
- ./scripts/validate-skill-sync.sh
- git diff --check
