### PR TITLE
fix: close skill contract and manifest drift

### DIFF
--- a/bundles/dev-workflow/skills/full-code-review/SKILL.md
+++ b/bundles/dev-workflow/skills/full-code-review/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   prioritized backlog instead of a merge verdict.
 compatibility: Requires gh CLI and git for PR diff fetching.
 metadata:
-  version: "1.0.1"
+  version: "1.0.2"
   tags: "code-review, security, structural, devex, orchestration, pr-gate"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -74,8 +74,8 @@ Outputs:
 - **PR mode:** verdict approve / request-changes / block — with one-sentence
   rationale.
 - **Retro mode:** verdict `retro-backlog` (never blocks anything) — findings
-  bucketed bug / optimization / refactor and ranked by (impact × recurrence) ÷
-  effort, for scheduling as follow-up work.
+  bucketed bug / optimization / refactor / other and ranked by (impact × recurrence)
+  ÷ effort, for scheduling as follow-up work.
 - Dimensions reviewed and adversarial refutation count.
 
 Creates/Modifies:
@@ -174,6 +174,10 @@ Optimizations:
 Refactors:
 [rank]. [SEVERITY] <file> — <finding>   (commits: <sha>, <sha>, <sha>)
   Fix: <consolidation>
+
+Other follow-ups:
+[rank]. [SEVERITY] <file> — <finding>   (commits: <sha>)
+  Fix: <remediation>
 
 Dimensions reviewed: structural, security, devex, cross-commit
 Adversarial pass: <N raw> → <M surviving>

--- a/bundles/dev-workflow/skills/full-code-review/plugin.json
+++ b/bundles/dev-workflow/skills/full-code-review/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "full-code-review",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Run orchestrated PR review with parallel reviewers, verification, and synthesis.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/full-code-review/scripts/full-code-review.js
+++ b/bundles/dev-workflow/skills/full-code-review/scripts/full-code-review.js
@@ -372,7 +372,7 @@ log(IS_RETRO ? "Phase 3: Synthesis (retro backlog)" : "Phase 3: Synthesis (merge
 
 const verdictSchema = {
   type: "object",
-  required: ["verdict", "rationale", "prioritized_findings", "stats"],
+  required: ["mode", "verdict", "rationale", "prioritized_findings", "stats"],
   properties: {
     mode: {
       type: "string",
@@ -391,12 +391,12 @@ const verdictSchema = {
       type: "array",
       items: {
         type: "object",
-        required: ["rank", "severity", "dimension", "file", "finding", "evidence", "fix", "overlap_weight"],
+        required: ["rank", "severity", "dimension", "bucket", "file", "finding", "evidence", "fix", "overlap_weight"],
         properties: {
           rank:           { type: "integer" },
           severity:       { type: "string", enum: ["BLOCKER", "HIGH", "MEDIUM", "LOW"] },
           dimension:      { type: "string" },
-          bucket:         { type: "string", enum: ["bug", "optimization", "refactor", "other"], description: "Retro grouping; omit in pr mode" },
+          bucket:         { type: "string", enum: ["bug", "optimization", "refactor", "other"], default: "other", description: "Retro grouping; use other in pr mode" },
           file:           { type: "string" },
           line:           { type: ["integer", "null"] },
           finding:        { type: "string" },
@@ -443,7 +443,7 @@ const prSynthesisPrompt = `You are the synthesis judge for a multi-dimension cod
    - "approve"          if only MEDIUM/LOW findings survive or none.
 5. Write a one-sentence rationale that names the most critical finding.
 
-Set \`mode\`: "pr".
+Set \`mode\`: "pr" and set every finding's \`bucket\` to "other".
 
 SURVIVING VERIFIED FINDINGS:
 ${redactSensitiveText(JSON.stringify(survivingFindings, null, 2))}
@@ -456,9 +456,9 @@ prioritized BACKLOG of follow-up work the team should schedule.
 
 1. Deduplicate findings describing the same root issue (merge evidence, union the
    commit SHAs).
-2. Assign each finding a \`bucket\`: "bug" (a defect shipped in the window),
+2. Assign every finding a \`bucket\`: "bug" (a defect shipped in the window),
    "optimization" (performance/cost left on the table), "refactor" (duplication,
-   drift, unstable abstraction), or "other".
+   drift, unstable abstraction), or "other". Never omit the bucket.
 3. Rank by value, not by gate. Order by (impact × recurrence) ÷ effort: a cheap fix
    that removes duplication reintroduced in five commits outranks an expensive
    rewrite that touches one. Shipped bugs always sort to the top of their tier.

--- a/bundles/infrastructure/skills/postgres-ops/SKILL.md
+++ b/bundles/infrastructure/skills/postgres-ops/SKILL.md
@@ -4,9 +4,9 @@ description: Operate a production Postgres database — backup strategy, point-i
 disable-model-invocation: true
 argument-hint: "[backup | restore | pooling | dr]"
 compatibility: Requires psql / pg_dump / pg_restore for self-managed instances; provider CLI for managed.
-allowed-tools: Bash(psql *) Bash(pg_dump *) Bash(pg_restore *) Bash(pg_basebackup *)
+allowed-tools: Bash(psql *) Bash(pg_dump *) Bash(pg_restore *) Bash(pg_basebackup *) Bash(createdb *) Bash(dropdb *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "postgres, backup, disaster-recovery, pooling, database, infrastructure"
   author: Ship Shit Dev
 when_to_use: "postgres backups, database backup strategy, point in time recovery, PITR, restore the database, connection pooling, PgBouncer, disaster recovery, DR runbook, harden postgres"
@@ -88,9 +88,13 @@ A backup is unproven until restored. Restore into a **scratch** database, never 
 production, and verify:
 
 ```bash
-createdb restore_check
-pg_restore --dbname=restore_check --clean --if-exists db-YYYY-MM-DD.dump
-psql restore_check -c "SELECT count(*) FROM <critical_table>;"   # sanity-check row counts
+scratch_db="restore_check_$(date +%s)"
+trap 'dropdb --if-exists "$scratch_db"' EXIT
+createdb "$scratch_db"
+pg_restore --dbname="$scratch_db" --clean --if-exists db-YYYY-MM-DD.dump
+psql "$scratch_db" -c "SELECT count(*) FROM <critical_table>;"   # sanity-check row counts
+dropdb "$scratch_db"
+trap - EXIT
 ```
 
 Only restore to production on an explicit, named request, after confirming the target

--- a/bundles/infrastructure/skills/postgres-ops/plugin.json
+++ b/bundles/infrastructure/skills/postgres-ops/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres-ops",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Operate production Postgres: backups, point-in-time recovery, pooling, and disaster recovery.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/infrastructure/skills/vercel-deploy/SKILL.md
+++ b/bundles/infrastructure/skills/vercel-deploy/SKILL.md
@@ -4,9 +4,9 @@ description: Deploy a Next.js app to Vercel and manage its environment — previ
 compatibility: Requires the Vercel CLI authenticated, and a linked project (.vercel/project.json).
 disable-model-invocation: true
 argument-hint: "[preview | prod | rollback | env]"
-allowed-tools: Bash(vercel *) Bash(git *) Bash(gh *)
+allowed-tools: Bash(vercel *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "vercel, deploy, nextjs, rollback, environments, infrastructure"
   author: Ship Shit Dev
 when_to_use: "deploy to Vercel, ship a preview, deploy to production, promote to production, roll back the deploy, revert deployment, manage Vercel env vars, /deploy vercel"

--- a/bundles/infrastructure/skills/vercel-deploy/plugin.json
+++ b/bundles/infrastructure/skills/vercel-deploy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-deploy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Deploy a Next.js app to Vercel: preview, production, rollback, and env vars, safely gated.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/planning/skills/roadmap-to-milestones/SKILL.md
+++ b/bundles/planning/skills/roadmap-to-milestones/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *)
 argument-hint: "[roadmap file, or 'burndown']"
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, milestones, roadmap, planning, burndown, mrr"
   author: Ship Shit Dev
 when_to_use: "create milestones, roadmap to milestones, set milestone due dates, group issues under a milestone, turn the roadmap into a schedule, milestone burndown, milestone progress"
@@ -28,7 +28,8 @@ this uses `gh api repos/{owner}/{repo}/milestones`.
 
 Inputs:
 
-- A roadmap (from `roadmap-analyzer`), a theme list, or a set of existing issues.
+- A revenue-ranked roadmap (from `roadmap-analyzer`), a ranked theme list, or a
+  ranked set of existing issues.
 - The target repo and a cadence or explicit due dates.
 
 Outputs:
@@ -69,8 +70,9 @@ gh api "repos/{owner}/{repo}/milestones?state=all" \
   --jq '.[] | {number, title, due_on, open_issues, closed_issues}'
 ```
 
-If the roadmap is missing, stop and recommend `roadmap-analyzer`. Sequencing without a
-revenue ranking just dates an arbitrary list.
+Continue when any supplied input is explicitly revenue-ranked: a roadmap, theme list,
+or issue set. If none is ranked, stop and recommend `roadmap-analyzer`; sequencing an
+unranked input just dates an arbitrary list.
 
 ## Step 2 — Derive milestones from themes
 
@@ -91,14 +93,20 @@ not force it in.
 
 ## Step 3 — Draft and confirm
 
-Show the full plan before any write:
+Reconcile every proposed title against the milestone inventory before presenting the
+plan. Match titles case-insensitively after trimming surrounding whitespace, but never
+fuzzy-match materially different names. Classify each proposal as `create`, `update`
+(same title, changed description or due date), or `unchanged`, and retain the existing
+milestone number for updates.
+
+Show the full reconciled plan before any write:
 
 ```text
 Milestones plan — <repo>
 
-1. Land: <theme>        due <date>   — <lever, metric>
+1. [update #4] Land: <theme>  due <date> — <lever, metric>
      #12 <issue>   #15 <issue>
-2. Retain: <theme>      due <date>   — <lever, metric>
+2. [create] Retain: <theme>    due <date> — <lever, metric>
      #18 <issue>
 Unassigned (need a home): #21 <issue> — <why it fits no theme>
 ```
@@ -107,10 +115,16 @@ Wait for approval. Let the user move dates or issues before committing.
 
 ## Step 4 — Create milestones and assign issues
 
-After approval, create each milestone, then assign its issues:
+After approval, PATCH each matching milestone by its inventoried number, create only
+unmatched milestones, skip unchanged milestones, then assign issues:
 
 ```bash
-# Create a milestone (due_on is ISO 8601 UTC). Capture the returned number.
+# Update a title-matched milestone first (due_on is ISO 8601 UTC).
+gh api -X PATCH repos/{owner}/{repo}/milestones/4 \
+  -f description="Lever: Land primary segment. Success: first-week activation >40%." \
+  -f due_on="2026-08-01T00:00:00Z"
+
+# Create only when reconciliation found no title match. Capture the returned number.
 gh api repos/{owner}/{repo}/milestones \
   -f title="Land: agency onboarding" \
   -f description="Lever: Land primary segment. Success: first-week activation >40%." \
@@ -118,12 +132,6 @@ gh api repos/{owner}/{repo}/milestones \
 
 # Assign issues by milestone title (gh resolves the title to its number).
 gh issue edit 12 --milestone "Land: agency onboarding"
-```
-
-To update an existing milestone instead of duplicating it, PATCH by its number:
-
-```bash
-gh api -X PATCH repos/{owner}/{repo}/milestones/<number> -f due_on="2026-08-15T00:00:00Z"
 ```
 
 ## Step 5 — Burndown
@@ -136,8 +144,9 @@ gh api "repos/{owner}/{repo}/milestones?state=open" \
 ```
 
 Flag any milestone that is **overdue with open issues** or **empty** (a dated bucket
-with no work is a planning smell). Recommend the next move: pull P0 issues into the
-board's `In Progress`, or re-date a milestone that cannot land in time.
+with no work is a planning smell). Recommend milestone-only recovery: re-date it,
+rebalance issues into a later milestone, or split its scope. Never change or recommend
+changing the board's `Status` field from this skill.
 
 ## Anti-Patterns
 

--- a/bundles/planning/skills/roadmap-to-milestones/plugin.json
+++ b/bundles/planning/skills/roadmap-to-milestones/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmap-to-milestones",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Turn a revenue-ranked roadmap into GitHub milestones with due dates and burndown.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/security/skills/dependency-audit/SKILL.md
+++ b/bundles/security/skills/dependency-audit/SKILL.md
@@ -3,10 +3,10 @@ name: dependency-audit
 description: Audit a project's dependency supply chain — known CVEs in installed packages, secrets about to be committed, and lockfile/provenance integrity — and wire the checks into CI as a merge gate. Use when asked to audit dependencies, check for vulnerable packages, scan for leaked secrets, add a security gate to CI, or harden the supply chain. Complements security-audit (app-level) and git-safety (git history).
 user-invocable: true
 argument-hint: "[audit | ci]"
-compatibility: Requires bun and git; gh to add the CI workflow. Uses gitleaks/trivy when available.
-allowed-tools: Bash(bun *) Bash(git *) Bash(gh *)
+compatibility: Requires bun and git; gh to add the CI workflow. Uses gitleaks when available.
+allowed-tools: Bash(bun *) Bash(git *) Bash(gh *) Bash(gitleaks *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "security, dependencies, sca, secrets, supply-chain, ci"
   author: Ship Shit Dev
 when_to_use: "audit dependencies, dependency audit, vulnerable packages, CVE scan, scan for secrets, secrets scanning, supply chain, add security gate to CI, SCA"
@@ -106,13 +106,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
+      - name: Verify one immutable Bun lockfile
+        shell: bash
+        run: |
+          test -f bun.lock
+          for stray in package-lock.json yarn.lock pnpm-lock.yaml; do
+            test ! -e "$stray" || { echo "Mixed lockfile: $stray"; exit 1; }
+          done
+          bun install --frozen-lockfile
+          git diff --exit-code -- bun.lock
+      - name: Reject unreviewed dependency lifecycle scripts
+        shell: bash
+        run: |
+          untrusted="$(bun pm untrusted)"
+          printf '%s\n' "$untrusted"
+          if [[ "$untrusted" == *"These dependencies had their lifecycle scripts blocked during install."* ]]; then
+            echo "Review package provenance before adding it to trustedDependencies."
+            exit 1
+          fi
       - run: bun audit --audit-level=high      # fail the PR on high/critical CVEs
       - uses: gitleaks/gitleaks-action@v2       # fail on any leaked secret
 ```
 
-Pin action versions, keep `permissions` least-privilege (`contents: read`), and set
-the audit threshold to the team's risk tolerance (default: fail on high/critical).
+The lockfile step rejects mixed package managers and install drift. The lifecycle step
+blocks newly introduced install scripts until their package provenance is reviewed and
+the package is explicitly trusted. Typosquat and package-age checks still require
+human judgment in `audit` mode; do not claim the CI gate can infer them reliably.
+
+Pin action versions, keep `permissions` least-privilege (`contents: read`), and set the
+audit threshold to the team's risk tolerance (default: fail on high/critical).
 
 ## Anti-Patterns
 

--- a/bundles/security/skills/dependency-audit/plugin.json
+++ b/bundles/security/skills/dependency-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-audit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Audit dependency CVEs, leaked secrets, and lockfile integrity; wire the checks into CI.",
   "author": {
     "name": "Ship Shit Dev",

--- a/commands/deslop.md
+++ b/commands/deslop.md
@@ -12,6 +12,7 @@ copy, default-shadcn UI, missing loading/error states, dead buttons and half-wir
 /deslop ui [target]  # audit/fix UI slop with the design-system primitive pass
 /deslop --changed    # clean only the lines this branch introduced (diff-only)
 /deslop --product    # also strip product slop (copy / UI / UX)
+/deslop --changed --product # combine diff-only scope with product cleanup
 /deslop all          # sweep every package in a monorepo
 /deslop dry-run      # preview the cleanup, change nothing
 ```

--- a/commands/roadmap.md
+++ b/commands/roadmap.md
@@ -23,7 +23,7 @@ as things change.
    for segment / pain / willingness-to-pay / buying trigger / churn, and writes
    `.agents/memory/icp.md` after you approve the draft. Everything downstream ranks
    against this.
-2. **`analyze`** → the `roadmap-analyzer` skill. Reads `icp.md`, inventories what
+2. **`analyze`** → the `roadmap-analyzer` skill. Reads `.agents/memory/icp.md`, inventories what
    already ships, and ranks gaps by revenue impact (Land / Retain / Expand), with a
    finish-over-start rule so half-shipped core features outrank new starts.
 3. **`milestones`** → the `roadmap-to-milestones` skill. Turns the ranked backlog

--- a/scripts/validate-skill-sync.sh
+++ b/scripts/validate-skill-sync.sh
@@ -425,7 +425,7 @@ check_model_references() {
     hits=$(grep -rInE "$model_re" \
         --include='SKILL.md' --include='*.md' --include='*.py' \
         --include='*.js' --include='*.ts' --include='*.sh' \
-        "$skill_dir" 2>/dev/null | grep -v '/README.md:' || true)
+        "$skill_dir" 2>/dev/null || true)
 
     if [[ -n "$hits" ]]; then
         while IFS= read -r hit; do
@@ -442,7 +442,6 @@ check_model_references() {
         --include='SKILL.md' --include='*.md' --include='*.py' \
         --include='*.js' --include='*.ts' --include='*.sh' \
         "$skill_dir" 2>/dev/null \
-        | grep -v '/README.md:' \
         | grep -viE 'model["'"'"']?\s*[:=]\s*["'"'"']?(sonnet|opus|haiku)' \
         | grep -vE "$model_re" || true)
 

--- a/skills/dependency-audit/SKILL.md
+++ b/skills/dependency-audit/SKILL.md
@@ -3,10 +3,10 @@ name: dependency-audit
 description: Audit a project's dependency supply chain — known CVEs in installed packages, secrets about to be committed, and lockfile/provenance integrity — and wire the checks into CI as a merge gate. Use when asked to audit dependencies, check for vulnerable packages, scan for leaked secrets, add a security gate to CI, or harden the supply chain. Complements security-audit (app-level) and git-safety (git history).
 user-invocable: true
 argument-hint: "[audit | ci]"
-compatibility: Requires bun and git; gh to add the CI workflow. Uses gitleaks/trivy when available.
-allowed-tools: Bash(bun *) Bash(git *) Bash(gh *)
+compatibility: Requires bun and git; gh to add the CI workflow. Uses gitleaks when available.
+allowed-tools: Bash(bun *) Bash(git *) Bash(gh *) Bash(gitleaks *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "security, dependencies, sca, secrets, supply-chain, ci"
   author: Ship Shit Dev
 when_to_use: "audit dependencies, dependency audit, vulnerable packages, CVE scan, scan for secrets, secrets scanning, supply chain, add security gate to CI, SCA"
@@ -106,13 +106,35 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
+      - name: Verify one immutable Bun lockfile
+        shell: bash
+        run: |
+          test -f bun.lock
+          for stray in package-lock.json yarn.lock pnpm-lock.yaml; do
+            test ! -e "$stray" || { echo "Mixed lockfile: $stray"; exit 1; }
+          done
+          bun install --frozen-lockfile
+          git diff --exit-code -- bun.lock
+      - name: Reject unreviewed dependency lifecycle scripts
+        shell: bash
+        run: |
+          untrusted="$(bun pm untrusted)"
+          printf '%s\n' "$untrusted"
+          if [[ "$untrusted" == *"These dependencies had their lifecycle scripts blocked during install."* ]]; then
+            echo "Review package provenance before adding it to trustedDependencies."
+            exit 1
+          fi
       - run: bun audit --audit-level=high      # fail the PR on high/critical CVEs
       - uses: gitleaks/gitleaks-action@v2       # fail on any leaked secret
 ```
 
-Pin action versions, keep `permissions` least-privilege (`contents: read`), and set
-the audit threshold to the team's risk tolerance (default: fail on high/critical).
+The lockfile step rejects mixed package managers and install drift. The lifecycle step
+blocks newly introduced install scripts until their package provenance is reviewed and
+the package is explicitly trusted. Typosquat and package-age checks still require
+human judgment in `audit` mode; do not claim the CI gate can infer them reliably.
+
+Pin action versions, keep `permissions` least-privilege (`contents: read`), and set the
+audit threshold to the team's risk tolerance (default: fail on high/critical).
 
 ## Anti-Patterns
 

--- a/skills/dependency-audit/plugin.json
+++ b/skills/dependency-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "dependency-audit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Audit dependency CVEs, leaked secrets, and lockfile integrity; wire the checks into CI.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/full-code-review/SKILL.md
+++ b/skills/full-code-review/SKILL.md
@@ -11,7 +11,7 @@ description: >-
   prioritized backlog instead of a merge verdict.
 compatibility: Requires gh CLI and git for PR diff fetching.
 metadata:
-  version: "1.0.1"
+  version: "1.0.2"
   tags: "code-review, security, structural, devex, orchestration, pr-gate"
   author: Ship Shit Dev
 allowed-tools: Bash(git *) Bash(gh *)
@@ -74,8 +74,8 @@ Outputs:
 - **PR mode:** verdict approve / request-changes / block — with one-sentence
   rationale.
 - **Retro mode:** verdict `retro-backlog` (never blocks anything) — findings
-  bucketed bug / optimization / refactor and ranked by (impact × recurrence) ÷
-  effort, for scheduling as follow-up work.
+  bucketed bug / optimization / refactor / other and ranked by (impact × recurrence)
+  ÷ effort, for scheduling as follow-up work.
 - Dimensions reviewed and adversarial refutation count.
 
 Creates/Modifies:
@@ -174,6 +174,10 @@ Optimizations:
 Refactors:
 [rank]. [SEVERITY] <file> — <finding>   (commits: <sha>, <sha>, <sha>)
   Fix: <consolidation>
+
+Other follow-ups:
+[rank]. [SEVERITY] <file> — <finding>   (commits: <sha>)
+  Fix: <remediation>
 
 Dimensions reviewed: structural, security, devex, cross-commit
 Adversarial pass: <N raw> → <M surviving>

--- a/skills/full-code-review/plugin.json
+++ b/skills/full-code-review/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "full-code-review",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Run orchestrated PR review with parallel reviewers, verification, and synthesis.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/full-code-review/scripts/full-code-review.js
+++ b/skills/full-code-review/scripts/full-code-review.js
@@ -372,7 +372,7 @@ log(IS_RETRO ? "Phase 3: Synthesis (retro backlog)" : "Phase 3: Synthesis (merge
 
 const verdictSchema = {
   type: "object",
-  required: ["verdict", "rationale", "prioritized_findings", "stats"],
+  required: ["mode", "verdict", "rationale", "prioritized_findings", "stats"],
   properties: {
     mode: {
       type: "string",
@@ -391,12 +391,12 @@ const verdictSchema = {
       type: "array",
       items: {
         type: "object",
-        required: ["rank", "severity", "dimension", "file", "finding", "evidence", "fix", "overlap_weight"],
+        required: ["rank", "severity", "dimension", "bucket", "file", "finding", "evidence", "fix", "overlap_weight"],
         properties: {
           rank:           { type: "integer" },
           severity:       { type: "string", enum: ["BLOCKER", "HIGH", "MEDIUM", "LOW"] },
           dimension:      { type: "string" },
-          bucket:         { type: "string", enum: ["bug", "optimization", "refactor", "other"], description: "Retro grouping; omit in pr mode" },
+          bucket:         { type: "string", enum: ["bug", "optimization", "refactor", "other"], default: "other", description: "Retro grouping; use other in pr mode" },
           file:           { type: "string" },
           line:           { type: ["integer", "null"] },
           finding:        { type: "string" },
@@ -443,7 +443,7 @@ const prSynthesisPrompt = `You are the synthesis judge for a multi-dimension cod
    - "approve"          if only MEDIUM/LOW findings survive or none.
 5. Write a one-sentence rationale that names the most critical finding.
 
-Set \`mode\`: "pr".
+Set \`mode\`: "pr" and set every finding's \`bucket\` to "other".
 
 SURVIVING VERIFIED FINDINGS:
 ${redactSensitiveText(JSON.stringify(survivingFindings, null, 2))}
@@ -456,9 +456,9 @@ prioritized BACKLOG of follow-up work the team should schedule.
 
 1. Deduplicate findings describing the same root issue (merge evidence, union the
    commit SHAs).
-2. Assign each finding a \`bucket\`: "bug" (a defect shipped in the window),
+2. Assign every finding a \`bucket\`: "bug" (a defect shipped in the window),
    "optimization" (performance/cost left on the table), "refactor" (duplication,
-   drift, unstable abstraction), or "other".
+   drift, unstable abstraction), or "other". Never omit the bucket.
 3. Rank by value, not by gate. Order by (impact × recurrence) ÷ effort: a cheap fix
    that removes duplication reintroduced in five commits outranks an expensive
    rewrite that touches one. Shipped bugs always sort to the top of their tier.

--- a/skills/postgres-ops/SKILL.md
+++ b/skills/postgres-ops/SKILL.md
@@ -4,9 +4,9 @@ description: Operate a production Postgres database — backup strategy, point-i
 disable-model-invocation: true
 argument-hint: "[backup | restore | pooling | dr]"
 compatibility: Requires psql / pg_dump / pg_restore for self-managed instances; provider CLI for managed.
-allowed-tools: Bash(psql *) Bash(pg_dump *) Bash(pg_restore *) Bash(pg_basebackup *)
+allowed-tools: Bash(psql *) Bash(pg_dump *) Bash(pg_restore *) Bash(pg_basebackup *) Bash(createdb *) Bash(dropdb *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "postgres, backup, disaster-recovery, pooling, database, infrastructure"
   author: Ship Shit Dev
 when_to_use: "postgres backups, database backup strategy, point in time recovery, PITR, restore the database, connection pooling, PgBouncer, disaster recovery, DR runbook, harden postgres"
@@ -88,9 +88,13 @@ A backup is unproven until restored. Restore into a **scratch** database, never 
 production, and verify:
 
 ```bash
-createdb restore_check
-pg_restore --dbname=restore_check --clean --if-exists db-YYYY-MM-DD.dump
-psql restore_check -c "SELECT count(*) FROM <critical_table>;"   # sanity-check row counts
+scratch_db="restore_check_$(date +%s)"
+trap 'dropdb --if-exists "$scratch_db"' EXIT
+createdb "$scratch_db"
+pg_restore --dbname="$scratch_db" --clean --if-exists db-YYYY-MM-DD.dump
+psql "$scratch_db" -c "SELECT count(*) FROM <critical_table>;"   # sanity-check row counts
+dropdb "$scratch_db"
+trap - EXIT
 ```
 
 Only restore to production on an explicit, named request, after confirming the target

--- a/skills/postgres-ops/plugin.json
+++ b/skills/postgres-ops/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "postgres-ops",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Operate production Postgres: backups, point-in-time recovery, pooling, and disaster recovery.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/roadmap-to-milestones/SKILL.md
+++ b/skills/roadmap-to-milestones/SKILL.md
@@ -6,7 +6,7 @@ disable-model-invocation: true
 allowed-tools: Bash(gh *) Bash(git *)
 argument-hint: "[roadmap file, or 'burndown']"
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, milestones, roadmap, planning, burndown, mrr"
   author: Ship Shit Dev
 when_to_use: "create milestones, roadmap to milestones, set milestone due dates, group issues under a milestone, turn the roadmap into a schedule, milestone burndown, milestone progress"
@@ -28,7 +28,8 @@ this uses `gh api repos/{owner}/{repo}/milestones`.
 
 Inputs:
 
-- A roadmap (from `roadmap-analyzer`), a theme list, or a set of existing issues.
+- A revenue-ranked roadmap (from `roadmap-analyzer`), a ranked theme list, or a
+  ranked set of existing issues.
 - The target repo and a cadence or explicit due dates.
 
 Outputs:
@@ -69,8 +70,9 @@ gh api "repos/{owner}/{repo}/milestones?state=all" \
   --jq '.[] | {number, title, due_on, open_issues, closed_issues}'
 ```
 
-If the roadmap is missing, stop and recommend `roadmap-analyzer`. Sequencing without a
-revenue ranking just dates an arbitrary list.
+Continue when any supplied input is explicitly revenue-ranked: a roadmap, theme list,
+or issue set. If none is ranked, stop and recommend `roadmap-analyzer`; sequencing an
+unranked input just dates an arbitrary list.
 
 ## Step 2 — Derive milestones from themes
 
@@ -91,14 +93,20 @@ not force it in.
 
 ## Step 3 — Draft and confirm
 
-Show the full plan before any write:
+Reconcile every proposed title against the milestone inventory before presenting the
+plan. Match titles case-insensitively after trimming surrounding whitespace, but never
+fuzzy-match materially different names. Classify each proposal as `create`, `update`
+(same title, changed description or due date), or `unchanged`, and retain the existing
+milestone number for updates.
+
+Show the full reconciled plan before any write:
 
 ```text
 Milestones plan — <repo>
 
-1. Land: <theme>        due <date>   — <lever, metric>
+1. [update #4] Land: <theme>  due <date> — <lever, metric>
      #12 <issue>   #15 <issue>
-2. Retain: <theme>      due <date>   — <lever, metric>
+2. [create] Retain: <theme>    due <date> — <lever, metric>
      #18 <issue>
 Unassigned (need a home): #21 <issue> — <why it fits no theme>
 ```
@@ -107,10 +115,16 @@ Wait for approval. Let the user move dates or issues before committing.
 
 ## Step 4 — Create milestones and assign issues
 
-After approval, create each milestone, then assign its issues:
+After approval, PATCH each matching milestone by its inventoried number, create only
+unmatched milestones, skip unchanged milestones, then assign issues:
 
 ```bash
-# Create a milestone (due_on is ISO 8601 UTC). Capture the returned number.
+# Update a title-matched milestone first (due_on is ISO 8601 UTC).
+gh api -X PATCH repos/{owner}/{repo}/milestones/4 \
+  -f description="Lever: Land primary segment. Success: first-week activation >40%." \
+  -f due_on="2026-08-01T00:00:00Z"
+
+# Create only when reconciliation found no title match. Capture the returned number.
 gh api repos/{owner}/{repo}/milestones \
   -f title="Land: agency onboarding" \
   -f description="Lever: Land primary segment. Success: first-week activation >40%." \
@@ -118,12 +132,6 @@ gh api repos/{owner}/{repo}/milestones \
 
 # Assign issues by milestone title (gh resolves the title to its number).
 gh issue edit 12 --milestone "Land: agency onboarding"
-```
-
-To update an existing milestone instead of duplicating it, PATCH by its number:
-
-```bash
-gh api -X PATCH repos/{owner}/{repo}/milestones/<number> -f due_on="2026-08-15T00:00:00Z"
 ```
 
 ## Step 5 — Burndown
@@ -136,8 +144,9 @@ gh api "repos/{owner}/{repo}/milestones?state=open" \
 ```
 
 Flag any milestone that is **overdue with open issues** or **empty** (a dated bucket
-with no work is a planning smell). Recommend the next move: pull P0 issues into the
-board's `In Progress`, or re-date a milestone that cannot land in time.
+with no work is a planning smell). Recommend milestone-only recovery: re-date it,
+rebalance issues into a later milestone, or split its scope. Never change or recommend
+changing the board's `Status` field from this skill.
 
 ## Anti-Patterns
 

--- a/skills/roadmap-to-milestones/plugin.json
+++ b/skills/roadmap-to-milestones/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "roadmap-to-milestones",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Turn a revenue-ranked roadmap into GitHub milestones with due dates and burndown.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/vercel-deploy/SKILL.md
+++ b/skills/vercel-deploy/SKILL.md
@@ -4,9 +4,9 @@ description: Deploy a Next.js app to Vercel and manage its environment — previ
 compatibility: Requires the Vercel CLI authenticated, and a linked project (.vercel/project.json).
 disable-model-invocation: true
 argument-hint: "[preview | prod | rollback | env]"
-allowed-tools: Bash(vercel *) Bash(git *) Bash(gh *)
+allowed-tools: Bash(vercel *)
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "vercel, deploy, nextjs, rollback, environments, infrastructure"
   author: Ship Shit Dev
 when_to_use: "deploy to Vercel, ship a preview, deploy to production, promote to production, roll back the deploy, revert deployment, manage Vercel env vars, /deploy vercel"

--- a/skills/vercel-deploy/plugin.json
+++ b/skills/vercel-deploy/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "vercel-deploy",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Deploy a Next.js app to Vercel: preview, production, rollback, and env vars, safely gated.",
   "author": {
     "name": "Ship Shit Dev",


### PR DESCRIPTION
Closes #52

## Summary
- make full-code-review mode and bucket output deterministic, including the retro Other section
- reconcile roadmap milestones before writes and keep recovery guidance out of board Status
- align dependency-audit tooling with its claims and add lockfile/lifecycle provenance CI gates
- make Postgres restore drills clean up scratch databases and narrow the Vercel deploy allowlist
- document composed deslop flags, use the canonical ICP path, and scan README files for model leakage

## Review finding disposition
- Vercel bundle manifest: already correct and intentionally unchanged. The generated bundle root uses `{ "path": "./skills" }`; the copied per-skill plugin manifest correctly uses `"."` under the current skill standard.
- Typosquat/package-age provenance: remains an explicit human audit check because CI cannot infer it reliably; CI now blocks mixed lockfiles, install drift, and unreviewed lifecycle scripts.

## Verification
- `bun run marketplace:generate`
- focused markdownlint
- `node --check skills/full-code-review/scripts/full-code-review.js`
- `./scripts/validate-skill-sync.sh`
- `git diff --check`

No tests, typechecks, or builds were run locally per repository policy.