### PR TITLE
docs: define the harness-owned execution boundary

### DIFF
--- a/.agents/memory/system/execution-boundary.md
+++ b/.agents/memory/system/execution-boundary.md
@@ -1,0 +1,112 @@
+# Harness-Owned Execution Boundary
+
+Reusable agent content defines **what outcome to pursue and what constraints to
+honor**. The harness or app defines **where, when, and with which execution lane it
+runs**. This boundary applies to public skills, Claude command bodies, Claude
+scheduled-task routines, and Codex automation prompt bodies.
+
+## Normative split
+
+| Harness or app owns | Reusable content owns |
+|---|---|
+| Model and reasoning/effort level | Objective and selection logic |
+| Schedule, recurrence, and wake-up policy | Domain invariants and stop conditions |
+| Project, current working directory, and workspace | Safety and confirmation gates |
+| Worktree versus local/source checkout | Evidence and verification requirements |
+| Approval mode, sandbox, and execution environment | Output and handoff contract |
+| Authentication and account selection | Parameter names and safe defaults |
+
+Do not copy app-owned values into a reusable prompt or frontmatter. A prompt may
+**verify** a safety invariant supplied by the app—for example, stop if the current
+repository is not the expected one—but it must not choose a checkout, model, effort
+level, schedule, sandbox, or working directory.
+
+## Artifact rules
+
+### Public skills
+
+- Omit `model` and `effort` from public skill frontmatter. Inherit the active session
+  lane selected by the harness.
+- Keep execution prerequisites in `compatibility`, but do not turn compatibility into
+  app configuration. "Requires an authenticated GitHub CLI" is portable; "run in
+  `/path/to/project` with model X" is not.
+- Put mutation, external-message, and destructive-action gates in the body so every
+  harness sees them. Platform-only invocation guards may add defense in depth, but
+  never carry the only copy of a safety rule.
+
+### Claude commands
+
+- Treat `commands/` as thin entry-point documentation that routes to portable skills.
+- Keep model, effort, project directory, and scheduling out of command bodies. Claude
+  settings and the active session own them.
+- A repo-specific command may name a stable domain concept or route, but paths and
+  environment selection still come from the project/session context.
+
+### Scheduled routines and automations
+
+- Write one parameterized routine body per objective family. Bind its target through
+  the app's project/cwd fields instead of cloning the body per repository.
+- Keep the routine body limited to objective, scope selection, safety gates, evidence,
+  and output. The schedule editor or automation configuration owns recurrence, model,
+  effort, environment, target checkout, and cwd.
+- Unattended does not mean unrestricted. Default to reporting. Require explicit policy
+  in the routine body before writing files, sending external messages, merging,
+  deploying, deleting, or performing another irreversible action.
+
+## Portable routine example
+
+Use the same routine body in both harnesses:
+
+```text
+Review dependency drift in the current repository. Report high-risk changes with
+file-backed evidence. Do not modify files or open issues unless this routine instance
+explicitly authorizes that write. Never merge, deploy, delete, or send an external
+message without an explicit action-specific gate.
+```
+
+Configure the execution outside that body:
+
+| Claude scheduled task | Codex automation |
+|---|---|
+| App selects project, schedule, session effort, and execution context | Automation fields select cwds/target, schedule, model, reasoning effort, and environment |
+| Task `SKILL.md` contains the portable routine body | Automation prompt contains the same portable routine body |
+
+These examples describe ownership only; they do not create a schedule or prescribe a
+particular app configuration shape.
+
+## Project-specific content
+
+Project-specific content is legitimate when it is a durable **domain invariant**:
+protected branch names, release policy, required evidence, or a known safety boundary.
+Store those facts in the project's instruction or memory files and let the routine read
+the current project context.
+
+Do not bake machine paths, workspace IDs, account names, worktree selection, or
+environment names into reusable content. If an objective truly needs a target name,
+declare a semantic parameter such as `TARGET_REPOSITORY`; let the app bind it and use
+the app-selected cwd as the execution location.
+
+## Migration
+
+To migrate existing duplicated prompts without creating or changing live schedules:
+
+1. Inventory normalized routine bodies and group copies by objective.
+2. Redact values; compare only field names and prompt structure.
+3. Extract one portable body containing the objective, invariants, safety gates,
+   evidence, and output contract.
+4. Remove model, effort, schedule, cwd, workspace, environment, and checkout selection
+   from the body.
+5. Parameterize only genuine domain inputs; bind execution location through app fields.
+6. Review each existing app configuration against the new body before manually
+   replacing it. Do not create, enable, or reschedule anything during the audit.
+7. Keep the old copies until each migrated instance has produced one expected report;
+   then retire the duplicates.
+
+## Review checklist
+
+- [ ] No concrete model, tier, or effort selection in reusable content
+- [ ] No recurrence or schedule text duplicated from the app
+- [ ] No machine path, workspace ID, or checkout-selection instruction
+- [ ] Objective and scope selection remain understandable without platform metadata
+- [ ] Writes, external messages, and destructive actions have explicit gates
+- [ ] Evidence and output contracts are deterministic

--- a/.agents/memory/system/platform-adaptations.md
+++ b/.agents/memory/system/platform-adaptations.md
@@ -2,6 +2,11 @@
 
 Skills in this library target **Claude Code and Codex together**. The shared baseline is the Agent Skills spec, and Claude-specific frontmatter extensions are allowed when they add real value.
 
+Execution settings are not platform adaptations. Follow the normative
+[Harness-Owned Execution Boundary](execution-boundary.md): the app owns model,
+effort, schedule, cwd/workspace, checkout selection, and execution environment;
+reusable content owns the objective, invariants, safety gates, evidence, and output.
+
 ## The Rule
 
 **Write one SKILL.md that works cleanly in Codex and still exposes Claude-specific capabilities where useful.**
@@ -35,7 +40,7 @@ disable-model-invocation: true
 ---
 ```
 
-Keep `version`, `tags`, and custom metadata inside `metadata`. Claude Code extension fields may stay top-level when they are intentionally used: `when_to_use`, `disable-model-invocation`, `user-invocable`, `argument-hint`, `model`, `effort`, `context`, `agent`, `hooks`, `paths`, and `shell`.
+Keep `version`, `tags`, and custom metadata inside `metadata`. Claude Code extension fields may stay top-level when they are intentionally used: `when_to_use`, `disable-model-invocation`, `user-invocable`, `argument-hint`, `context`, `agent`, `hooks`, `paths`, and `shell`. Claude Code also recognizes `model` and `effort`, but public reusable skills must omit them and inherit app/session configuration.
 
 ## Writing Style
 

--- a/.agents/memory/system/skill-standards.md
+++ b/.agents/memory/system/skill-standards.md
@@ -1,6 +1,6 @@
 # Skill Standards
 
-This repo follows the [Agent Skills open standard](https://agentskills.io/specification) as the base spec, extended with Claude Code-specific fields. Codex compatibility comes from the base spec plus the skill body; Claude can additionally use the extension fields.
+This repo follows the [Agent Skills open standard](https://agentskills.io/specification) as the base spec, extended with selected Claude Code-specific fields. Codex compatibility comes from the base spec plus the skill body; Claude can additionally use approved extension fields. The normative split between reusable content and app configuration lives in [Harness-Owned Execution Boundary](execution-boundary.md).
 
 ---
 
@@ -24,8 +24,8 @@ This repo follows the [Agent Skills open standard](https://agentskills.io/specif
 | `when_to_use` | Extra trigger phrases appended to `description` in skill listing. Combined with `description`, capped at 1,536 chars. |
 | `disable-model-invocation` | `true` = only user can invoke (no auto-trigger). Use for destructive/side-effect skills. |
 | `user-invocable` | `false` = hides from `/` menu. Use for background knowledge skills. |
-| `model` | Override model for this skill. |
-| `effort` | Override effort level: `low`, `medium`, `high`, `xhigh`, `max`. |
+| `model` | Recognized by Claude Code, but forbidden in this public library; the harness owns model selection. |
+| `effort` | Recognized by Claude Code, but forbidden in this public library; the harness owns reasoning effort. |
 | `context` | `fork` = run in isolated subagent. Only for skills with an actionable task — a guidelines-only skill returns **empty output** when forked. ⚠️ May not be honored via the Skill tool (issue #17283). |
 | `agent` | Subagent type when `context: fork`. Options: `Explore`, `Plan`, `general-purpose`, or custom. |
 | `hooks` | Lifecycle hooks scoped to this skill. |
@@ -162,7 +162,6 @@ Rules:
 | `context: fork` | Skill does independent research/exploration that shouldn't see conversation history (must have an actionable task — guidelines-only forks return empty) |
 | `allowed-tools` | You want to skip the per-use prompt for tools the skill calls repeatedly. Remember it only *auto-approves*, it does not restrict — see note below |
 | `disallowed-tools` | You need to actually **block** a tool while the skill runs (e.g. keep an autonomous loop from calling `AskUserQuestion`) |
-| `effort: high` | Skill requires deep reasoning (architecture decisions, complex debugging) |
 | `paths` | ~~Skill only applies to specific file types~~ — avoid until issue #49835 is fixed (sets the skill undiscoverable); use nested `.claude/skills/` dirs instead |
 
 **`allowed-tools` is an allowlist, not a sandbox.** Listing tools only bypasses their permission prompt; every unlisted tool is still callable and just prompts as normal. Narrowing `allowed-tools` does not lock a skill down — use `disallowed-tools`, deny rules, or hooks to actually block. For MCP tools, list the fully-qualified `ServerName:tool_name` so the grant resolves when multiple MCP servers are connected.
@@ -236,10 +235,9 @@ touches only the per-repo routing block, never the skills.
   the repo routing block (`CLAUDE.md`/`AGENTS.md`, written by `setup-agent-routing`),
   so one per-repo file absorbs each model generation and each harness (Claude,
   Codex) maps the tiers to its own models.
-- **The `model:` frontmatter field**, if set, carries a tier alias the harness
-  resolves (`sonnet`, `opus` as Claude aliases — the field is Claude-only), not a
-  version-pinned ID. Prefer omitting it and inheriting the session model unless the
-  skill genuinely needs a fixed tier.
+- **Do not set `model:` or `effort:` in public skills.** Although Claude Code parses
+  those extension fields, model and reasoning-effort selection belong to the active
+  session or app configuration. See [Harness-Owned Execution Boundary](execution-boundary.md).
 - **External tools are lanes, not models.** Naming Codex, `gh`, or a CLI as a
   dependency the skill shells out to is fine (it is a tool, like `git`). Naming the
   model that tool runs is not.

--- a/.agents/skills/skill-auditor/SKILL.md
+++ b/.agents/skills/skill-auditor/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Run periodically or before releases.
 metadata:
   internal: true
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "audit, skills, quality, maintenance"
 ---
 
@@ -31,6 +31,9 @@ For each SKILL.md, check:
 - `version`/`tags` inside `metadata:` block, not top-level
 - No forbidden fields (`auto_activate`, `auto_trigger`, `risk`)
 - `metadata.tags` is a comma-separated string, not YAML list
+- No harness-owned execution parameters in reusable content; apply
+  `.agents/memory/system/execution-boundary.md` to skills, commands, and routine
+  templates
 
 ### 3. Structural Issues
 

--- a/.agents/skills/skill-validator/SKILL.md
+++ b/.agents/skills/skill-validator/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Run on new or modified skills before committing.
 metadata:
   internal: true
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "validation, skills, spec-compliance, quality"
 ---
 
@@ -69,8 +69,6 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 | `disallowed-tools` | Removes tools from the pool while active (the actual block mechanism) |
 | `argument-hint` | Autocomplete hint for expected arguments |
 | `compatibility` | Environment prerequisites (packages, network, target agent) |
-| `model` | Tier-alias override (never a version-pinned ID — see Model References) |
-| `effort` | Effort level (`low`…`max`) |
 | `context` | `fork` for subagent isolation |
 | `agent` | Subagent type when `context: fork` |
 | `hooks` | Lifecycle hooks scoped to the skill |
@@ -81,6 +79,8 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 
 - `auto_activate` / `auto_trigger` — removed in 2026-04 migration
 - `risk` — not in any spec
+- `model` / `effort` — recognized by Claude Code but owned by app/session
+  configuration, not public reusable skills
 - Any top-level field not in the tables above → "Unsupported top-level frontmatter field"
 
 ### Content Rules
@@ -89,7 +89,9 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 - No tool names in instructions (say "search for" not "use Grep")
 - Imperative/infinitive style ("Configure X" not "You should configure X")
 - Code blocks use real backtick fences, not escaped `\`\`\``
-- **No concrete model names** in body, `references/`, or `scripts/` — reject tier+version IDs (`claude-3-7-sonnet-20250219`, `claude-opus-4.5`, `gpt-5.5`), dated snapshots, and bare family names used as routing keys. Exception: orchestrator skills may name **capability tiers** in prose. See [skill-standards.md → Model references](../../memory/system/skill-standards.md).
+- **No concrete model names** in body, `references/`, or `scripts/` — reject tier+version IDs (`claude-3-7-sonnet-20250219`, `claude-opus-4.5`, `gpt-5.5`), dated snapshots, and bare family names used as routing keys. Exception: orchestrator skills may name **capability tiers** in prose. See [skill-standards.md → Model references](../memory/system/skill-standards.md).
+- **No harness-owned execution parameters** in skills, commands, or routine templates.
+  Apply [execution-boundary.md](../memory/system/execution-boundary.md).
 - **Provenance (derived skills only):** when `metadata.source` is set, `metadata.last_synced` and a README `## Upstream` section are required (enforced by `check_provenance()`). In-house skills need no provenance fields.
 
 ## Validation Process
@@ -100,7 +102,7 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 4. Check `description` plus `when_to_use` is under 1536 chars
 5. Check `plugin.json` description is present and under 100 chars
 6. Check `version`/`tags` are NOT top-level (must be inside `metadata:`)
-7. Check for forbidden fields (`auto_activate`, `auto_trigger`, `risk`, any field not in the extension tables)
+7. Check for forbidden fields (`auto_activate`, `auto_trigger`, `risk`, `model`, `effort`, any field not in the extension tables)
 8. Check for escaped backtick fences in content
 9. Check for hardcoded paths (`/workspace/`, project-specific paths)
 10. Grep body + `references/` + `scripts/` for concrete model names (`claude-*`, `gpt-*`, `sonnet`/`opus`/`haiku` used as IDs); allow only capability-tier prose in orchestrator skills

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ touch skills/my-skill/SKILL.md
 - `.agents/memory/system/skill-management.md` - Single-source skill workflow
 - `.agents/memory/system/architecture.md` - .agents folder structure
 - `.agents/memory/system/platform-adaptations.md` - Claude vs Codex writing guide
+- `.agents/memory/system/execution-boundary.md` - app-owned execution settings vs reusable content
 - `.agents/memory/system/ai-dev-loop.md` - Board-driven autonomous dev loop (`/loop` + agent-dispatch)
 
 ## Development Commands


### PR DESCRIPTION
Closes #67

## Summary
- add one normative boundary for skills, Claude commands and scheduled routines, and Codex automation prompts
- assign model, effort, schedule, cwd/workspace, checkout, sandbox, and environment selection to the app/harness
- keep objective logic, domain invariants, safety gates, evidence, and output contracts in reusable content
- add portable Claude/Codex routine examples plus a no-live-schedule migration procedure
- update standards and maintenance meta-skills to forbid model/effort overrides in public skills

## Verification
- focused markdownlint
- `git diff --check`

No tests, typechecks, builds, or live automation changes were run.