### PR TITLE
fix: harden agent-config-audit activation and permissions

### DIFF
--- a/.agents/memory/system/execution-boundary.md
+++ b/.agents/memory/system/execution-boundary.md
@@ -1,0 +1,112 @@
+# Harness-Owned Execution Boundary
+
+Reusable agent content defines **what outcome to pursue and what constraints to
+honor**. The harness or app defines **where, when, and with which execution lane it
+runs**. This boundary applies to public skills, Claude command bodies, Claude
+scheduled-task routines, and Codex automation prompt bodies.
+
+## Normative split
+
+| Harness or app owns | Reusable content owns |
+|---|---|
+| Model and reasoning/effort level | Objective and selection logic |
+| Schedule, recurrence, and wake-up policy | Domain invariants and stop conditions |
+| Project, current working directory, and workspace | Safety and confirmation gates |
+| Worktree versus local/source checkout | Evidence and verification requirements |
+| Approval mode, sandbox, and execution environment | Output and handoff contract |
+| Authentication and account selection | Parameter names and safe defaults |
+
+Do not copy app-owned values into a reusable prompt or frontmatter. A prompt may
+**verify** a safety invariant supplied by the app—for example, stop if the current
+repository is not the expected one—but it must not choose a checkout, model, effort
+level, schedule, sandbox, or working directory.
+
+## Artifact rules
+
+### Public skills
+
+- Omit `model` and `effort` from public skill frontmatter. Inherit the active session
+  lane selected by the harness.
+- Keep execution prerequisites in `compatibility`, but do not turn compatibility into
+  app configuration. "Requires an authenticated GitHub CLI" is portable; "run in
+  `/path/to/project` with model X" is not.
+- Put mutation, external-message, and destructive-action gates in the body so every
+  harness sees them. Platform-only invocation guards may add defense in depth, but
+  never carry the only copy of a safety rule.
+
+### Claude commands
+
+- Treat `commands/` as thin entry-point documentation that routes to portable skills.
+- Keep model, effort, project directory, and scheduling out of command bodies. Claude
+  settings and the active session own them.
+- A repo-specific command may name a stable domain concept or route, but paths and
+  environment selection still come from the project/session context.
+
+### Scheduled routines and automations
+
+- Write one parameterized routine body per objective family. Bind its target through
+  the app's project/cwd fields instead of cloning the body per repository.
+- Keep the routine body limited to objective, scope selection, safety gates, evidence,
+  and output. The schedule editor or automation configuration owns recurrence, model,
+  effort, environment, target checkout, and cwd.
+- Unattended does not mean unrestricted. Default to reporting. Require explicit policy
+  in the routine body before writing files, sending external messages, merging,
+  deploying, deleting, or performing another irreversible action.
+
+## Portable routine example
+
+Use the same routine body in both harnesses:
+
+```text
+Review dependency drift in the current repository. Report high-risk changes with
+file-backed evidence. Do not modify files or open issues unless this routine instance
+explicitly authorizes that write. Never merge, deploy, delete, or send an external
+message without an explicit action-specific gate.
+```
+
+Configure the execution outside that body:
+
+| Claude scheduled task | Codex automation |
+|---|---|
+| App selects project, schedule, session effort, and execution context | Automation fields select cwds/target, schedule, model, reasoning effort, and environment |
+| Task `SKILL.md` contains the portable routine body | Automation prompt contains the same portable routine body |
+
+These examples describe ownership only; they do not create a schedule or prescribe a
+particular app configuration shape.
+
+## Project-specific content
+
+Project-specific content is legitimate when it is a durable **domain invariant**:
+protected branch names, release policy, required evidence, or a known safety boundary.
+Store those facts in the project's instruction or memory files and let the routine read
+the current project context.
+
+Do not bake machine paths, workspace IDs, account names, worktree selection, or
+environment names into reusable content. If an objective truly needs a target name,
+declare a semantic parameter such as `TARGET_REPOSITORY`; let the app bind it and use
+the app-selected cwd as the execution location.
+
+## Migration
+
+To migrate existing duplicated prompts without creating or changing live schedules:
+
+1. Inventory normalized routine bodies and group copies by objective.
+2. Redact values; compare only field names and prompt structure.
+3. Extract one portable body containing the objective, invariants, safety gates,
+   evidence, and output contract.
+4. Remove model, effort, schedule, cwd, workspace, environment, and checkout selection
+   from the body.
+5. Parameterize only genuine domain inputs; bind execution location through app fields.
+6. Review each existing app configuration against the new body before manually
+   replacing it. Do not create, enable, or reschedule anything during the audit.
+7. Keep the old copies until each migrated instance has produced one expected report;
+   then retire the duplicates.
+
+## Review checklist
+
+- [ ] No concrete model, tier, or effort selection in reusable content
+- [ ] No recurrence or schedule text duplicated from the app
+- [ ] No machine path, workspace ID, or checkout-selection instruction
+- [ ] Objective and scope selection remain understandable without platform metadata
+- [ ] Writes, external messages, and destructive actions have explicit gates
+- [ ] Evidence and output contracts are deterministic

--- a/.agents/memory/system/platform-adaptations.md
+++ b/.agents/memory/system/platform-adaptations.md
@@ -67,19 +67,28 @@ Codex-safe rule: never make the skill depend on Claude-only frontmatter to be un
 
 ## When Platform-Specific Content Is Needed
 
-Rare cases where a skill legitimately needs different behavior per platform (e.g., `agent-folder-init` scaffolding different config directories):
+Keep the canonical `SKILL.md`, its references, and its scripts platform-neutral.
+HTML comments do not hide enclosed Markdown from a harness, so
+`PLATFORM-SPECIFIC-START/END` markers are forbidden and validation reads every line.
 
-```markdown
-<!-- PLATFORM-SPECIFIC-START: claude -->
-Config directory: `~/.claude/`
-<!-- PLATFORM-SPECIFIC-END: claude -->
+Put a small adapter **outside the skill body** when a harness needs a distinct entry
+surface. The adapter may route into a shared skill, expose a platform-native project
+instruction file, or point a platform loader at shared repo-management content. It
+must not duplicate the workflow.
 
-<!-- PLATFORM-SPECIFIC-START: cursor -->
-Config directory: `~/.cursor/`
-<!-- PLATFORM-SPECIFIC-END: cursor -->
-```
+Three real repository examples are checked by `scripts/validate-skill-sync.sh`:
 
-Use this sparingly. If more than 10% of a skill is platform-specific, consider splitting the skill or moving the CLI-specific material into `references/`.
+1. **Shared loader adapter:** `.claude/skills` and `.codex/skills` both link to
+   `.agents/skills`; neither contains a forked copy.
+2. **Command adapter:** `commands/review.md` is a thin command entry point that routes
+   to the portable `review-dispatch` skill.
+3. **Project-instruction adapter:** `AGENTS.md` contains Codex-facing repository
+   instructions outside every public skill body.
+
+The validator fails if either loader link drifts, the command stops routing to its
+canonical skill, the project instruction entry point disappears, or a canonical skill
+reintroduces platform-marker blocks. Bundle generation copies only validated canonical
+skill directories, so no target receives an incompatible hidden block.
 
 ## Skill-to-Skill References
 

--- a/.agents/memory/system/platform-adaptations.md
+++ b/.agents/memory/system/platform-adaptations.md
@@ -2,6 +2,11 @@
 
 Skills in this library target **Claude Code and Codex together**. The shared baseline is the Agent Skills spec, and Claude-specific frontmatter extensions are allowed when they add real value.
 
+Execution settings are not platform adaptations. Follow the normative
+[Harness-Owned Execution Boundary](execution-boundary.md): the app owns model,
+effort, schedule, cwd/workspace, checkout selection, and execution environment;
+reusable content owns the objective, invariants, safety gates, evidence, and output.
+
 ## The Rule
 
 **Write one SKILL.md that works cleanly in Codex and still exposes Claude-specific capabilities where useful.**
@@ -35,7 +40,7 @@ disable-model-invocation: true
 ---
 ```
 
-Keep `version`, `tags`, and custom metadata inside `metadata`. Claude Code extension fields may stay top-level when they are intentionally used: `when_to_use`, `disable-model-invocation`, `user-invocable`, `argument-hint`, `model`, `effort`, `context`, `agent`, `hooks`, `paths`, and `shell`.
+Keep `version`, `tags`, and custom metadata inside `metadata`. Claude Code extension fields may stay top-level when they are intentionally used: `when_to_use`, `disable-model-invocation`, `user-invocable`, `argument-hint`, `context`, `agent`, `hooks`, `paths`, and `shell`. Claude Code also recognizes `model` and `effort`, but public reusable skills must omit them and inherit app/session configuration.
 
 ## Writing Style
 

--- a/.agents/memory/system/skill-standards.md
+++ b/.agents/memory/system/skill-standards.md
@@ -1,6 +1,6 @@
 # Skill Standards
 
-This repo follows the [Agent Skills open standard](https://agentskills.io/specification) as the base spec, extended with Claude Code-specific fields. Codex compatibility comes from the base spec plus the skill body; Claude can additionally use the extension fields.
+This repo follows the [Agent Skills open standard](https://agentskills.io/specification) as the base spec, extended with selected Claude Code-specific fields. Codex compatibility comes from the base spec plus the skill body; Claude can additionally use approved extension fields. The normative split between reusable content and app configuration lives in [Harness-Owned Execution Boundary](execution-boundary.md).
 
 ---
 
@@ -24,8 +24,8 @@ This repo follows the [Agent Skills open standard](https://agentskills.io/specif
 | `when_to_use` | Extra trigger phrases appended to `description` in skill listing. Combined with `description`, capped at 1,536 chars. |
 | `disable-model-invocation` | `true` = only user can invoke (no auto-trigger). Use for destructive/side-effect skills. |
 | `user-invocable` | `false` = hides from `/` menu. Use for background knowledge skills. |
-| `model` | Override model for this skill. |
-| `effort` | Override effort level: `low`, `medium`, `high`, `xhigh`, `max`. |
+| `model` | Recognized by Claude Code, but forbidden in this public library; the harness owns model selection. |
+| `effort` | Recognized by Claude Code, but forbidden in this public library; the harness owns reasoning effort. |
 | `context` | `fork` = run in isolated subagent. Only for skills with an actionable task — a guidelines-only skill returns **empty output** when forked. ⚠️ May not be honored via the Skill tool (issue #17283). |
 | `agent` | Subagent type when `context: fork`. Options: `Explore`, `Plan`, `general-purpose`, or custom. |
 | `hooks` | Lifecycle hooks scoped to this skill. |
@@ -162,7 +162,6 @@ Rules:
 | `context: fork` | Skill does independent research/exploration that shouldn't see conversation history (must have an actionable task — guidelines-only forks return empty) |
 | `allowed-tools` | You want to skip the per-use prompt for tools the skill calls repeatedly. Remember it only *auto-approves*, it does not restrict — see note below |
 | `disallowed-tools` | You need to actually **block** a tool while the skill runs (e.g. keep an autonomous loop from calling `AskUserQuestion`) |
-| `effort: high` | Skill requires deep reasoning (architecture decisions, complex debugging) |
 | `paths` | ~~Skill only applies to specific file types~~ — avoid until issue #49835 is fixed (sets the skill undiscoverable); use nested `.claude/skills/` dirs instead |
 
 **`allowed-tools` is an allowlist, not a sandbox.** Listing tools only bypasses their permission prompt; every unlisted tool is still callable and just prompts as normal. Narrowing `allowed-tools` does not lock a skill down — use `disallowed-tools`, deny rules, or hooks to actually block. For MCP tools, list the fully-qualified `ServerName:tool_name` so the grant resolves when multiple MCP servers are connected.
@@ -236,10 +235,9 @@ touches only the per-repo routing block, never the skills.
   the repo routing block (`CLAUDE.md`/`AGENTS.md`, written by `setup-agent-routing`),
   so one per-repo file absorbs each model generation and each harness (Claude,
   Codex) maps the tiers to its own models.
-- **The `model:` frontmatter field**, if set, carries a tier alias the harness
-  resolves (`sonnet`, `opus` as Claude aliases — the field is Claude-only), not a
-  version-pinned ID. Prefer omitting it and inheriting the session model unless the
-  skill genuinely needs a fixed tier.
+- **Do not set `model:` or `effort:` in public skills.** Although Claude Code parses
+  those extension fields, model and reasoning-effort selection belong to the active
+  session or app configuration. See [Harness-Owned Execution Boundary](execution-boundary.md).
 - **External tools are lanes, not models.** Naming Codex, `gh`, or a CLI as a
   dependency the skill shells out to is fine (it is a tool, like `git`). Naming the
   model that tool runs is not.

--- a/.agents/skills/skill-auditor/SKILL.md
+++ b/.agents/skills/skill-auditor/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Run periodically or before releases.
 metadata:
   internal: true
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "audit, skills, quality, maintenance"
 ---
 
@@ -31,6 +31,9 @@ For each SKILL.md, check:
 - `version`/`tags` inside `metadata:` block, not top-level
 - No forbidden fields (`auto_activate`, `auto_trigger`, `risk`)
 - `metadata.tags` is a comma-separated string, not YAML list
+- No harness-owned execution parameters in reusable content; apply
+  `.agents/memory/system/execution-boundary.md` to skills, commands, and routine
+  templates
 
 ### 3. Structural Issues
 

--- a/.agents/skills/skill-validator/SKILL.md
+++ b/.agents/skills/skill-validator/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Run on new or modified skills before committing.
 metadata:
   internal: true
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "validation, skills, spec-compliance, quality"
 ---
 
@@ -69,8 +69,6 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 | `disallowed-tools` | Removes tools from the pool while active (the actual block mechanism) |
 | `argument-hint` | Autocomplete hint for expected arguments |
 | `compatibility` | Environment prerequisites (packages, network, target agent) |
-| `model` | Tier-alias override (never a version-pinned ID — see Model References) |
-| `effort` | Effort level (`low`…`max`) |
 | `context` | `fork` for subagent isolation |
 | `agent` | Subagent type when `context: fork` |
 | `hooks` | Lifecycle hooks scoped to the skill |
@@ -81,6 +79,8 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 
 - `auto_activate` / `auto_trigger` — removed in 2026-04 migration
 - `risk` — not in any spec
+- `model` / `effort` — recognized by Claude Code but owned by app/session
+  configuration, not public reusable skills
 - Any top-level field not in the tables above → "Unsupported top-level frontmatter field"
 
 ### Content Rules
@@ -89,7 +89,9 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 - No tool names in instructions (say "search for" not "use Grep")
 - Imperative/infinitive style ("Configure X" not "You should configure X")
 - Code blocks use real backtick fences, not escaped `\`\`\``
-- **No concrete model names** in body, `references/`, or `scripts/` — reject tier+version IDs (`claude-3-7-sonnet-20250219`, `claude-opus-4.5`, `gpt-5.5`), dated snapshots, and bare family names used as routing keys. Exception: orchestrator skills may name **capability tiers** in prose. See [skill-standards.md → Model references](../../memory/system/skill-standards.md).
+- **No concrete model names** in body, `references/`, or `scripts/` — reject tier+version IDs (`claude-3-7-sonnet-20250219`, `claude-opus-4.5`, `gpt-5.5`), dated snapshots, and bare family names used as routing keys. Exception: orchestrator skills may name **capability tiers** in prose. See [skill-standards.md → Model references](../memory/system/skill-standards.md).
+- **No harness-owned execution parameters** in skills, commands, or routine templates.
+  Apply [execution-boundary.md](../memory/system/execution-boundary.md).
 - **Provenance (derived skills only):** when `metadata.source` is set, `metadata.last_synced` and a README `## Upstream` section are required (enforced by `check_provenance()`). In-house skills need no provenance fields.
 
 ## Validation Process
@@ -100,7 +102,7 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 4. Check `description` plus `when_to_use` is under 1536 chars
 5. Check `plugin.json` description is present and under 100 chars
 6. Check `version`/`tags` are NOT top-level (must be inside `metadata:`)
-7. Check for forbidden fields (`auto_activate`, `auto_trigger`, `risk`, any field not in the extension tables)
+7. Check for forbidden fields (`auto_activate`, `auto_trigger`, `risk`, `model`, `effort`, any field not in the extension tables)
 8. Check for escaped backtick fences in content
 9. Check for hardcoded paths (`/workspace/`, project-specific paths)
 10. Grep body + `references/` + `scripts/` for concrete model names (`claude-*`, `gpt-*`, `sonnet`/`opus`/`haiku` used as IDs); allow only capability-tier prose in orchestrator skills

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -93,7 +93,7 @@
     {
       "name": "agent-config-audit",
       "source": "./skills/agent-config-audit",
-      "description": "Audit and sync AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring."
+      "description": "Audit AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces in read-only report mode. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring; apply fixes only when explicitly requested."
     },
     {
       "name": "agent-dispatch",

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ touch skills/my-skill/SKILL.md
 - `.agents/memory/system/skill-management.md` - Single-source skill workflow
 - `.agents/memory/system/architecture.md` - .agents folder structure
 - `.agents/memory/system/platform-adaptations.md` - Claude vs Codex writing guide
+- `.agents/memory/system/execution-boundary.md` - app-owned execution settings vs reusable content
 - `.agents/memory/system/ai-dev-loop.md` - Board-driven autonomous dev loop (`/loop` + agent-dispatch)
 
 ## Development Commands

--- a/bundles/dev-workflow/skills/agent-config-audit/SKILL.md
+++ b/bundles/dev-workflow/skills/agent-config-audit/SKILL.md
@@ -1,18 +1,11 @@
 ---
 name: agent-config-audit
-description: Audit and sync AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring.
+description: Audit AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces in read-only report mode. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring; apply fixes only when explicitly requested.
 metadata:
-  version: "1.1.0"
-  tags: audit, claude-md, agents-md, config, documentation, maintenance
-  triggers: audit AGENTS.md, audit CLAUDE.md, agent config audit, sync agent configs, check AGENTS.md, docs out of date, rules duplicated, config drift, stale cursorrules, agent config maintenance
-allowed-tools:
-- Read
-- Write
-- Edit
-- Glob
-- Grep
-- Bash
-- Task
+  version: "1.1.1"
+  tags: "audit, claude-md, agents-md, config, documentation, maintenance"
+when_to_use: "audit AGENTS.md, audit CLAUDE.md, agent config audit, sync agent configs, check AGENTS.md, docs out of date, rules duplicated, config drift, stale cursorrules, agent config maintenance"
+disable-model-invocation: true
 ---
 
 # Agent Config Audit
@@ -34,7 +27,8 @@ Outputs:
 Creates/Modifies:
 
 - Report mode: no file changes
-- Fix mode: agent config files, `.agents/` docs, and related settings
+- Fix mode: agent config files, `.agents/` docs, and related settings, but only
+  after an explicit fix request and confirmation of the exact plan
 
 External Side Effects:
 
@@ -43,7 +37,8 @@ External Side Effects:
 
 Confirmation Required:
 
-- Before applying fix mode
+- Before entering fix mode or using any mutating file/shell operation; an audit or
+  sync request alone authorizes report mode only
 - Before overwriting existing agent configs
 - Before deleting or consolidating duplicated rules
 
@@ -63,10 +58,10 @@ Delegates To:
 
 ## When NOT to Use
 
-- If writing actual application code → use **bugfix**, **refactor-code**, or repo-specific skills
+- If writing actual application code → use `bug` or `refactor-dispatch`
 - If capturing a single new rule from conversation → use **rules-capture**
-- If auditing code quality / CRITICAL-NEVER-DO violations → use **genfeed-codebase-audit**
-- If checking formatter/linter configs (biome, prettier, tsconfig) → use **genfeed-config-harmony**
+- If auditing code quality rather than agent configuration → use `audit`
+- If setting up or repairing formatter/linter config → use `linter-formatter-init`
 - If scaffolding `.agents/` from scratch → use **agent-folder-init**
 
 ## Inputs
@@ -242,7 +237,10 @@ Output format:
 
 ### Step 9: Apply Fixes (if fix mode)
 
-If user requested `fix` mode, apply changes following these principles:
+Never infer fix mode from the audit findings or from a request to "sync" configs.
+Enter fix mode only when the user explicitly requests mutation, show the exact files
+and operations, and obtain confirmation before using write/edit or mutating shell
+behavior. Then apply changes following these principles:
 
 - Each rule lives in ONE canonical location
 - Hooks enforce at runtime — docs teach, not repeat
@@ -283,9 +281,8 @@ After running the audit:
 
 ## Related Skills
 
-- **rules-capture** — Route here if user is expressing a new rule during conversation (not auditing)
-- **agent-folder-init** — Route here if scaffolding `.agents/` structure from scratch
-- **genfeed-config-harmony** — Route here if the issue is formatter/linter configs (biome, prettier, tsconfig)
-- **genfeed-codebase-audit** — Route here if auditing code quality, not config quality
-- **claude-md-management:revise-claude-md** — Route here if updating a single CLAUDE.md with session learnings (not full audit)
-- **claude-md-management:claude-md-improver** — Complementary; focuses on individual CLAUDE.md quality while this skill focuses on cross-file consistency
+- `rules-capture` — capture one new preference instead of auditing a config set
+- `agent-folder-init` — scaffold a missing `.agents/` structure
+- `linter-formatter-init` — set up or repair formatter/linter configuration
+- `audit` — audit application quality instead of agent configuration
+- `session-documenter` — preserve session learnings before proposing instruction updates

--- a/bundles/dev-workflow/skills/agent-config-audit/plugin.json
+++ b/bundles/dev-workflow/skills/agent-config-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-config-audit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Audit and sync AI agent config files, hooks, settings, and workspace rules.",
   "author": {
     "name": "Ship Shit Dev",

--- a/scripts/validate-skill-sync.sh
+++ b/scripts/validate-skill-sync.sh
@@ -319,9 +319,8 @@ check_tool_references() {
         return 0
     fi
 
-    # Strip content inside PLATFORM-SPECIFIC markers before checking
     local content
-    content=$(sed '/<!-- PLATFORM-SPECIFIC-START/,/<!-- PLATFORM-SPECIFIC-END/d' "$file")
+    content=$(cat "$file")
 
     # Check for Claude-specific tool references (match as standalone tool names)
     local tool_patterns=(
@@ -369,12 +368,11 @@ check_platform_names() {
         fi
     done
 
-    # Strip content inside PLATFORM-SPECIFIC markers before checking
     local content
-    content=$(sed '/<!-- PLATFORM-SPECIFIC-START/,/<!-- PLATFORM-SPECIFIC-END/d' "$file")
+    content=$(cat "$file")
 
-    # Check for platform-name coupling in universal instructions.
-    # Small CLI-specific notes are fine when isolated behind marker blocks.
+    # Check for platform-name coupling in universal instructions. Platform-specific
+    # entry surfaces live outside canonical skill bodies; comments do not isolate them.
     local platform_patterns=(
         "Claude will"
         "Claude reads"
@@ -473,9 +471,8 @@ check_platform_paths() {
         fi
     done
 
-    # Strip content inside PLATFORM-SPECIFIC markers before checking
     local content
-    content=$(sed '/<!-- PLATFORM-SPECIFIC-START/,/<!-- PLATFORM-SPECIFIC-END/d' "$file")
+    content=$(cat "$file")
 
     # These are literal strings to search for in file content, not shell paths
     # shellcheck disable=SC2088
@@ -495,6 +492,53 @@ check_platform_paths() {
     done
 
     return $warnings
+}
+
+# HTML comments do not hide instructions from a harness. Canonical skills and their
+# bundled resources must never rely on PLATFORM-SPECIFIC marker blocks.
+check_platform_markers() {
+    local skill_dir="$1"
+    local issues=0
+    local hits
+
+    hits=$(grep -rInF --include='*.md' 'PLATFORM-SPECIFIC-' "$skill_dir" 2>/dev/null || true)
+    if [[ -n "$hits" ]]; then
+        while IFS= read -r hit; do
+            [[ -n "$hit" ]] || continue
+            echo -e "  ${RED}✗${NC} Inert platform marker in canonical skill content: $hit"
+            ((++issues))
+        done <<< "$hits"
+    fi
+
+    return $issues
+}
+
+# Validate three concrete adapter patterns kept outside public skill bodies. These
+# checks prove the repository adapters route to shared sources instead of copying
+# incompatible platform instructions into canonical skills.
+validate_adapter_examples() {
+    local issues=0
+
+    if [[ ! -L "$REPO_ROOT/.claude/skills" ]] ||
+        [[ "$(readlink "$REPO_ROOT/.claude/skills")" != "../.agents/skills" ]] ||
+        [[ ! -L "$REPO_ROOT/.codex/skills" ]] ||
+        [[ "$(readlink "$REPO_ROOT/.codex/skills")" != "../.agents/skills" ]]; then
+        echo -e "${RED}✗${NC} Platform loader adapters must link to ../.agents/skills"
+        ((++issues))
+    fi
+
+    if ! grep -Fq 'Use the `review-dispatch` skill.' "$REPO_ROOT/commands/review.md"; then
+        echo -e "${RED}✗${NC} commands/review.md no longer routes to review-dispatch"
+        ((++issues))
+    fi
+
+    if [[ ! -f "$REPO_ROOT/AGENTS.md" ]] ||
+        ! grep -Fq '# Skills Repo — Agent Instructions' "$REPO_ROOT/AGENTS.md"; then
+        echo -e "${RED}✗${NC} Codex project-instruction adapter AGENTS.md is missing"
+        ((++issues))
+    fi
+
+    return $issues
 }
 
 # Function to check for external skill handoffs
@@ -817,6 +861,10 @@ validate_skill() {
         check_model_references "$SKILLS_DIR/$skill_name" || model_warnings=$?
         ((skill_warnings += model_warnings, 1))
 
+        local marker_issues=0
+        check_platform_markers "$SKILLS_DIR/$skill_name" || marker_issues=$?
+        ((skill_issues += marker_issues, 1))
+
         # Platform-agnostic checks
         local tool_warnings=0
         check_tool_references "$skill_file" || tool_warnings=$?
@@ -896,6 +944,11 @@ validate_skill() {
     echo
     return 0
 }
+
+# Validate external adapter examples before canonical skill content.
+adapter_issues=0
+validate_adapter_examples || adapter_issues=$?
+((TOTAL_ISSUES += adapter_issues, 1))
 
 # Main validation logic
 if [[ -n "$SKILL_NAME" ]]; then

--- a/scripts/validate-skill-sync.sh
+++ b/scripts/validate-skill-sync.sh
@@ -527,7 +527,7 @@ validate_adapter_examples() {
         ((++issues))
     fi
 
-    if ! grep -Fq 'Use the `review-dispatch` skill.' "$REPO_ROOT/commands/review.md"; then
+    if ! grep -Fq "Use the \`review-dispatch\` skill." "$REPO_ROOT/commands/review.md"; then
         echo -e "${RED}✗${NC} commands/review.md no longer routes to review-dispatch"
         ((++issues))
     fi

--- a/skills/agent-config-audit/SKILL.md
+++ b/skills/agent-config-audit/SKILL.md
@@ -1,18 +1,11 @@
 ---
 name: agent-config-audit
-description: Audit and sync AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring.
+description: Audit AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces in read-only report mode. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring; apply fixes only when explicitly requested.
 metadata:
-  version: "1.1.0"
-  tags: audit, claude-md, agents-md, config, documentation, maintenance
-  triggers: audit AGENTS.md, audit CLAUDE.md, agent config audit, sync agent configs, check AGENTS.md, docs out of date, rules duplicated, config drift, stale cursorrules, agent config maintenance
-allowed-tools:
-- Read
-- Write
-- Edit
-- Glob
-- Grep
-- Bash
-- Task
+  version: "1.1.1"
+  tags: "audit, claude-md, agents-md, config, documentation, maintenance"
+when_to_use: "audit AGENTS.md, audit CLAUDE.md, agent config audit, sync agent configs, check AGENTS.md, docs out of date, rules duplicated, config drift, stale cursorrules, agent config maintenance"
+disable-model-invocation: true
 ---
 
 # Agent Config Audit
@@ -34,7 +27,8 @@ Outputs:
 Creates/Modifies:
 
 - Report mode: no file changes
-- Fix mode: agent config files, `.agents/` docs, and related settings
+- Fix mode: agent config files, `.agents/` docs, and related settings, but only
+  after an explicit fix request and confirmation of the exact plan
 
 External Side Effects:
 
@@ -43,7 +37,8 @@ External Side Effects:
 
 Confirmation Required:
 
-- Before applying fix mode
+- Before entering fix mode or using any mutating file/shell operation; an audit or
+  sync request alone authorizes report mode only
 - Before overwriting existing agent configs
 - Before deleting or consolidating duplicated rules
 
@@ -63,10 +58,10 @@ Delegates To:
 
 ## When NOT to Use
 
-- If writing actual application code → use **bugfix**, **refactor-code**, or repo-specific skills
+- If writing actual application code → use `bug` or `refactor-dispatch`
 - If capturing a single new rule from conversation → use **rules-capture**
-- If auditing code quality / CRITICAL-NEVER-DO violations → use **genfeed-codebase-audit**
-- If checking formatter/linter configs (biome, prettier, tsconfig) → use **genfeed-config-harmony**
+- If auditing code quality rather than agent configuration → use `audit`
+- If setting up or repairing formatter/linter config → use `linter-formatter-init`
 - If scaffolding `.agents/` from scratch → use **agent-folder-init**
 
 ## Inputs
@@ -242,7 +237,10 @@ Output format:
 
 ### Step 9: Apply Fixes (if fix mode)
 
-If user requested `fix` mode, apply changes following these principles:
+Never infer fix mode from the audit findings or from a request to "sync" configs.
+Enter fix mode only when the user explicitly requests mutation, show the exact files
+and operations, and obtain confirmation before using write/edit or mutating shell
+behavior. Then apply changes following these principles:
 
 - Each rule lives in ONE canonical location
 - Hooks enforce at runtime — docs teach, not repeat
@@ -283,9 +281,8 @@ After running the audit:
 
 ## Related Skills
 
-- **rules-capture** — Route here if user is expressing a new rule during conversation (not auditing)
-- **agent-folder-init** — Route here if scaffolding `.agents/` structure from scratch
-- **genfeed-config-harmony** — Route here if the issue is formatter/linter configs (biome, prettier, tsconfig)
-- **genfeed-codebase-audit** — Route here if auditing code quality, not config quality
-- **claude-md-management:revise-claude-md** — Route here if updating a single CLAUDE.md with session learnings (not full audit)
-- **claude-md-management:claude-md-improver** — Complementary; focuses on individual CLAUDE.md quality while this skill focuses on cross-file consistency
+- `rules-capture` — capture one new preference instead of auditing a config set
+- `agent-folder-init` — scaffold a missing `.agents/` structure
+- `linter-formatter-init` — set up or repair formatter/linter configuration
+- `audit` — audit application quality instead of agent configuration
+- `session-documenter` — preserve session learnings before proposing instruction updates

--- a/skills/agent-config-audit/plugin.json
+++ b/skills/agent-config-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-config-audit",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Audit and sync AI agent config files, hooks, settings, and workspace rules.",
   "author": {
     "name": "Ship Shit Dev",


### PR DESCRIPTION
Closes #68

Stacked on #82 so the validator follow-up can enforce the repaired contract without mixing issue scopes.

## Summary
- make report mode the explicit read-only default and remove all auto-approved tools
- require an explicit fix request plus confirmation before write/edit or mutating shell behavior
- add the side-effect invocation guard and move trigger phrases to supported frontmatter
- quote metadata values and remove dead `metadata.triggers`
- replace project-specific and dangling routes with existing catalog skills
- regenerate the affected bundle and marketplace entry

Validator regression fixtures for these defects are intentionally delivered by #71 after the concrete #68/#70 repairs.

## Verification
- `bun run marketplace:generate`
- focused markdownlint
- `./scripts/validate-skill-sync.sh agent-config-audit`
- `git diff --check`

No tests, typechecks, or builds were run locally.