### PR TITLE
feat: add portable routine authoring guidance

### DIFF
--- a/.agents/memory/system/routine-standards.md
+++ b/.agents/memory/system/routine-standards.md
@@ -1,0 +1,177 @@
+# Routine Authoring Standard
+
+Routines are unattended or recurring invocations of a reusable objective. Write
+one platform-neutral routine family, parameterize the repository-specific inputs,
+and let the Claude or Codex app own execution configuration.
+
+This standard applies to scheduled-task prompts, automation prompt bodies, and
+templates used to create them. It does not create or enable live schedules.
+
+## Ownership Boundary
+
+| Routine content owns | Harness/app owns |
+|---|---|
+| Objective and completion condition | Schedule, recurrence, and timezone |
+| Named input parameters and defaults | Model and reasoning effort |
+| Preconditions and read/write scope | Target project, cwd, workspace, and checkout |
+| Safety gates and prohibited actions | Execution environment and sandbox policy |
+| Evidence to collect and output schema | Notification and delivery configuration |
+| Failure and escalation behavior | Enabled/paused state and concurrency policy |
+
+Never repeat an app-owned value in the routine body. The body may consume a named
+input such as `repository`, but it must not pin a concrete repository, checkout,
+model, effort level, schedule, cwd, or environment.
+
+## Canonical Routine Contract
+
+Every routine family defines:
+
+1. **Objective** — one measurable outcome.
+2. **Parameters** — named inputs such as `repository`, `lookback_window`, and
+   `report_destination`; no concrete project values in the reusable source.
+3. **Preconditions** — required access, clean-state assumptions, and data sources.
+4. **Procedure** — deterministic steps that use the parameters.
+5. **Mutation policy** — read-only, local-write, external-write, or destructive.
+6. **Safety gates** — explicit conditions that must be satisfied before each side
+   effect class.
+7. **Evidence** — facts, links, diffs, or command results that prove completion.
+8. **Output** — a stable summary schema, including blocked/no-op outcomes.
+
+## Parameterized Family Pattern
+
+Maintain one source for a repeated family instead of project copies:
+
+```markdown
+# Dependency health sweep
+
+Parameters:
+
+- `repository` — repository selected by the app target/cwd
+- `lookback_window` — reporting window supplied by the invocation
+- `report_destination` — optional destination; defaults to draft-only output
+
+Objective:
+
+Identify actionable dependency risk in `repository` during `lookback_window` and
+return a prioritized report with source evidence.
+
+Mutation policy:
+
+- Read-only by default.
+- Do not open issues, send messages, update dependencies, or push changes unless
+  the corresponding invocation gate is explicitly enabled.
+```
+
+Project variants supply only parameter values. They do not copy or rewrite the
+procedure. If a project truly needs different steps, add a named policy parameter
+or define a separate family with a different objective.
+
+## Unattended Safety Gates
+
+| Action class | Default | Gate required |
+|---|---|---|
+| Read local or remote state | Allowed | Access stays within the configured target |
+| Write local files | Denied | Explicit `allow_local_writes`, allowed path scope, and a clean-state preflight |
+| Create/update issues or PRs | Denied | Explicit `allow_external_writes` plus repository and action allowlists |
+| Send email/chat/notifications | Draft only | Explicit `allow_send`, destination allowlist, and final content validation |
+| Merge, deploy, delete, rotate secrets, charge, or publish | Prohibited unattended | Stop and request a separately authenticated human action |
+
+An app-level permission or broad sandbox is not routine-level authorization. The
+routine must still enforce its own narrow action gate. Never infer a send/write gate
+from phrases such as “keep going,” “autonomous,” or “handle everything.”
+
+For every allowed side effect:
+
+- Re-read the target immediately before mutation.
+- Make the operation idempotent or detect an already-complete state.
+- Record what changed without printing credentials, tokens, environment values, or
+  private prompt bodies.
+- Stop on ambiguous ownership, destination, or destructive impact.
+
+## Claude Scheduled-Task Adapter
+
+Keep the scheduled task's `SKILL.md` body thin and route to the canonical family:
+
+```markdown
+---
+name: dependency-health-sweep
+description: Run the dependency health routine with app-supplied project inputs.
+---
+
+Apply the canonical dependency health sweep routine.
+
+Parameters:
+
+- `repository`: use the project selected by the scheduled-task app
+- `lookback_window`: use the invocation input or the routine default
+- `report_destination`: draft-only unless an explicit send gate is present
+```
+
+Select recurrence, model, effort, project, workspace, and delivery in the Claude
+scheduled-task UI/configuration. Do not restate them in `SKILL.md`.
+
+## Codex Automation Adapter
+
+Keep the TOML prompt focused on routing and parameters. The surrounding automation
+record owns execution fields:
+
+```toml
+name = "Dependency health sweep"
+prompt = """
+Apply the canonical dependency health sweep routine.
+Use the repository selected by the automation target and return the standard report.
+All external actions remain draft-only unless an explicit routine gate is present.
+"""
+
+# App-owned examples; values are selected in Codex, not copied into prompt text.
+rrule = "<app-owned>"
+model = "<app-owned>"
+reasoning_effort = "<app-owned>"
+cwds = ["<app-owned>"]
+execution_environment = "<app-owned>"
+target = "<app-owned>"
+```
+
+Treat the field list as a placement example, not an automation to install. Do not
+write an `automation.toml` into a user's Codex home or create a live automation from
+this repository.
+
+## Read-Only Audit Mode
+
+Run the local auditor against explicit roots or its standard user-level defaults:
+
+```bash
+python3 scripts/audit-routines.py
+python3 scripts/audit-routines.py \
+  --claude-dir ~/.claude/scheduled-tasks \
+  --codex-dir ~/.codex/automations
+```
+
+The auditor reports anonymous source identifiers by default. It detects:
+
+- exact and near-duplicate normalized routine bodies;
+- model, effort, schedule, cwd/workspace/worktree, and environment directives in
+  prompt content;
+- app-owned Codex field names that are present, without emitting their values.
+
+It never prints prompt bodies, environment values, or TOML values. Add
+`--show-paths` only when local filenames are safe to reveal. Audit mode is read-only
+and returns success with findings unless `--fail-on-findings` is explicitly set.
+
+## Safe Migration
+
+1. Pause or disable existing schedules in the owning app. Do not create replacements
+   during discovery.
+2. Run the read-only auditor and group duplicates by family.
+3. Choose one representative body; remove app-owned settings and concrete project
+   values.
+4. Extract named parameters and add the canonical routine contract and safety gates.
+5. Replace each paused copy with a thin adapter that routes to the family and supplies
+   only parameters.
+6. Dry-run each adapter in read-only/draft-only mode and compare its output schema.
+7. Re-enable schedules manually in the owning app after review. Preserve the app's
+   existing recurrence, target, model, effort, and environment rather than copying
+   those values into the prompt.
+
+Never migrate authentication material, environment values, or private prompt output
+into this public repository.

--- a/.agents/skills/skill-auditor/SKILL.md
+++ b/.agents/skills/skill-auditor/SKILL.md
@@ -5,13 +5,27 @@ description: |
   Run periodically or before releases.
 metadata:
   internal: true
-  version: "1.0.1"
+  version: "1.1.0"
   tags: "audit, skills, quality, maintenance"
 ---
 
 # Skill Auditor
 
 Comprehensive audit of the skills library for quality and consistency.
+
+## Audit Modes
+
+| Mode | Scope | Command |
+|---|---|---|
+| `skills` (default) | Public skills, commands, bundles, and catalog sync | Follow the categories below |
+| `routines` | Local Claude scheduled tasks and Codex automations | `python3 scripts/audit-routines.py` |
+
+Routine mode follows
+`.agents/memory/system/routine-standards.md`. It is read-only: detect normalized
+duplicate bodies and prompt-level model, effort, schedule, cwd/workspace/worktree,
+and environment leakage. Report source identifiers and field names only; never print
+prompt bodies, environment values, or TOML values. Use `--show-paths` only when the
+caller explicitly wants local paths in the report.
 
 ## Audit Categories
 
@@ -74,4 +88,8 @@ Report findings as a table:
 |-------|-------|----------|--------|
 | `code-refactoring-refactor-clean` | Duplicate of `refactor-code` | HIGH | Merge |
 | `spec-to-code-compliance` | Empty directory | HIGH | Delete |
+
+For routine mode, report totals, leakage categories, anonymous source identifiers,
+duplicate-family groups, and observed app-owned field names. Do not include the
+matched text or configuration values.
 | `skill-capture` | tags as YAML list | MEDIUM | Fix to string |

--- a/.agents/skills/skill-validator/SKILL.md
+++ b/.agents/skills/skill-validator/SKILL.md
@@ -5,7 +5,7 @@ description: |
   Run on new or modified skills before committing.
 metadata:
   internal: true
-  version: "1.0.2"
+  version: "1.0.3"
   tags: "validation, skills, spec-compliance, quality"
 ---
 
@@ -94,6 +94,10 @@ Valid extension fields (must match `allowed_fields` in `scripts/validate-skill-s
 - **No concrete model names** in body, `references/`, or `scripts/` — reject tier+version IDs (`claude-3-7-sonnet-20250219`, `claude-opus-4.5`, `gpt-5.5`), dated snapshots, and bare family names used as routing keys. Exception: orchestrator skills may name **capability tiers** in prose. See [skill-standards.md → Model references](../memory/system/skill-standards.md).
 - **No harness-owned execution parameters** in skills, commands, or routine templates.
   Apply [execution-boundary.md](../memory/system/execution-boundary.md).
+- **Routine templates** follow
+  [routine-standards.md](../memory/system/routine-standards.md). Run
+  `python3 scripts/audit-routines.py` to detect duplicate bodies and app-parameter
+  leakage without printing prompt or configuration values.
 - **Provenance (derived skills only):** when `metadata.source` is set, `metadata.last_synced` and a README `## Upstream` section are required (enforced by `check_provenance()`). In-house skills need no provenance fields.
 
 ## Validation Process

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ touch skills/my-skill/SKILL.md
 - `.agents/memory/system/architecture.md` - .agents folder structure
 - `.agents/memory/system/platform-adaptations.md` - Claude vs Codex writing guide
 - `.agents/memory/system/execution-boundary.md` - app-owned execution settings vs reusable content
+- `.agents/memory/system/routine-standards.md` - portable scheduled-task and automation authoring
 - `.agents/memory/system/ai-dev-loop.md` - Board-driven autonomous dev loop (`/loop` + agent-dispatch)
 
 ## Development Commands

--- a/scripts/audit-routines.py
+++ b/scripts/audit-routines.py
@@ -35,33 +35,32 @@ LEAKAGE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "effort",
         re.compile(
-            r"\b(?:reasoning[_ -]?effort|effort\s*[:=]|"
-            r"(?:low|medium|high|xhigh|max)\s+effort)\b",
+            r"\b(?:reasoning[_ -]?effort|(?:low|medium|high|xhigh|max)\s+effort)\b|"
+            r"\beffort\s*[:=]",
             re.IGNORECASE,
         ),
     ),
     (
         "schedule",
         re.compile(
-            r"\b(?:rrule|cron|schedule\s*[:=]|run\s+every\s+|"
-            r"every\s+(?:day|week|month|hour))\b",
+            r"\b(?:rrule|cron|run\s+every\s+|every\s+(?:day|week|month|hour))\b|"
+            r"\bschedule\s*[:=]",
             re.IGNORECASE,
         ),
     ),
     (
         "workspace",
         re.compile(
-            r"\b(?:cwd\s*[:=]|working\s+directory\s*[:=]|"
-            r"(?:create|use|switch\s+to)\s+(?:a\s+)?worktree|"
-            r"source\s+checkout|workspace\s*[:=])\b",
+            r"\b(?:(?:create|use|switch\s+to)\s+(?:a\s+)?worktree|"
+            r"source\s+checkout)\b|\b(?:cwd|working\s+directory|workspace)\s*[:=]",
             re.IGNORECASE,
         ),
     ),
     (
         "environment",
         re.compile(
-            r"\b(?:execution_environment|environment\s*[:=]|"
-            r"export\s+[A-Z][A-Z0-9_]*=)\b",
+            r"\bexecution_environment\b|\benvironment\s*[:=]|"
+            r"\bexport\s+[A-Z][A-Z0-9_]*=",
             re.IGNORECASE,
         ),
     ),

--- a/scripts/audit-routines.py
+++ b/scripts/audit-routines.py
@@ -1,0 +1,324 @@
+#!/usr/bin/env python3
+"""Audit local routine prompts without emitting prompt or configuration values."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import tomllib
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable
+
+
+APP_OWNED_CODEX_FIELDS = {
+    "cwds",
+    "execution_environment",
+    "model",
+    "reasoning_effort",
+    "rrule",
+    "schedule",
+    "target",
+}
+
+LEAKAGE_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "model",
+        re.compile(
+            r"\b(?:model\s*[:=]|use\s+(?:the\s+)?(?:[a-z0-9.-]+\s+)?model\b|"
+            r"claude-[a-z0-9.-]+|gpt-[a-z0-9.-]+|gemini-[a-z0-9.-]+|"
+            r"\b(?:sonnet|opus|haiku)\b)",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "effort",
+        re.compile(
+            r"\b(?:reasoning[_ -]?effort|effort\s*[:=]|"
+            r"(?:low|medium|high|xhigh|max)\s+effort)\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "schedule",
+        re.compile(
+            r"\b(?:rrule|cron|schedule\s*[:=]|run\s+every\s+|"
+            r"every\s+(?:day|week|month|hour))\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "workspace",
+        re.compile(
+            r"\b(?:cwd\s*[:=]|working\s+directory\s*[:=]|"
+            r"(?:create|use|switch\s+to)\s+(?:a\s+)?worktree|"
+            r"source\s+checkout|workspace\s*[:=])\b",
+            re.IGNORECASE,
+        ),
+    ),
+    (
+        "environment",
+        re.compile(
+            r"\b(?:execution_environment|environment\s*[:=]|"
+            r"export\s+[A-Z][A-Z0-9_]*=)\b",
+            re.IGNORECASE,
+        ),
+    ),
+)
+
+
+@dataclass(frozen=True)
+class RoutineSource:
+    identifier: str
+    platform: str
+    path: Path
+    body: str
+    frontmatter: str = ""
+
+
+@dataclass(frozen=True)
+class Finding:
+    source: str
+    platform: str
+    category: str
+    location: str
+
+
+@dataclass(frozen=True)
+class AuditResult:
+    claude_sources: int
+    codex_sources: int
+    findings: list[Finding]
+    duplicate_groups: list[list[str]]
+    codex_app_fields: list[str]
+
+
+def split_frontmatter(text: str) -> tuple[str, str]:
+    if not text.startswith("---"):
+        return "", text
+    parts = text.split("---", 2)
+    if len(parts) != 3:
+        return "", text
+    return parts[1], parts[2]
+
+
+def discover_claude_sources(root: Path) -> list[RoutineSource]:
+    sources: list[RoutineSource] = []
+    for index, path in enumerate(sorted(root.glob("*/SKILL.md")), 1):
+        frontmatter, body = split_frontmatter(path.read_text(errors="replace"))
+        sources.append(
+            RoutineSource(
+                identifier=f"claude-task-{index:03d}",
+                platform="claude",
+                path=path,
+                body=body,
+                frontmatter=frontmatter,
+            )
+        )
+    return sources
+
+
+def discover_codex_sources(root: Path) -> tuple[list[RoutineSource], set[str]]:
+    sources: list[RoutineSource] = []
+    observed_fields: set[str] = set()
+    for index, path in enumerate(sorted(root.glob("*/automation.toml")), 1):
+        try:
+            data = tomllib.loads(path.read_text(errors="replace"))
+        except (OSError, tomllib.TOMLDecodeError):
+            continue
+        observed_fields.update(APP_OWNED_CODEX_FIELDS.intersection(data))
+        prompt = data.get("prompt", "")
+        sources.append(
+            RoutineSource(
+                identifier=f"codex-automation-{index:03d}",
+                platform="codex",
+                path=path,
+                body=prompt if isinstance(prompt, str) else "",
+            )
+        )
+    return sources, observed_fields
+
+
+def scan_leakage(source: RoutineSource) -> list[Finding]:
+    findings: list[Finding] = []
+    sections = (("frontmatter", source.frontmatter), ("body", source.body))
+    for section, text in sections:
+        for line_number, line in enumerate(text.splitlines(), 1):
+            for category, pattern in LEAKAGE_PATTERNS:
+                if pattern.search(line):
+                    findings.append(
+                        Finding(
+                            source=source.identifier,
+                            platform=source.platform,
+                            category=category,
+                            location=f"{section} line {line_number}",
+                        )
+                    )
+                    break
+    return findings
+
+
+def normalize_body(text: str) -> str:
+    normalized = text.lower()
+    normalized = re.sub(r"https?://\S+", "<url>", normalized)
+    normalized = re.sub(r"(?<!\w)/(?:[^\s/]+/)+[^\s]+", "<path>", normalized)
+    normalized = re.sub(r"\b[a-z0-9_.-]+/[a-z0-9_.-]+\b", "<repository>", normalized)
+    normalized = re.sub(r"\b[0-9a-f]{8}-[0-9a-f-]{27,}\b", "<identifier>", normalized)
+    normalized = re.sub(r"\$\{?[A-Z][A-Z0-9_]*\}?", "<parameter>", normalized)
+    normalized = re.sub(r"`[^`\n]+`", "<parameter>", normalized)
+    normalized = re.sub(
+        r"(?im)^\s*(?:project|repository|repo|workspace)\s*[:=].*$",
+        "<project-parameter>",
+        normalized,
+    )
+    normalized = re.sub(r"\s+", " ", normalized).strip()
+    return normalized
+
+
+def duplicate_groups(
+    sources: list[RoutineSource], similarity: float
+) -> list[list[str]]:
+    normalized = [normalize_body(source.body) for source in sources]
+    signatures: list[frozenset[tuple[str, ...]]] = []
+    for body in normalized:
+        tokens = body.split()
+        signatures.append(
+            frozenset(tuple(tokens[index : index + 5]) for index in range(len(tokens) - 4))
+        )
+    parents = list(range(len(sources)))
+
+    def find(index: int) -> int:
+        while parents[index] != index:
+            parents[index] = parents[parents[index]]
+            index = parents[index]
+        return index
+
+    def union(left: int, right: int) -> None:
+        left_root = find(left)
+        right_root = find(right)
+        if left_root != right_root:
+            parents[right_root] = left_root
+
+    for left in range(len(sources)):
+        if len(normalized[left]) < 80:
+            continue
+        for right in range(left + 1, len(sources)):
+            if len(normalized[right]) < 80:
+                continue
+            union_size = len(signatures[left] | signatures[right])
+            ratio = (
+                len(signatures[left] & signatures[right]) / union_size
+                if union_size
+                else 0.0
+            )
+            if ratio >= similarity:
+                union(left, right)
+
+    grouped: dict[int, list[str]] = {}
+    for index, source in enumerate(sources):
+        grouped.setdefault(find(index), []).append(source.identifier)
+    return sorted(
+        (members for members in grouped.values() if len(members) > 1),
+        key=lambda members: (-len(members), members),
+    )
+
+
+def audit(claude_dir: Path, codex_dir: Path, similarity: float) -> AuditResult:
+    claude_sources = discover_claude_sources(claude_dir)
+    codex_sources, observed_fields = discover_codex_sources(codex_dir)
+    sources = claude_sources + codex_sources
+    findings = [finding for source in sources for finding in scan_leakage(source)]
+    return AuditResult(
+        claude_sources=len(claude_sources),
+        codex_sources=len(codex_sources),
+        findings=findings,
+        duplicate_groups=duplicate_groups(sources, similarity),
+        codex_app_fields=sorted(observed_fields),
+    )
+
+
+def source_labels(sources: Iterable[RoutineSource], show_paths: bool) -> dict[str, str]:
+    return {
+        source.identifier: str(source.path) if show_paths else source.identifier
+        for source in sources
+    }
+
+
+def render_text(
+    result: AuditResult,
+    labels: dict[str, str],
+) -> str:
+    lines = [
+        "Routine audit (read-only)",
+        f"Sources: Claude {result.claude_sources}, Codex {result.codex_sources}",
+        f"App-parameter leakage findings: {len(result.findings)}",
+    ]
+    for finding in result.findings:
+        lines.append(
+            f"- {labels[finding.source]}: {finding.category} directive "
+            f"({finding.location})"
+        )
+    lines.append(f"Duplicate routine families: {len(result.duplicate_groups)}")
+    for index, group in enumerate(result.duplicate_groups, 1):
+        members = ", ".join(labels[source] for source in group)
+        lines.append(f"- family-{index:03d}: {members}")
+    fields = ", ".join(result.codex_app_fields) or "none"
+    lines.append(f"Codex app-owned fields observed (names only): {fields}")
+    lines.append("Prompt bodies and configuration values were not emitted.")
+    return "\n".join(lines)
+
+
+def render_json(result: AuditResult, labels: dict[str, str]) -> str:
+    payload = asdict(result)
+    for finding in payload["findings"]:
+        finding["source"] = labels[finding["source"]]
+    payload["duplicate_groups"] = [
+        [labels[source] for source in group] for group in result.duplicate_groups
+    ]
+    payload["value_redaction"] = "Prompt bodies and configuration values omitted."
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Audit Claude scheduled-task and Codex automation prompt bodies."
+    )
+    parser.add_argument(
+        "--claude-dir",
+        type=Path,
+        default=Path("~/.claude/scheduled-tasks").expanduser(),
+    )
+    parser.add_argument(
+        "--codex-dir",
+        type=Path,
+        default=Path("~/.codex/automations").expanduser(),
+    )
+    parser.add_argument("--similarity", type=float, default=0.92)
+    parser.add_argument("--format", choices=("text", "json"), default="text")
+    parser.add_argument("--show-paths", action="store_true")
+    parser.add_argument("--fail-on-findings", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if not 0.0 <= args.similarity <= 1.0:
+        raise SystemExit("--similarity must be between 0 and 1")
+
+    result = audit(args.claude_dir, args.codex_dir, args.similarity)
+    claude_sources = discover_claude_sources(args.claude_dir)
+    codex_sources, _ = discover_codex_sources(args.codex_dir)
+    labels = source_labels(claude_sources + codex_sources, args.show_paths)
+    output = (
+        render_json(result, labels)
+        if args.format == "json"
+        else render_text(result, labels)
+    )
+    print(output)
+    has_findings = bool(result.findings or result.duplicate_groups)
+    return 1 if args.fail_on_findings and has_findings else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_audit_routines.py
+++ b/scripts/tests/test_audit_routines.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "audit-routines.py"
+SPEC = importlib.util.spec_from_file_location("audit_routines", MODULE_PATH)
+assert SPEC and SPEC.loader
+audit_routines = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = audit_routines
+SPEC.loader.exec_module(audit_routines)
+
+
+class RoutineAuditTests(unittest.TestCase):
+    def test_reports_leakage_without_values(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            claude_dir = root / "claude"
+            codex_dir = root / "codex"
+            task_dir = claude_dir / "task-a"
+            automation_dir = codex_dir / "automation-a"
+            task_dir.mkdir(parents=True)
+            automation_dir.mkdir(parents=True)
+            (task_dir / "SKILL.md").write_text(
+                "---\nname: task-a\ndescription: Audit fixture.\n---\n"
+                "Use the sonnet model.\n"
+                "Set effort: high.\n"
+            )
+            (automation_dir / "automation.toml").write_text(
+                'model = "do-not-print-model"\n'
+                'reasoning_effort = "do-not-print-effort"\n'
+                'cwds = ["/do/not/print/path"]\n'
+                'prompt = "Create a worktree, then report findings."\n'
+            )
+
+            result = audit_routines.audit(claude_dir, codex_dir, 0.92)
+            sources = audit_routines.discover_claude_sources(claude_dir)
+            codex_sources, _ = audit_routines.discover_codex_sources(codex_dir)
+            labels = audit_routines.source_labels(sources + codex_sources, False)
+            output = audit_routines.render_text(result, labels)
+
+            self.assertIn("model directive", output)
+            self.assertIn("effort directive", output)
+            self.assertIn("workspace directive", output)
+            self.assertNotIn("do-not-print", output)
+            self.assertNotIn("/do/not/print/path", output)
+
+    def test_groups_parameterized_duplicate_bodies(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            claude_dir = root / "claude"
+            for name, repository in (("task-a", "org/alpha"), ("task-b", "org/beta")):
+                task_dir = claude_dir / name
+                task_dir.mkdir(parents=True)
+                (task_dir / "SKILL.md").write_text(
+                    "---\n"
+                    f"name: {name}\n"
+                    "description: Audit fixture.\n"
+                    "---\n"
+                    "Review dependency health and return a prioritized report with "
+                    "source evidence. Do not update files or send messages.\n"
+                    f"Repository: {repository}\n"
+                )
+
+            result = audit_routines.audit(claude_dir, root / "codex", 0.92)
+
+            self.assertEqual(len(result.duplicate_groups), 1)
+            self.assertEqual(len(result.duplicate_groups[0]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- define a platform-neutral routine contract and the objective-versus-app configuration boundary
- document parameterized routine families, unattended mutation gates, Claude/Codex adapters, and safe migration
- add a read-only auditor for duplicate bodies and model/effort/schedule/workspace/environment leakage
- keep audit output value-safe with anonymous source IDs and app field names only
- link routine mode from the maintenance auditor and validator meta-skills

## Verification
- Python AST parse for the auditor and its CI test module
- read-only audit of 38 Claude scheduled tasks and 17 Codex automations (anonymous/value-redacted output)
- scoped Markdown lint
- `git diff --check`
- regression tests intentionally left to CI per local machine policy

Closes #75