### PR TITLE
docs: generate catalog facts from canonical sources

### DIFF
--- a/.agents/memory/architecture.md
+++ b/.agents/memory/architecture.md
@@ -1,74 +1,36 @@
 # Repository Architecture
 
-last_verified: 2026-06-18
+last_verified: 2026-07-13
 
 ## Directory Map
 
-```
-skills-repo/
-├── skills/                          # 141 skills (source of truth)
-│   └── <skill-name>/
-│       ├── SKILL.md                 # Skill definition (frontmatter + body)
-│       └── plugin.json              # Skill distribution manifest
-│
-├── commands/                        # 11 slash commands (.md files, flat)
-│   └── <command-name>.md
-│
-├── bundles/                         # 13 themed bundles (generated snapshots)
-│   └── <bundle-name>/
-│       ├── plugin.json              # Bundle manifest
-│       └── skills/                  # Copies of bundled skills
-│
-├── scripts/                         # Build, validate, generate tooling
-│   ├── generate-marketplace-bundles.js # Bundle snapshot generation
-│   ├── generate-marketplace-json.js # Marketplace catalog generation
-│   ├── validate-skill-sync.sh       # Skill validation (frontmatter, structure)
-│   ├── validate-changed-skills.sh   # Pre-commit hook: validate only changed
-│   ├── cleanup-global-duplicates.sh # Remove duplicate installs from ~/.claude
-│   ├── install-skills.sh            # npx skills add entrypoint
-│   ├── migrate-frontmatter.py       # Spec migration tool
-│   ├── lint-shellcheck.sh           # Shell lint wrapper
-│   └── plugin-categories.json       # Bundle → skills mapping data
-│
-├── prompts/                         # Reusable prompts
-│   └── prd-interview.md
-│
-├── assets/                          # Static assets
-│   └── banner.svg
-│
-├── .agents/                         # AI agent workspace
-│   ├── README.md                    # Agent entry point
-│   ├── memory/                      # Persistent memory (this dir)
-│   │   └── system/                  # Project docs and standards
-│   │       ├── architecture.md      # .agents/ folder structure
-│   │       ├── ai-dev-loop.md       # /loop workflow
-│   │       ├── skill-standards.md   # Skill authoring spec
-│   │       ├── skill-management.md  # Sync workflow
-│   │       └── platform-adaptations.md # Claude vs Codex differences
-│   └── sessions/                    # Historical session logs
-│
-├── .claude/                         # Claude Code config
-│   ├── rules/CLAUDE_RULES.md        # Project rules
-│   └── settings.local.json          # Local permissions + plugins
-│
-├── .claude-plugin/
-│   └── marketplace.json             # Full marketplace catalog (generated)
-│
-├── .github/workflows/
-│   └── generate-bundles.yml         # CI: regenerate on push to master
-│
-├── .husky/                          # Git hooks (pre-commit)
-├── biome.json                       # JS/JSON formatter + linter config
-├── .markdownlint.json               # Markdown lint rules
-└── package.json                     # Bun project config
-```
+<!-- catalog-layout:start -->
+| Path | Role | Generated fact |
+|---|---|---|
+| `.agents/` | Repository memory, standards, and maintenance skills | Tracked |
+| `.claude/` | Claude loader adapters for shared maintenance content | Tracked |
+| `.claude-plugin/` | Generated Claude marketplace catalog | 177 generated plugins |
+| `.codex/` | Codex loader adapters for shared maintenance content | Tracked |
+| `.github/` | Issue templates and GitHub Actions workflows | Tracked |
+| `.husky/` | Git hook configuration | Tracked |
+| `assets/` | Static repository assets | Tracked |
+| `bundles/` | Generated marketplace bundle snapshots | 13 generated bundles |
+| `commands/` | Claude Code/plugin command adapters | 30 command adapters |
+| `prompts/` | Shared prompt resources | Tracked |
+| `resources/` | Authoring references and supporting documentation | Tracked |
+| `scripts/` | Validation, generation, migration, and audit tooling | Tracked |
+| `skills/` | Canonical public Agent Skills sources | 164 canonical skills |
+<!-- catalog-layout:end -->
 
 ## Data Flow
 
 ```
+skills/*/SKILL.md ─┐
+commands/*.md      ├─→ scripts/generate-catalog-summary.js ─→ catalog.json + marked docs
+bundle definitions ┘
 skills/<name>/SKILL.md    ──→  scripts/generate-marketplace-bundles.js  ──→  bundles/<name>/
 skills/<name>/plugin.json ──→  copied into bundle snapshots
-skills/<name>/SKILL.md    ──→  scripts/generate-marketplace-json.js     ──→  .claude-plugin/marketplace.json
+catalog.json + skills/    ──→  scripts/generate-marketplace-json.js     ──→  .claude-plugin/marketplace.json
 ```
 
 All generation is triggered by: `bun run marketplace:generate`
@@ -94,11 +56,13 @@ metadata:
 ```
 
 Required: `name`, `description`, `SKILL.md`, `plugin.json`
-Optional: `license`, `compatibility`, `when_to_use`, `allowed-tools`, `model`, `context`
+Optional: `license`, `compatibility`, `when_to_use`, `allowed-tools`, `context`
 
 ## Bundle Structure
 
-13 bundles: `ai-agents`, `backend`, `dev-loop`, `dev-workflow`, `frontend`, `github`, `infrastructure`, `payments`, `planning`, `security`, `session`, `testing`, `workspace`
+<!-- catalog-bundles:start -->
+13 generated bundles: `ai-agents`, `backend`, `dev-loop`, `dev-workflow`, `frontend`, `github`, `infrastructure`, `payments`, `planning`, `security`, `session`, `testing`, `workspace`.
+<!-- catalog-bundles:end -->
 
 Each bundle = curated subset of skills for a domain. Defined in `scripts/plugin-categories.json`.
 

--- a/.agents/memory/memory.md
+++ b/.agents/memory/memory.md
@@ -1,10 +1,14 @@
 # Skills Repo Memory
 
-last_verified: 2026-06-19
+last_verified: 2026-07-13
 
 ## What This Repo Is
 
-Public skills library at `shipshitdev/skills`. 141 skills, 11 commands, 13 bundles. Installable via `npx skills add shipshitdev/skills --skill <name>`. Works with Claude Code, Codex, Cursor, OpenClaw, Gemini.
+<!-- catalog-summary:start -->
+Public skills library at `shipshitdev/skills`. Installable via `npx skills add shipshitdev/skills --skill <name>`. Works with Claude Code, Codex, Cursor, OpenClaw, and Gemini.
+
+Generated catalog: **164 skills · 30 commands · 13 bundles · 177 plugins**.
+<!-- catalog-summary:end -->
 
 Published through committed marketplace bundles in `bundles/` and the generated `.claude-plugin/marketplace.json` catalog. The old generated `plugins/` package tree is retired.
 
@@ -17,15 +21,16 @@ Published through committed marketplace bundles in `bundles/` and the generated 
 - **Linting:** markdownlint (markdown), biome (JSON/JS), shellcheck (bash)
 - **CI:** GitHub Actions on push to master — regenerates bundles + marketplace
 
-## Numbers (snapshot 2026-06-18)
+## Generated Catalog Counts
 
-| Asset | Count | Location |
-|-------|-------|----------|
-| Skills | 141 | `skills/<name>/SKILL.md` |
-| Commands | 11 | `commands/<name>.md` |
-| Bundles | 13 | `bundles/<bundle>/plugin.json` |
-| Scripts | 15 | `scripts/` |
-| Prompts | 2 | `prompts/` |
+<!-- catalog-counts:start -->
+| Asset | Count | Canonical source |
+|---|---:|---|
+| Skills | 164 | `skills/*/SKILL.md` |
+| Commands | 30 | `commands/*.md` |
+| Bundles | 13 | `scripts/plugin-categories.json` |
+| Plugins | 177 | skills + bundles |
+<!-- catalog-counts:end -->
 
 ## Architecture Decisions
 
@@ -94,7 +99,9 @@ None currently tracked.
 - `.agents/memory/system/skill-standards.md` — authoritative spec doc
 - `.agents/memory/system/skill-management.md` — workflow guide
 - `scripts/validate-skill-sync.sh` — validation script
+- `scripts/generate-catalog-summary.js` — generated catalog facts and documentation blocks
 - `scripts/generate-marketplace-bundles.js` — bundle snapshot generation
 - `scripts/generate-marketplace-json.js` — marketplace catalog generation
+- `catalog.json` — single generated source for counts, bundles, and tracked layout
 - `.claude-plugin/marketplace.json` — full marketplace catalog (generated)
 - `.github/workflows/generate-bundles.yml` — CI pipeline

--- a/.agents/memory/system/skill-standards.md
+++ b/.agents/memory/system/skill-standards.md
@@ -252,7 +252,7 @@ touches only the per-repo routing block, never the skills.
 A skill authored in-house needs no provenance fields. A skill **derived from an
 upstream** declares where it came from, so the rewrite-vs-resync decision is
 mechanical. The convention is enforced by `check_provenance()` in
-`scripts/validate-skill-sync.sh` and used by 30 skills today.
+`scripts/validate-skill-sync.sh` and used by derived skills in this catalog.
 
 Frontmatter (all under `metadata`):
 

--- a/.agents/skills/readme-sync/SKILL.md
+++ b/.agents/skills/readme-sync/SKILL.md
@@ -1,53 +1,59 @@
 ---
 name: readme-sync
 description: |
-  Regenerate the README.md skills table from the filesystem.
-  Run after adding, removing, or renaming skills.
+  Regenerate catalog counts, layout claims, and README summaries from canonical sources.
+  Run after adding, removing, or renaming skills, commands, or bundles.
 metadata:
   internal: true
-  version: "1.0.0"
+  version: "1.1.0"
   tags: "readme, sync, maintenance, automation"
 ---
 
-# README Sync
+# README and Catalog Sync
 
-Regenerate the README.md skills table from the actual `skills/` directory.
+Regenerate `catalog.json` and every marked count/layout summary from the actual
+skill, command, bundle, and tracked-path sources.
 
 ## When to Run
 
 - After adding new skills
 - After removing or renaming skills
+- After adding or removing commands or bundles
 - After importing skills from external repos
-- When README skill count doesn't match filesystem
+- When any catalog count or directory claim does not match the repository
 
 ## Process
 
-### 1. Generate Table Rows
+### 1. Generate the Catalog and Documentation Blocks
 
 ```bash
-find skills -maxdepth 1 -mindepth 1 -type d | sed 's|skills/||' | sort | while read skill; do
-  desc=$(grep -m1 "^description:" "skills/$skill/SKILL.md" 2>/dev/null | sed 's/^description: *//' | tr -d '"' | head -c 75)
-  echo "| [$skill](https://skills.sh/shipshitdev/skills/$skill) | $desc | \`npx skills add shipshitdev/skills --skill $skill\` |"
-done
+bun run catalog:generate
 ```
 
-### 2. Update README
+The generator derives:
 
-Replace the skills table in README.md between `## Skills` and the next `##` heading.
+- skills from `skills/*/SKILL.md`;
+- commands from `commands/*.md`;
+- bundles from `scripts/plugin-categories.json`;
+- plugins as skills plus bundles;
+- top-level layout from `git ls-files`.
 
-### 3. Update Counts
+It writes the single generated source `catalog.json`, then updates marked blocks in
+`README.md`, `AGENTS.md`, and memory/architecture docs plus the package description.
+Do not edit text between `catalog-*:start` and `catalog-*:end` markers manually.
 
-- Header tagline: "250+ AI agent skills" → update to match
-- Directory structure: "(252 skills)" → update to actual count
-
-### 4. Validate
+### 2. Validate Without Writing
 
 ```bash
-bunx markdownlint-cli README.md
+bun run catalog:check
 ```
 
-## Edge Cases
+The lightweight repository validator also runs this check, and CI regenerates the
+catalog and fails if any generated file changes.
 
-- Skills with multiline YAML descriptions need the awk-based extractor
-- Skills with special characters in descriptions (em dashes, backticks) need escaping
-- Some descriptions start with "When the user wants..." — these are trigger phrases, consider rewriting for the table
+## Safety
+
+- Preserve prose outside generated markers.
+- Never infer counts from README text.
+- Never add a top-level path to the generated layout unless it is tracked.
+- Review `catalog.json` and generated documentation diffs before committing.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,9 +8,13 @@ on:
       - 'skills/**'
       - 'commands/**'
       - 'bundles/**'
+      - '.agents/**'
       - '.claude-plugin/marketplace.json'
       - '.github/workflows/**'
       - 'scripts/**'
+      - 'AGENTS.md'
+      - 'README.md'
+      - 'catalog.json'
       - 'package.json'
       - 'bun.lock'
       - 'biome.json'
@@ -63,4 +67,12 @@ jobs:
 
       - name: Verify generated bundles are current
         run: |
-          git diff --exit-code -- bundles/ .claude-plugin/marketplace.json
+          git diff --exit-code -- \
+            bundles/ \
+            .claude-plugin/marketplace.json \
+            catalog.json \
+            README.md \
+            AGENTS.md \
+            .agents/memory/memory.md \
+            .agents/memory/architecture.md \
+            package.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Skills Repo — Agent Instructions
 
-This is the shipshitdev/skills repo: 154 AI agent skills for Claude Code, Codex, and Cursor.
+<!-- catalog-summary:start -->
+This is the shipshitdev/skills repo: 164 AI agent skills for Claude Code, Codex, and Cursor. The generated catalog also contains 30 command adapters, 13 bundles, and 177 marketplace plugins.
+<!-- catalog-summary:end -->
 
 ## Repo Structure
 

--- a/README.md
+++ b/README.md
@@ -4,24 +4,33 @@
 
 ![Project Type](https://img.shields.io/badge/Project-Skills-blue)
 
+<!-- catalog-summary:start -->
 164 AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.
+
+Catalog: **164 skills · 30 commands · 13 bundles · 177 plugins**.
+<!-- catalog-summary:end -->
 
 Skills are **model-agnostic playbooks**: the harness supplies the model, so no skill names a concrete model — orchestrators speak in capability tiers, and each repo's routing block maps tiers to models. Enforced by `scripts/validate-skill-sync.sh`; standards live in `.agents/memory/system/skill-standards.md`.
 
 ## Directory Structure
 
-```
-skills/
-├── skills/              # All skills (164)
-├── commands/            # All commands (30)
-├── bundles/             # Generated marketplace bundles
-├── .agents/             # Repo management, memory, meta-skills
-│   ├── memory/          # Repo decisions, context, and system docs
-│   ├── sessions/        # Historical session logs
-│   └── skills/          # Meta-skills for maintaining this repo
-├── .claude/             # Claude Code adapters (agents, rules)
-└── scripts/             # Validation, generation, migration
-```
+<!-- catalog-layout:start -->
+| Path | Role | Generated fact |
+|---|---|---|
+| `.agents/` | Repository memory, standards, and maintenance skills | Tracked |
+| `.claude/` | Claude loader adapters for shared maintenance content | Tracked |
+| `.claude-plugin/` | Generated Claude marketplace catalog | 177 generated plugins |
+| `.codex/` | Codex loader adapters for shared maintenance content | Tracked |
+| `.github/` | Issue templates and GitHub Actions workflows | Tracked |
+| `.husky/` | Git hook configuration | Tracked |
+| `assets/` | Static repository assets | Tracked |
+| `bundles/` | Generated marketplace bundle snapshots | 13 generated bundles |
+| `commands/` | Claude Code/plugin command adapters | 30 command adapters |
+| `prompts/` | Shared prompt resources | Tracked |
+| `resources/` | Authoring references and supporting documentation | Tracked |
+| `scripts/` | Validation, generation, migration, and audit tooling | Tracked |
+| `skills/` | Canonical public Agent Skills sources | 164 canonical skills |
+<!-- catalog-layout:end -->
 
 ## What's Included
 
@@ -202,7 +211,9 @@ or another Agent Skills-compatible harness.
 | test | Run, author, and set up tests |
 | tests | Run the right tests and turn red green |
 
+<!-- catalog-skills-heading:start -->
 ## Skills (164)
+<!-- catalog-skills-heading:end -->
 
 ### Dev Loop (10)
 

--- a/catalog.json
+++ b/catalog.json
@@ -1,0 +1,84 @@
+{
+  "generated": true,
+  "sources": {
+    "skills": "skills/*/SKILL.md",
+    "commands": "commands/*.md",
+    "bundles": "scripts/plugin-categories.json",
+    "layout": "git ls-files"
+  },
+  "counts": {
+    "skills": 164,
+    "commands": 30,
+    "bundles": 13,
+    "plugins": 177
+  },
+  "bundles": [
+    "ai-agents",
+    "backend",
+    "dev-loop",
+    "dev-workflow",
+    "frontend",
+    "github",
+    "infrastructure",
+    "payments",
+    "planning",
+    "security",
+    "session",
+    "testing",
+    "workspace"
+  ],
+  "layout": [
+    {
+      "path": ".agents/",
+      "role": "Repository memory, standards, and maintenance skills"
+    },
+    {
+      "path": ".claude/",
+      "role": "Claude loader adapters for shared maintenance content"
+    },
+    {
+      "path": ".claude-plugin/",
+      "role": "Generated Claude marketplace catalog"
+    },
+    {
+      "path": ".codex/",
+      "role": "Codex loader adapters for shared maintenance content"
+    },
+    {
+      "path": ".github/",
+      "role": "Issue templates and GitHub Actions workflows"
+    },
+    {
+      "path": ".husky/",
+      "role": "Git hook configuration"
+    },
+    {
+      "path": "assets/",
+      "role": "Static repository assets"
+    },
+    {
+      "path": "bundles/",
+      "role": "Generated marketplace bundle snapshots"
+    },
+    {
+      "path": "commands/",
+      "role": "Claude Code/plugin command adapters"
+    },
+    {
+      "path": "prompts/",
+      "role": "Shared prompt resources"
+    },
+    {
+      "path": "resources/",
+      "role": "Authoring references and supporting documentation"
+    },
+    {
+      "path": "scripts/",
+      "role": "Validation, generation, migration, and audit tooling"
+    },
+    {
+      "path": "skills/",
+      "role": "Canonical public Agent Skills sources"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -32,7 +32,9 @@
   "private": true,
   "scripts": {
     "cleanup:global": "bash scripts/cleanup-global-duplicates.sh --execute",
-    "count": "bash -c 'echo \"Skills: $(find skills -maxdepth 2 -name SKILL.md | wc -l | tr -d \" \")\"; echo \"Commands: $(find commands -maxdepth 1 -type f -name \"*.md\" | wc -l | tr -d \" \")\"'",
+    "catalog:check": "bun scripts/generate-catalog-summary.js --check",
+    "catalog:generate": "bun scripts/generate-catalog-summary.js",
+    "count": "bun scripts/generate-catalog-summary.js --print --check",
     "deps:update": "bunx npm-check-updates -u && bun install",
     "inventory": "bash scripts/cleanup-global-duplicates.sh --dry-run",
     "lint": "bun run lint:md && bun run lint:code && bun run lint:sh",
@@ -42,7 +44,7 @@
     "lint:md": "bunx markdownlint-cli --ignore bundles --ignore dist --ignore plugins \"**/*.md\"",
     "lint:md:fix": "bunx markdownlint-cli --ignore bundles --ignore dist --ignore plugins \"**/*.md\" --fix",
     "lint:sh": "find scripts -name \"*.sh\" -exec bash scripts/lint-shellcheck.sh {} +",
-    "marketplace:generate": "bun scripts/generate-marketplace-bundles.js && bun scripts/generate-marketplace-json.js",
+    "marketplace:generate": "bun run catalog:generate && bun scripts/generate-marketplace-bundles.js && bun scripts/generate-marketplace-json.js",
     "prepare": "husky",
     "validate": "bash scripts/validate-skill-sync.sh",
     "validate:skill": "bash scripts/validate-skill-sync.sh"

--- a/scripts/generate-catalog-summary.js
+++ b/scripts/generate-catalog-summary.js
@@ -1,0 +1,229 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process';
+import { existsSync, lstatSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const ROOT = join(SCRIPT_DIR, '..');
+const CHECK = process.argv.includes('--check');
+const PRINT = process.argv.includes('--print');
+
+const ROLE_BY_DIRECTORY = {
+  '.agents': 'Repository memory, standards, and maintenance skills',
+  '.claude': 'Claude loader adapters for shared maintenance content',
+  '.claude-plugin': 'Generated Claude marketplace catalog',
+  '.codex': 'Codex loader adapters for shared maintenance content',
+  '.github': 'Issue templates and GitHub Actions workflows',
+  '.husky': 'Git hook configuration',
+  assets: 'Static repository assets',
+  bundles: 'Generated marketplace bundle snapshots',
+  commands: 'Claude Code/plugin command adapters',
+  prompts: 'Shared prompt resources',
+  resources: 'Authoring references and supporting documentation',
+  scripts: 'Validation, generation, migration, and audit tooling',
+  skills: 'Canonical public Agent Skills sources',
+};
+
+const BLOCKS = {
+  readmeSummary: ['README.md', 'catalog-summary'],
+  readmeLayout: ['README.md', 'catalog-layout'],
+  readmeSkillsHeading: ['README.md', 'catalog-skills-heading'],
+  agentsSummary: ['AGENTS.md', 'catalog-summary'],
+  memorySummary: ['.agents/memory/memory.md', 'catalog-summary'],
+  memoryCounts: ['.agents/memory/memory.md', 'catalog-counts'],
+  architectureLayout: ['.agents/memory/architecture.md', 'catalog-layout'],
+  architectureBundles: ['.agents/memory/architecture.md', 'catalog-bundles'],
+};
+
+const staleFiles = [];
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'));
+}
+
+function countSkills() {
+  const root = join(ROOT, 'skills');
+  return readdirSync(root, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory() && existsSync(join(root, entry.name, 'SKILL.md'))
+  ).length;
+}
+
+function countCommands() {
+  return readdirSync(join(ROOT, 'commands'), { withFileTypes: true }).filter(
+    (entry) => entry.isFile() && entry.name.endsWith('.md')
+  ).length;
+}
+
+function trackedTopLevelDirectories() {
+  let paths = [];
+  try {
+    paths = execFileSync('git', ['ls-files', '-z'], {
+      cwd: ROOT,
+      encoding: 'utf8',
+    })
+      .split('\0')
+      .filter(Boolean);
+  } catch {
+    paths = readdirSync(ROOT)
+      .filter((name) => {
+        const path = join(ROOT, name);
+        return lstatSync(path).isDirectory() || lstatSync(path).isSymbolicLink();
+      })
+      .map((name) => `${name}/`);
+  }
+
+  return [...new Set(paths.filter((path) => path.includes('/')).map((path) => path.split('/')[0]))]
+    .sort()
+    .map((name) => ({
+      path: `${name}/`,
+      role: ROLE_BY_DIRECTORY[name] ?? 'Tracked repository content',
+    }));
+}
+
+function buildCatalog() {
+  const categories = readJson(join(SCRIPT_DIR, 'plugin-categories.json'));
+  const bundles = Object.keys(categories.bundles).sort();
+  const skills = countSkills();
+  const commands = countCommands();
+  return {
+    generated: true,
+    sources: {
+      skills: 'skills/*/SKILL.md',
+      commands: 'commands/*.md',
+      bundles: 'scripts/plugin-categories.json',
+      layout: 'git ls-files',
+    },
+    counts: {
+      skills,
+      commands,
+      bundles: bundles.length,
+      plugins: skills + bundles.length,
+    },
+    bundles,
+    layout: trackedTopLevelDirectories(),
+  };
+}
+
+function expectedBlock(text, marker, content) {
+  const start = `<!-- ${marker}:start -->`;
+  const end = `<!-- ${marker}:end -->`;
+  const startIndex = text.indexOf(start);
+  const endIndex = text.indexOf(end);
+  if (startIndex === -1 || endIndex === -1 || endIndex < startIndex) {
+    throw new Error(`Missing generated block ${marker}`);
+  }
+  const afterEnd = endIndex + end.length;
+  return `${text.slice(0, startIndex)}${start}\n${content.trim()}\n${end}${text.slice(afterEnd)}`;
+}
+
+function updateBlock(relativePath, marker, content) {
+  const path = join(ROOT, relativePath);
+  const current = readFileSync(path, 'utf8');
+  const expected = expectedBlock(current, marker, content);
+  if (current === expected) return;
+  if (CHECK) {
+    staleFiles.push(`${relativePath} (${marker})`);
+  } else {
+    writeFileSync(path, expected);
+  }
+}
+
+function writeGeneratedFile(relativePath, content) {
+  const path = join(ROOT, relativePath);
+  const current = existsSync(path) ? readFileSync(path, 'utf8') : '';
+  if (current === content) return;
+  if (CHECK) {
+    staleFiles.push(relativePath);
+  } else {
+    writeFileSync(path, content);
+  }
+}
+
+function layoutTable(catalog) {
+  const countByPath = {
+    '.claude-plugin/': `${catalog.counts.plugins} generated plugins`,
+    'bundles/': `${catalog.counts.bundles} generated bundles`,
+    'commands/': `${catalog.counts.commands} command adapters`,
+    'skills/': `${catalog.counts.skills} canonical skills`,
+  };
+  const rows = catalog.layout.map(
+    (entry) => `| \`${entry.path}\` | ${entry.role} | ${countByPath[entry.path] ?? 'Tracked'} |`
+  );
+  return ['| Path | Role | Generated fact |', '|---|---|---|', ...rows].join('\n');
+}
+
+function updatePackageDescription(catalog) {
+  const path = join(ROOT, 'package.json');
+  const packageJson = readJson(path);
+  packageJson.description = `${catalog.counts.skills} AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.`;
+  const expected = `${JSON.stringify(packageJson, null, 2)}\n`;
+  const current = readFileSync(path, 'utf8');
+  if (current === expected) return;
+  if (CHECK) {
+    staleFiles.push('package.json (description)');
+  } else {
+    writeFileSync(path, expected);
+  }
+}
+
+function updateDocuments(catalog) {
+  const counts = catalog.counts;
+  updateBlock(
+    ...BLOCKS.readmeSummary,
+    `${counts.skills} AI agent skills for development workflows. Works with Claude Code, OpenAI Codex, and Cursor.\n\nCatalog: **${counts.skills} skills · ${counts.commands} commands · ${counts.bundles} bundles · ${counts.plugins} plugins**.`
+  );
+  updateBlock(...BLOCKS.readmeLayout, layoutTable(catalog));
+  updateBlock(...BLOCKS.readmeSkillsHeading, `## Skills (${counts.skills})`);
+  updateBlock(
+    ...BLOCKS.agentsSummary,
+    `This is the shipshitdev/skills repo: ${counts.skills} AI agent skills for Claude Code, Codex, and Cursor. The generated catalog also contains ${counts.commands} command adapters, ${counts.bundles} bundles, and ${counts.plugins} marketplace plugins.`
+  );
+  updateBlock(
+    ...BLOCKS.memorySummary,
+    `Public skills library at \`shipshitdev/skills\`. Installable via \`npx skills add shipshitdev/skills --skill <name>\`. Works with Claude Code, Codex, Cursor, OpenClaw, and Gemini.\n\nGenerated catalog: **${counts.skills} skills · ${counts.commands} commands · ${counts.bundles} bundles · ${counts.plugins} plugins**.`
+  );
+  updateBlock(
+    ...BLOCKS.memoryCounts,
+    [
+      '| Asset | Count | Canonical source |',
+      '|---|---:|---|',
+      `| Skills | ${counts.skills} | \`skills/*/SKILL.md\` |`,
+      `| Commands | ${counts.commands} | \`commands/*.md\` |`,
+      `| Bundles | ${counts.bundles} | \`scripts/plugin-categories.json\` |`,
+      `| Plugins | ${counts.plugins} | skills + bundles |`,
+    ].join('\n')
+  );
+  updateBlock(...BLOCKS.architectureLayout, layoutTable(catalog));
+  updateBlock(
+    ...BLOCKS.architectureBundles,
+    `${counts.bundles} generated bundles: ${catalog.bundles.map((name) => `\`${name}\``).join(', ')}.`
+  );
+}
+
+const catalog = buildCatalog();
+const catalogJson = `${JSON.stringify(catalog, null, 2)}\n`;
+writeGeneratedFile('catalog.json', catalogJson);
+updateDocuments(catalog);
+updatePackageDescription(catalog);
+
+if (PRINT) {
+  console.log(
+    `Skills: ${catalog.counts.skills}\nCommands: ${catalog.counts.commands}\nBundles: ${catalog.counts.bundles}\nPlugins: ${catalog.counts.plugins}`
+  );
+}
+
+if (CHECK && staleFiles.length > 0) {
+  console.error('Generated catalog facts are stale:');
+  for (const file of staleFiles) console.error(`  - ${file}`);
+  process.exit(1);
+}
+
+if (!PRINT) {
+  console.log(
+    CHECK
+      ? 'Generated catalog facts are current.'
+      : `Generated catalog facts: ${catalog.counts.skills} skills, ${catalog.counts.commands} commands, ${catalog.counts.bundles} bundles, ${catalog.counts.plugins} plugins.`
+  );
+}

--- a/scripts/generate-marketplace-json.js
+++ b/scripts/generate-marketplace-json.js
@@ -11,6 +11,7 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = join(__dirname, '..');
 const SKILLS_DIR = join(ROOT, 'skills');
 const CATEGORIES = JSON.parse(readFileSync(join(__dirname, 'plugin-categories.json'), 'utf-8'));
+const CATALOG = JSON.parse(readFileSync(join(ROOT, 'catalog.json'), 'utf-8'));
 
 // Get skill description from SKILL.md frontmatter.
 // Handles plain/quoted single-line values AND YAML block scalars
@@ -97,9 +98,25 @@ const marketplace = {
   owner: {
     name: 'Ship Shit Dev',
   },
-  description: `${includedSkillCount} AI agent skills for development workflows`,
+  description: `${CATALOG.counts.skills} AI agent skills for development workflows`,
   plugins,
 };
+
+if (includedSkillCount !== CATALOG.counts.skills) {
+  throw new Error(
+    `Catalog skill count ${CATALOG.counts.skills} does not match marketplace sources ${includedSkillCount}`
+  );
+}
+if (Object.keys(CATEGORIES.bundles).length !== CATALOG.counts.bundles) {
+  throw new Error(
+    `Catalog bundle count ${CATALOG.counts.bundles} does not match plugin categories`
+  );
+}
+if (plugins.length !== CATALOG.counts.plugins) {
+  throw new Error(
+    `Catalog plugin count ${CATALOG.counts.plugins} does not match generated plugins ${plugins.length}`
+  );
+}
 
 const outputDir = join(ROOT, '.claude-plugin');
 if (!existsSync(outputDir)) {

--- a/scripts/validate-skill-sync.sh
+++ b/scripts/validate-skill-sync.sh
@@ -723,6 +723,19 @@ check_supported_codex_surfaces() {
     return $issues
 }
 
+# Ensure generated count and layout claims match the canonical catalog sources.
+check_catalog_summary() {
+    local output
+    if ! output=$(bun "$REPO_ROOT/scripts/generate-catalog-summary.js" --check 2>&1); then
+        echo -e "${RED}✗${NC} Generated catalog facts are stale"
+        while IFS= read -r line; do
+            [[ -n "$line" ]] && echo "  $line"
+        done <<< "$output"
+        return 1
+    fi
+    return 0
+}
+
 # Function to check for hardcoded platform paths
 check_platform_paths() {
     local file="$1"
@@ -1239,6 +1252,10 @@ check_public_execution_parameters || public_execution_warnings=$?
 codex_surface_issues=0
 check_supported_codex_surfaces || codex_surface_issues=$?
 ((TOTAL_ISSUES += codex_surface_issues, 1))
+
+catalog_issues=0
+check_catalog_summary || catalog_issues=$?
+((TOTAL_ISSUES += catalog_issues, 1))
 
 # Validate external adapter examples before canonical skill content.
 adapter_issues=0


### PR DESCRIPTION
## Summary
- add deterministic `catalog.json` with skill, command, bundle, plugin, and tracked-layout facts
- generate README, AGENTS, memory, architecture, package, and marketplace count claims from canonical sources
- replace the stale handwritten directory trees with tracked-path tables
- add read-only catalog drift validation to the lightweight sync check
- wire catalog generation and committed-output verification into CI and maintenance guidance

## Verification
- `bun run marketplace:generate`
- `bun run catalog:check`
- `bun run count`
- focused repository validator
- scoped Biome and Markdown lint
- `git diff --check`

Closes #74