### PR TITLE
fix: scope performance-expert to backend/infra, delegate React render work to react-component-performance

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -548,7 +548,7 @@
     {
       "name": "performance-expert",
       "source": "./skills/performance-expert",
-      "description": "Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching."
+      "description": "Backend, database, and infrastructure performance expert covering API response times, query and index optimization, N+1 elimination, caching and background jobs, server profiling, and build/asset delivery. Use when improving API latency, optimizing database queries or indexes, designing a caching layer, moving heavy work to a queue, profiling a server process, shrinking a shipped bundle, or configuring CDN and edge caching. React render and component work belongs to `react-component-performance`."
     },
     {
       "name": "playwright-e2e-init",
@@ -633,7 +633,7 @@
     {
       "name": "react-component-performance",
       "source": "./skills/react-component-performance",
-      "description": "Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work."
+      "description": "Diagnose slow React components and apply targeted render-time fixes. Use when profiling a slow React component, cutting re-renders or props churn, fixing list lag or janky typing and scrolling, deciding where `memo`, `useMemo`, or `useCallback` pay off, virtualizing a long list, or reading a React DevTools Profiler trace. API latency, database queries, caching, and infrastructure belong to `performance-expert`."
     },
     {
       "name": "react-hook-form",

--- a/bundles/frontend/skills/react-component-performance/README.md
+++ b/bundles/frontend/skills/react-component-performance/README.md
@@ -14,6 +14,6 @@ Derived from **[Dimillian/Skills](https://github.com/Dimillian/Skills)** (MIT).
 | Last synced | 2026-06-12 |
 | License | MIT |
 
-**Local modifications:** Vendored as a standalone marketplace plugin. The prior `source: "Dimillian/Skills (MIT)"` shorthand was upgraded to a verifiable upstream URL + pinned commit. No behavioral changes.
+**Local modifications:** Adapted as a standalone marketplace plugin. The prior `source: "Dimillian/Skills (MIT)"` shorthand was upgraded to a verifiable upstream URL + pinned commit. The `description` and `when_to_use` triggers were rewritten so this skill owns React render/component performance outright and `performance-expert` owns backend, database, and infrastructure performance — the two no longer compete for the same activation. Workflow, checklist, and optimization patterns are unchanged from upstream.
 
 **Checking for upstream changes:** when upstream has moved ahead of the synced marker above, diff [`react-component-performance/SKILL.md`](https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md) on `main` since commit `3db84e63d050`, port anything worth bringing home, then bump `metadata.upstream_commit` (or `metadata.upstream_version`) and `metadata.last_synced` in `SKILL.md` and this table.

--- a/bundles/frontend/skills/react-component-performance/SKILL.md
+++ b/bundles/frontend/skills/react-component-performance/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: react-component-performance
-description: Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work.
+description: >-
+  Diagnose slow React components and apply targeted render-time fixes. Use when
+  profiling a slow React component, cutting re-renders or props churn, fixing
+  list lag or janky typing and scrolling, deciding where `memo`, `useMemo`, or
+  `useCallback` pay off, virtualizing a long list, or reading a React DevTools
+  Profiler trace. API latency, database queries, caching, and infrastructure
+  belong to `performance-expert`.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   source: https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md
   upstream_repo: Dimillian/Skills
   upstream_ref: main
@@ -12,6 +18,7 @@ metadata:
   tags: "react, performance, components"
   risk: safe
   date_added: "2026-03-25"
+when_to_use: "slow React component, too many re-renders, component re-renders on every keystroke, props churn, memo useMemo useCallback, virtualize a long list, React DevTools Profiler flamegraph, laggy list or scroll in React UI, expensive render work"
 ---
 # React Component Performance
 
@@ -21,6 +28,9 @@ Identify render hotspots, isolate expensive updates, and apply targeted optimiza
 
 - When the user asks to profile or improve a slow React component.
 - When you need to reduce re-renders, list lag, or expensive render work in React UI.
+
+For API latency, database queries, caching, background jobs, or infrastructure
+tuning, use `performance-expert` instead.
 
 ## Workflow
 

--- a/bundles/frontend/skills/react-component-performance/plugin.json
+++ b/bundles/frontend/skills/react-component-performance/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-component-performance",
-  "version": "1.0.0",
-  "description": "Diagnose slow React components and suggest targeted performance fixes.",
+  "version": "1.1.0",
+  "description": "Diagnose slow React components and apply targeted render-time fixes.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/infrastructure/skills/performance-expert/SKILL.md
+++ b/bundles/infrastructure/skills/performance-expert/SKILL.md
@@ -1,69 +1,109 @@
 ---
 name: performance-expert
-description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching.
+description: >-
+  Backend, database, and infrastructure performance expert covering API
+  response times, query and index optimization, N+1 elimination, caching and
+  background jobs, server profiling, and build/asset delivery. Use when
+  improving API latency, optimizing database queries or indexes, designing a
+  caching layer, moving heavy work to a queue, profiling a server process,
+  shrinking a shipped bundle, or configuring CDN and edge caching. React render
+  and component work belongs to `react-component-performance`.
 metadata:
-  version: "1.0.0"
-  tags: "performance, optimization, fullstack"
+  version: "1.1.0"
+  tags: "performance, optimization, backend, database, infrastructure"
+when_to_use: "slow API endpoint, high p95 latency, slow database query, missing index, N+1 queries, add caching, Redis cache strategy, move work to a background job, profile the server, connection pooling, bundle size too large, CDN and cache headers, cold starts, load testing"
 ---
 
 # Performance Expert Skill
 
+Backend, database, and infrastructure performance. This skill owns the
+server-side and delivery-layer of a stack: request latency, data access,
+caching, background work, and what ships over the wire.
+
+Render-time work inside React components — re-renders, memoization,
+virtualized lists, Profiler traces — is a different diagnosis with different
+tooling. Route it to `react-component-performance` instead of duplicating it
+here.
+
+## Contract
+
+Inputs:
+
+- A performance symptom with a surface: an endpoint, a query, a job, a build
+  output, or a metric that regressed.
+
+Outputs:
+
+- A ranked list of bottlenecks with the measurement that proves each one, plus
+  a targeted fix per bottleneck.
+
+Creates/Modifies:
+
+- None on its own. It diagnoses and prescribes; edits happen in the caller's
+  workflow.
+
+External Side Effects:
+
+- None. Profiling and load-testing commands are prescribed, not executed
+  unattended.
+
+Delegates To:
+
+- `react-component-performance` for React render hotspots, re-render churn,
+  memoization, and Profiler-driven component work.
+- `workspace-performance-audit` when the target is a whole monorepo rather than
+  one surface.
+
 ## When to Use
 
-- Optimizing React components or Next.js pages
 - Improving API response times
-- Optimizing database queries
-- Analyzing bundle sizes
-- Implementing caching strategies
-- Optimizing images or assets
-- Configuring CDN or caching
-- Reviewing Core Web Vitals
+- Optimizing database queries, indexes, and aggregation pipelines
+- Diagnosing N+1 query patterns
+- Implementing caching strategies and invalidation
+- Moving heavy work into background jobs or queues
+- Profiling a server process or tracing a slow request
+- Analyzing shipped bundle size and asset delivery
+- Configuring CDN, cache headers, or edge caching
 
 ## Project Context Discovery
 
-1. Check `.agents/memory/` for performance architecture context (e.g., `repo_frontend_design_execution.md`, any `*performance*` or `*architecture*` files)
-2. Identify performance tools (Lighthouse CI, APM)
+1. Check `.agents/memory/` for performance architecture context (e.g., any
+   `*performance*` or `*architecture*` files)
+2. Identify performance tools (APM, load-testing harness, profiler)
 3. Review existing optimizations and caching strategies
 4. Check for `[project]-performance-expert` skill
 
 ## Core Performance Principles
 
-### Frontend (React/Next.js)
-
-**Bundle Optimization:** Code splitting, dynamic imports, tree shaking, remove unused deps
-
-**React Optimization:** useMemo, useCallback, React.memo, virtualization, lazy loading
-
-**Next.js:** Server Components, SSG, ISR, next/image, font optimization
-
-**Assets:** WebP images, font subset, CSS minify, Gzip/Brotli
-
-### Backend (NestJS)
+### Backend
 
 **API Response Times:** Target < 200ms (p95), caching, background jobs, connection pooling
 
 **Query Optimization:** Indexes, projections, pagination, optimized aggregations
 
-### Database (MongoDB)
+**Background Processing:** Queues for heavy operations, async for non-critical tasks, no blocking work in request handlers
+
+### Database
 
 **Indexes:** On frequently queried fields, compound indexes, monitor usage
 
-**Queries:** Early $match, projection before expensive ops, sort with indexes
+**Queries:** Filter early, project before expensive stages, sort with indexes, avoid full scans
 
-### Infrastructure (AWS)
+### Infrastructure
 
-**CDN:** CloudFront caching, cache headers, edge optimization
+**CDN:** Edge caching, correct cache headers, static assets off the origin
 
-**Lambda:** Cold start optimization, memory allocation, provisioned concurrency
+**Serverless:** Cold start optimization, memory allocation, provisioned concurrency
+
+### Delivery Layer
+
+**Bundles:** Code splitting by route, dynamic imports for heavy modules, tree shaking, drop unused dependencies
+
+**Assets:** WebP images, subset fonts, minify CSS/JS, Gzip/Brotli compression
+
+**Server rendering:** Static generation for static content, incremental revalidation, framework image and font pipelines
 
 ## Performance Metrics
-
-### Frontend (Core Web Vitals)
-
-- **LCP:** < 2.5s
-- **FID:** < 100ms
-- **CLS:** < 0.1
-- **FCP:** < 1.8s
 
 ### Backend
 
@@ -72,14 +112,13 @@ metadata:
 - **DB Query p95:** < 50ms
 - **Error Rate:** < 0.1%
 
+### Delivery
+
+- **LCP:** < 2.5s
+- **TTFB:** < 800ms
+- **Initial bundle:** < 200KB
+
 ## Quick Checklist
-
-### Frontend
-
-- [ ] Bundle size < 200KB initial
-- [ ] Code splitting implemented
-- [ ] Images optimized and lazy loaded
-- [ ] React components memoized
 
 ### Backend
 
@@ -87,7 +126,15 @@ metadata:
 - [ ] Indexes created and used
 - [ ] Caching implemented
 - [ ] Background jobs for heavy operations
+- [ ] Connection pooling configured
+
+### Delivery
+
+- [ ] Bundle size < 200KB initial
+- [ ] Code splitting implemented
+- [ ] Images optimized and lazy loaded
+- [ ] Compression and cache headers configured
 
 ---
 
-**For complete React memoization patterns, Next.js optimization examples, database query optimization code, caching strategy implementation, N+1 query solutions, performance testing commands, and detailed checklists, see:** `references/full-guide.md`
+**For database query optimization code, caching strategy implementation, N+1 query solutions, background-job patterns, infrastructure tuning, performance testing commands, and detailed checklists, see:** `references/full-guide.md`

--- a/bundles/infrastructure/skills/performance-expert/plugin.json
+++ b/bundles/infrastructure/skills/performance-expert/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "performance-expert",
-  "version": "1.0.0",
-  "description": "Expert in performance optimization for React, Next.js, NestJS applications covering frontend renderi",
+  "version": "1.1.0",
+  "description": "Backend, database, and infrastructure performance: queries, caching, jobs, delivery.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/infrastructure/skills/performance-expert/references/full-guide.md
+++ b/bundles/infrastructure/skills/performance-expert/references/full-guide.md
@@ -1,43 +1,12 @@
 # Performance Expert - Full Guide
 
+Backend, database, and infrastructure performance. For React render hotspots,
+re-render churn, memoization, and Profiler-driven component work, use the
+`react-component-performance` skill instead.
+
 ## Core Performance Principles
 
-### 1. Frontend Performance (React/Next.js)
-
-**Bundle Optimization:**
-
-- Code splitting by route
-- Dynamic imports for heavy components
-- Tree shaking enabled
-- Remove unused dependencies
-- Optimize large dependencies
-
-**React Optimization:**
-
-- Memoization (`useMemo`, `useCallback`)
-- Component splitting to prevent re-renders
-- Virtualization for long lists
-- Lazy loading for routes/components
-- React.memo for expensive components
-
-**Next.js Optimization:**
-
-- Server Components where appropriate
-- Static generation (SSG) for static content
-- ISR (Incremental Static Regeneration)
-- Image optimization (`next/image`)
-- Font optimization
-- Script optimization
-
-**Asset Optimization:**
-
-- Images optimized (WebP, compression)
-- Fonts subset and preloaded
-- CSS minified and purged
-- JavaScript minified
-- Gzip/Brotli compression
-
-### 2. Backend Performance (NestJS)
+### 1. Backend Performance
 
 **API Response Times:**
 
@@ -57,19 +26,19 @@
 
 **Caching Strategy:**
 
-- Redis caching for frequently accessed data
+- Cache frequently accessed data (e.g. Redis)
 - Cache invalidation strategy
 - Cache TTL configured
 - Cache warming for critical data
 
 **Background Processing:**
 
-- Heavy operations in queues (BullMQ)
+- Heavy operations in queues (e.g. BullMQ)
 - Async processing for non-critical tasks
 - WebSocket for real-time updates
 - No blocking operations in request handlers
 
-### 3. Database Performance (MongoDB)
+### 2. Database Performance
 
 **Index Strategy:**
 
@@ -102,17 +71,17 @@
 - Idle connections closed
 - Connection monitoring
 
-### 4. Infrastructure Performance (AWS)
+### 3. Infrastructure Performance
 
 **CDN Configuration:**
 
-- CloudFront caching configured
+- Edge caching configured
 - Cache headers set correctly
 - Static assets on CDN
 - Edge locations optimized
 - Cache invalidation strategy
 
-**Lambda Optimization:**
+**Serverless Optimization:**
 
 - Cold start optimization
 - Memory allocation optimized
@@ -120,24 +89,40 @@
 - Provisioned concurrency (if needed)
 - Function size minimized
 
-**Database Performance:**
+**Managed Database:**
 
-- MongoDB Atlas performance tier appropriate
+- Performance tier appropriate for load
 - Read replicas configured (if needed)
 - Connection pooling optimized
 - Monitoring enabled
 - Query performance tracked
 
+### 4. Delivery Layer
+
+**Bundle Optimization:**
+
+- Code splitting by route
+- Dynamic imports for heavy modules
+- Tree shaking enabled
+- Remove unused dependencies
+- Optimize large dependencies
+
+**Server Rendering:**
+
+- Static generation for static content
+- Incremental revalidation for semi-static content
+- Framework image pipeline for responsive images
+- Font and script loading optimized
+
+**Asset Optimization:**
+
+- Images optimized (WebP, compression)
+- Fonts subset and preloaded
+- CSS minified and purged
+- JavaScript minified
+- Gzip/Brotli compression
+
 ## Performance Metrics
-
-### Frontend Metrics (Core Web Vitals)
-
-- **LCP (Largest Contentful Paint)**: < 2.5s
-- **FID (First Input Delay)**: < 100ms
-- **CLS (Cumulative Layout Shift)**: < 0.1
-- **FCP (First Contentful Paint)**: < 1.8s
-- **TTI (Time to Interactive)**: < 3.8s
-- **TBT (Total Blocking Time)**: < 200ms
 
 ### Backend Metrics
 
@@ -154,6 +139,13 @@
 - **Index Hit Ratio**: > 95%
 - **Connection Pool Usage**: < 80%
 - **Slow Query Count**: < 1% of queries
+
+### Delivery Metrics
+
+- **TTFB (Time to First Byte)**: < 800ms
+- **LCP (Largest Contentful Paint)**: < 2.5s
+- **Initial bundle**: < 200KB
+- **Cache hit ratio at the edge**: > 90%
 
 ## Common Performance Issues
 
@@ -195,7 +187,7 @@ async findAll() {
 **Solution:**
 
 - Code splitting by route
-- Dynamic imports for heavy components
+- Dynamic imports for heavy modules
 - Remove unused dependencies
 - Optimize large libraries
 - Tree shaking enabled
@@ -214,77 +206,29 @@ await db.collection('posts').createIndex(
 );
 ```
 
-### 4. Unnecessary Re-renders
-
-**Problem:** React components re-rendering too often
-
-**Solution:**
-
-```typescript
-// Memoized
-const processed = useMemo(
-  () => data.map(item => process(item)),
-  [data]
-);
-
-const handleClick = useCallback(() => {
-  // handler
-}, [dependencies]);
-```
-
-### 5. Blocking Operations
+### 4. Blocking Operations
 
 **Problem:** Heavy operations blocking request handlers
 
 **Solution:**
 
 - Move to background jobs
-- Use queues (BullMQ)
+- Use queues (e.g. BullMQ)
 - Async processing
 - WebSocket for real-time updates
 
+### 5. Cache Stampede
+
+**Problem:** A hot key expires and every request rebuilds it at once
+
+**Solution:**
+
+- Stagger TTLs so keys expire at different times
+- Serve stale while a single request revalidates
+- Lock or single-flight the rebuild
+- Warm critical keys before traffic arrives
+
 ## Performance Optimization Patterns
-
-### React Memoization
-
-```typescript
-// Memoize expensive computations
-const expensiveValue = useMemo(() => {
-  return heavyComputation(data);
-}, [data]);
-
-// Memoize callbacks
-const handleClick = useCallback(() => {
-  doSomething(id);
-}, [id]);
-
-// Memoize components
-const ExpensiveComponent = React.memo(({ data }) => {
-  return <div>{/* render */}</div>;
-});
-```
-
-### Next.js Optimization
-
-```typescript
-// Static generation
-export async function getStaticProps() {
-  return {
-    props: { data },
-    revalidate: 3600 // ISR
-  };
-}
-
-// Dynamic imports
-const HeavyComponent = dynamic(() => import('./HeavyComponent'), {
-  loading: () => <Loading />,
-  ssr: false
-});
-
-// Image optimization
-import Image from 'next/image';
-<Image src="/image.jpg" width={500} height={300} alt="..." />
-```
 
 ### Database Query Optimization
 
@@ -327,6 +271,31 @@ async findAll(organizationId: string) {
 }
 ```
 
+### Background Jobs
+
+```typescript
+// Return fast; do the expensive work off the request path
+async requestExport(organizationId: string) {
+  await this.exportQueue.add('generate', { organizationId });
+  return { status: 'queued' };
+}
+```
+
+### Delivery Layer
+
+```typescript
+// Static generation with incremental revalidation
+export async function getStaticProps() {
+  return {
+    props: { data },
+    revalidate: 3600
+  };
+}
+
+// Dynamic import for a heavy module kept off the initial bundle
+const HeavyModule = dynamic(() => import('./HeavyModule'), { ssr: false });
+```
+
 ## Performance Testing
 
 **Load Testing:**
@@ -354,27 +323,14 @@ node --prof-process isolate-*.log
 
 ```bash
 # Analyze bundle
-npm run build
-npm run analyze
+bun run build
+bun run analyze
 
-# Or with webpack-bundle-analyzer
-ANALYZE=true npm run build
+# Or with a bundle analyzer plugin
+ANALYZE=true bun run build
 ```
 
 ## Performance Checklist
-
-### Frontend
-
-- [ ] Bundle size optimized (< 200KB initial)
-- [ ] Code splitting implemented
-- [ ] Images optimized and lazy loaded
-- [ ] Fonts optimized
-- [ ] CSS purged
-- [ ] JavaScript minified
-- [ ] Gzip/Brotli compression enabled
-- [ ] Caching headers configured
-- [ ] React components memoized
-- [ ] Virtualization for long lists
 
 ### Backend
 
@@ -404,6 +360,17 @@ ANALYZE=true npm run build
 - [ ] Auto-scaling configured
 - [ ] Monitoring and alerting set up
 - [ ] Cost optimization reviewed
+
+### Delivery
+
+- [ ] Bundle size optimized (< 200KB initial)
+- [ ] Code splitting implemented
+- [ ] Images optimized and lazy loaded
+- [ ] Fonts optimized
+- [ ] CSS purged
+- [ ] JavaScript minified
+- [ ] Gzip/Brotli compression enabled
+- [ ] Caching headers configured
 
 ## Best Practices
 

--- a/skills/performance-expert/SKILL.md
+++ b/skills/performance-expert/SKILL.md
@@ -1,69 +1,109 @@
 ---
 name: performance-expert
-description: Expert in performance optimization for React, Next.js, NestJS applications covering frontend rendering, API response times, database queries, and infrastructure optimization. Use when optimizing React components or Next.js pages, improving API response times, optimizing database queries, analyzing bundle sizes, or implementing caching.
+description: >-
+  Backend, database, and infrastructure performance expert covering API
+  response times, query and index optimization, N+1 elimination, caching and
+  background jobs, server profiling, and build/asset delivery. Use when
+  improving API latency, optimizing database queries or indexes, designing a
+  caching layer, moving heavy work to a queue, profiling a server process,
+  shrinking a shipped bundle, or configuring CDN and edge caching. React render
+  and component work belongs to `react-component-performance`.
 metadata:
-  version: "1.0.0"
-  tags: "performance, optimization, fullstack"
+  version: "1.1.0"
+  tags: "performance, optimization, backend, database, infrastructure"
+when_to_use: "slow API endpoint, high p95 latency, slow database query, missing index, N+1 queries, add caching, Redis cache strategy, move work to a background job, profile the server, connection pooling, bundle size too large, CDN and cache headers, cold starts, load testing"
 ---
 
 # Performance Expert Skill
 
+Backend, database, and infrastructure performance. This skill owns the
+server-side and delivery-layer of a stack: request latency, data access,
+caching, background work, and what ships over the wire.
+
+Render-time work inside React components — re-renders, memoization,
+virtualized lists, Profiler traces — is a different diagnosis with different
+tooling. Route it to `react-component-performance` instead of duplicating it
+here.
+
+## Contract
+
+Inputs:
+
+- A performance symptom with a surface: an endpoint, a query, a job, a build
+  output, or a metric that regressed.
+
+Outputs:
+
+- A ranked list of bottlenecks with the measurement that proves each one, plus
+  a targeted fix per bottleneck.
+
+Creates/Modifies:
+
+- None on its own. It diagnoses and prescribes; edits happen in the caller's
+  workflow.
+
+External Side Effects:
+
+- None. Profiling and load-testing commands are prescribed, not executed
+  unattended.
+
+Delegates To:
+
+- `react-component-performance` for React render hotspots, re-render churn,
+  memoization, and Profiler-driven component work.
+- `workspace-performance-audit` when the target is a whole monorepo rather than
+  one surface.
+
 ## When to Use
 
-- Optimizing React components or Next.js pages
 - Improving API response times
-- Optimizing database queries
-- Analyzing bundle sizes
-- Implementing caching strategies
-- Optimizing images or assets
-- Configuring CDN or caching
-- Reviewing Core Web Vitals
+- Optimizing database queries, indexes, and aggregation pipelines
+- Diagnosing N+1 query patterns
+- Implementing caching strategies and invalidation
+- Moving heavy work into background jobs or queues
+- Profiling a server process or tracing a slow request
+- Analyzing shipped bundle size and asset delivery
+- Configuring CDN, cache headers, or edge caching
 
 ## Project Context Discovery
 
-1. Check `.agents/memory/` for performance architecture context (e.g., `repo_frontend_design_execution.md`, any `*performance*` or `*architecture*` files)
-2. Identify performance tools (Lighthouse CI, APM)
+1. Check `.agents/memory/` for performance architecture context (e.g., any
+   `*performance*` or `*architecture*` files)
+2. Identify performance tools (APM, load-testing harness, profiler)
 3. Review existing optimizations and caching strategies
 4. Check for `[project]-performance-expert` skill
 
 ## Core Performance Principles
 
-### Frontend (React/Next.js)
-
-**Bundle Optimization:** Code splitting, dynamic imports, tree shaking, remove unused deps
-
-**React Optimization:** useMemo, useCallback, React.memo, virtualization, lazy loading
-
-**Next.js:** Server Components, SSG, ISR, next/image, font optimization
-
-**Assets:** WebP images, font subset, CSS minify, Gzip/Brotli
-
-### Backend (NestJS)
+### Backend
 
 **API Response Times:** Target < 200ms (p95), caching, background jobs, connection pooling
 
 **Query Optimization:** Indexes, projections, pagination, optimized aggregations
 
-### Database (MongoDB)
+**Background Processing:** Queues for heavy operations, async for non-critical tasks, no blocking work in request handlers
+
+### Database
 
 **Indexes:** On frequently queried fields, compound indexes, monitor usage
 
-**Queries:** Early $match, projection before expensive ops, sort with indexes
+**Queries:** Filter early, project before expensive stages, sort with indexes, avoid full scans
 
-### Infrastructure (AWS)
+### Infrastructure
 
-**CDN:** CloudFront caching, cache headers, edge optimization
+**CDN:** Edge caching, correct cache headers, static assets off the origin
 
-**Lambda:** Cold start optimization, memory allocation, provisioned concurrency
+**Serverless:** Cold start optimization, memory allocation, provisioned concurrency
+
+### Delivery Layer
+
+**Bundles:** Code splitting by route, dynamic imports for heavy modules, tree shaking, drop unused dependencies
+
+**Assets:** WebP images, subset fonts, minify CSS/JS, Gzip/Brotli compression
+
+**Server rendering:** Static generation for static content, incremental revalidation, framework image and font pipelines
 
 ## Performance Metrics
-
-### Frontend (Core Web Vitals)
-
-- **LCP:** < 2.5s
-- **FID:** < 100ms
-- **CLS:** < 0.1
-- **FCP:** < 1.8s
 
 ### Backend
 
@@ -72,14 +112,13 @@ metadata:
 - **DB Query p95:** < 50ms
 - **Error Rate:** < 0.1%
 
+### Delivery
+
+- **LCP:** < 2.5s
+- **TTFB:** < 800ms
+- **Initial bundle:** < 200KB
+
 ## Quick Checklist
-
-### Frontend
-
-- [ ] Bundle size < 200KB initial
-- [ ] Code splitting implemented
-- [ ] Images optimized and lazy loaded
-- [ ] React components memoized
 
 ### Backend
 
@@ -87,7 +126,15 @@ metadata:
 - [ ] Indexes created and used
 - [ ] Caching implemented
 - [ ] Background jobs for heavy operations
+- [ ] Connection pooling configured
+
+### Delivery
+
+- [ ] Bundle size < 200KB initial
+- [ ] Code splitting implemented
+- [ ] Images optimized and lazy loaded
+- [ ] Compression and cache headers configured
 
 ---
 
-**For complete React memoization patterns, Next.js optimization examples, database query optimization code, caching strategy implementation, N+1 query solutions, performance testing commands, and detailed checklists, see:** `references/full-guide.md`
+**For database query optimization code, caching strategy implementation, N+1 query solutions, background-job patterns, infrastructure tuning, performance testing commands, and detailed checklists, see:** `references/full-guide.md`

--- a/skills/performance-expert/plugin.json
+++ b/skills/performance-expert/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "performance-expert",
-  "version": "1.0.0",
-  "description": "Expert in performance optimization for React, Next.js, NestJS applications covering frontend renderi",
+  "version": "1.1.0",
+  "description": "Backend, database, and infrastructure performance: queries, caching, jobs, delivery.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/performance-expert/references/full-guide.md
+++ b/skills/performance-expert/references/full-guide.md
@@ -1,43 +1,12 @@
 # Performance Expert - Full Guide
 
+Backend, database, and infrastructure performance. For React render hotspots,
+re-render churn, memoization, and Profiler-driven component work, use the
+`react-component-performance` skill instead.
+
 ## Core Performance Principles
 
-### 1. Frontend Performance (React/Next.js)
-
-**Bundle Optimization:**
-
-- Code splitting by route
-- Dynamic imports for heavy components
-- Tree shaking enabled
-- Remove unused dependencies
-- Optimize large dependencies
-
-**React Optimization:**
-
-- Memoization (`useMemo`, `useCallback`)
-- Component splitting to prevent re-renders
-- Virtualization for long lists
-- Lazy loading for routes/components
-- React.memo for expensive components
-
-**Next.js Optimization:**
-
-- Server Components where appropriate
-- Static generation (SSG) for static content
-- ISR (Incremental Static Regeneration)
-- Image optimization (`next/image`)
-- Font optimization
-- Script optimization
-
-**Asset Optimization:**
-
-- Images optimized (WebP, compression)
-- Fonts subset and preloaded
-- CSS minified and purged
-- JavaScript minified
-- Gzip/Brotli compression
-
-### 2. Backend Performance (NestJS)
+### 1. Backend Performance
 
 **API Response Times:**
 
@@ -57,19 +26,19 @@
 
 **Caching Strategy:**
 
-- Redis caching for frequently accessed data
+- Cache frequently accessed data (e.g. Redis)
 - Cache invalidation strategy
 - Cache TTL configured
 - Cache warming for critical data
 
 **Background Processing:**
 
-- Heavy operations in queues (BullMQ)
+- Heavy operations in queues (e.g. BullMQ)
 - Async processing for non-critical tasks
 - WebSocket for real-time updates
 - No blocking operations in request handlers
 
-### 3. Database Performance (MongoDB)
+### 2. Database Performance
 
 **Index Strategy:**
 
@@ -102,17 +71,17 @@
 - Idle connections closed
 - Connection monitoring
 
-### 4. Infrastructure Performance (AWS)
+### 3. Infrastructure Performance
 
 **CDN Configuration:**
 
-- CloudFront caching configured
+- Edge caching configured
 - Cache headers set correctly
 - Static assets on CDN
 - Edge locations optimized
 - Cache invalidation strategy
 
-**Lambda Optimization:**
+**Serverless Optimization:**
 
 - Cold start optimization
 - Memory allocation optimized
@@ -120,24 +89,40 @@
 - Provisioned concurrency (if needed)
 - Function size minimized
 
-**Database Performance:**
+**Managed Database:**
 
-- MongoDB Atlas performance tier appropriate
+- Performance tier appropriate for load
 - Read replicas configured (if needed)
 - Connection pooling optimized
 - Monitoring enabled
 - Query performance tracked
 
+### 4. Delivery Layer
+
+**Bundle Optimization:**
+
+- Code splitting by route
+- Dynamic imports for heavy modules
+- Tree shaking enabled
+- Remove unused dependencies
+- Optimize large dependencies
+
+**Server Rendering:**
+
+- Static generation for static content
+- Incremental revalidation for semi-static content
+- Framework image pipeline for responsive images
+- Font and script loading optimized
+
+**Asset Optimization:**
+
+- Images optimized (WebP, compression)
+- Fonts subset and preloaded
+- CSS minified and purged
+- JavaScript minified
+- Gzip/Brotli compression
+
 ## Performance Metrics
-
-### Frontend Metrics (Core Web Vitals)
-
-- **LCP (Largest Contentful Paint)**: < 2.5s
-- **FID (First Input Delay)**: < 100ms
-- **CLS (Cumulative Layout Shift)**: < 0.1
-- **FCP (First Contentful Paint)**: < 1.8s
-- **TTI (Time to Interactive)**: < 3.8s
-- **TBT (Total Blocking Time)**: < 200ms
 
 ### Backend Metrics
 
@@ -154,6 +139,13 @@
 - **Index Hit Ratio**: > 95%
 - **Connection Pool Usage**: < 80%
 - **Slow Query Count**: < 1% of queries
+
+### Delivery Metrics
+
+- **TTFB (Time to First Byte)**: < 800ms
+- **LCP (Largest Contentful Paint)**: < 2.5s
+- **Initial bundle**: < 200KB
+- **Cache hit ratio at the edge**: > 90%
 
 ## Common Performance Issues
 
@@ -195,7 +187,7 @@ async findAll() {
 **Solution:**
 
 - Code splitting by route
-- Dynamic imports for heavy components
+- Dynamic imports for heavy modules
 - Remove unused dependencies
 - Optimize large libraries
 - Tree shaking enabled
@@ -214,77 +206,29 @@ await db.collection('posts').createIndex(
 );
 ```
 
-### 4. Unnecessary Re-renders
-
-**Problem:** React components re-rendering too often
-
-**Solution:**
-
-```typescript
-// Memoized
-const processed = useMemo(
-  () => data.map(item => process(item)),
-  [data]
-);
-
-const handleClick = useCallback(() => {
-  // handler
-}, [dependencies]);
-```
-
-### 5. Blocking Operations
+### 4. Blocking Operations
 
 **Problem:** Heavy operations blocking request handlers
 
 **Solution:**
 
 - Move to background jobs
-- Use queues (BullMQ)
+- Use queues (e.g. BullMQ)
 - Async processing
 - WebSocket for real-time updates
 
+### 5. Cache Stampede
+
+**Problem:** A hot key expires and every request rebuilds it at once
+
+**Solution:**
+
+- Stagger TTLs so keys expire at different times
+- Serve stale while a single request revalidates
+- Lock or single-flight the rebuild
+- Warm critical keys before traffic arrives
+
 ## Performance Optimization Patterns
-
-### React Memoization
-
-```typescript
-// Memoize expensive computations
-const expensiveValue = useMemo(() => {
-  return heavyComputation(data);
-}, [data]);
-
-// Memoize callbacks
-const handleClick = useCallback(() => {
-  doSomething(id);
-}, [id]);
-
-// Memoize components
-const ExpensiveComponent = React.memo(({ data }) => {
-  return <div>{/* render */}</div>;
-});
-```
-
-### Next.js Optimization
-
-```typescript
-// Static generation
-export async function getStaticProps() {
-  return {
-    props: { data },
-    revalidate: 3600 // ISR
-  };
-}
-
-// Dynamic imports
-const HeavyComponent = dynamic(() => import('./HeavyComponent'), {
-  loading: () => <Loading />,
-  ssr: false
-});
-
-// Image optimization
-import Image from 'next/image';
-<Image src="/image.jpg" width={500} height={300} alt="..." />
-```
 
 ### Database Query Optimization
 
@@ -327,6 +271,31 @@ async findAll(organizationId: string) {
 }
 ```
 
+### Background Jobs
+
+```typescript
+// Return fast; do the expensive work off the request path
+async requestExport(organizationId: string) {
+  await this.exportQueue.add('generate', { organizationId });
+  return { status: 'queued' };
+}
+```
+
+### Delivery Layer
+
+```typescript
+// Static generation with incremental revalidation
+export async function getStaticProps() {
+  return {
+    props: { data },
+    revalidate: 3600
+  };
+}
+
+// Dynamic import for a heavy module kept off the initial bundle
+const HeavyModule = dynamic(() => import('./HeavyModule'), { ssr: false });
+```
+
 ## Performance Testing
 
 **Load Testing:**
@@ -354,27 +323,14 @@ node --prof-process isolate-*.log
 
 ```bash
 # Analyze bundle
-npm run build
-npm run analyze
+bun run build
+bun run analyze
 
-# Or with webpack-bundle-analyzer
-ANALYZE=true npm run build
+# Or with a bundle analyzer plugin
+ANALYZE=true bun run build
 ```
 
 ## Performance Checklist
-
-### Frontend
-
-- [ ] Bundle size optimized (< 200KB initial)
-- [ ] Code splitting implemented
-- [ ] Images optimized and lazy loaded
-- [ ] Fonts optimized
-- [ ] CSS purged
-- [ ] JavaScript minified
-- [ ] Gzip/Brotli compression enabled
-- [ ] Caching headers configured
-- [ ] React components memoized
-- [ ] Virtualization for long lists
 
 ### Backend
 
@@ -404,6 +360,17 @@ ANALYZE=true npm run build
 - [ ] Auto-scaling configured
 - [ ] Monitoring and alerting set up
 - [ ] Cost optimization reviewed
+
+### Delivery
+
+- [ ] Bundle size optimized (< 200KB initial)
+- [ ] Code splitting implemented
+- [ ] Images optimized and lazy loaded
+- [ ] Fonts optimized
+- [ ] CSS purged
+- [ ] JavaScript minified
+- [ ] Gzip/Brotli compression enabled
+- [ ] Caching headers configured
 
 ## Best Practices
 

--- a/skills/react-component-performance/README.md
+++ b/skills/react-component-performance/README.md
@@ -14,6 +14,6 @@ Derived from **[Dimillian/Skills](https://github.com/Dimillian/Skills)** (MIT).
 | Last synced | 2026-06-12 |
 | License | MIT |
 
-**Local modifications:** Vendored as a standalone marketplace plugin. The prior `source: "Dimillian/Skills (MIT)"` shorthand was upgraded to a verifiable upstream URL + pinned commit. No behavioral changes.
+**Local modifications:** Adapted as a standalone marketplace plugin. The prior `source: "Dimillian/Skills (MIT)"` shorthand was upgraded to a verifiable upstream URL + pinned commit. The `description` and `when_to_use` triggers were rewritten so this skill owns React render/component performance outright and `performance-expert` owns backend, database, and infrastructure performance — the two no longer compete for the same activation. Workflow, checklist, and optimization patterns are unchanged from upstream.
 
 **Checking for upstream changes:** when upstream has moved ahead of the synced marker above, diff [`react-component-performance/SKILL.md`](https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md) on `main` since commit `3db84e63d050`, port anything worth bringing home, then bump `metadata.upstream_commit` (or `metadata.upstream_version`) and `metadata.last_synced` in `SKILL.md` and this table.

--- a/skills/react-component-performance/SKILL.md
+++ b/skills/react-component-performance/SKILL.md
@@ -1,8 +1,14 @@
 ---
 name: react-component-performance
-description: Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work.
+description: >-
+  Diagnose slow React components and apply targeted render-time fixes. Use when
+  profiling a slow React component, cutting re-renders or props churn, fixing
+  list lag or janky typing and scrolling, deciding where `memo`, `useMemo`, or
+  `useCallback` pay off, virtualizing a long list, or reading a React DevTools
+  Profiler trace. API latency, database queries, caching, and infrastructure
+  belong to `performance-expert`.
 metadata:
-  version: "1.0.0"
+  version: "1.1.0"
   source: https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md
   upstream_repo: Dimillian/Skills
   upstream_ref: main
@@ -12,6 +18,7 @@ metadata:
   tags: "react, performance, components"
   risk: safe
   date_added: "2026-03-25"
+when_to_use: "slow React component, too many re-renders, component re-renders on every keystroke, props churn, memo useMemo useCallback, virtualize a long list, React DevTools Profiler flamegraph, laggy list or scroll in React UI, expensive render work"
 ---
 # React Component Performance
 
@@ -21,6 +28,9 @@ Identify render hotspots, isolate expensive updates, and apply targeted optimiza
 
 - When the user asks to profile or improve a slow React component.
 - When you need to reduce re-renders, list lag, or expensive render work in React UI.
+
+For API latency, database queries, caching, background jobs, or infrastructure
+tuning, use `performance-expert` instead.
 
 ## Workflow
 

--- a/skills/react-component-performance/plugin.json
+++ b/skills/react-component-performance/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "react-component-performance",
-  "version": "1.0.0",
-  "description": "Diagnose slow React components and suggest targeted performance fixes.",
+  "version": "1.1.0",
+  "description": "Diagnose slow React components and apply targeted render-time fixes.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",


### PR DESCRIPTION
Closes #101

## Problem

A duplicate-detection audit found `skills/performance-expert/` restating React render guidance that already lives in `skills/react-component-performance/`:

- `useMemo` / `useCallback` / `React.memo` memoization patterns (with code samples)
- virtualization for long lists
- an "Unnecessary Re-renders" issue section

Both skills also claimed React performance triggers in `description`, so they competed for the same activation.

## Change

**`performance-expert` → backend / database / infrastructure + delivery layer.** It now owns API latency, query and index optimization, N+1, caching and invalidation, background jobs, server profiling, load testing, bundle and asset delivery, and CDN/edge. The React render content is removed from both `SKILL.md` and `references/full-guide.md`.

**Delegation contract.** `performance-expert` gained a `## Contract` block in the style of `skills/review-dispatch/SKILL.md`, with:

```text
Delegates To:

- `react-component-performance` for React render hotspots, re-render churn,
  memoization, and Profiler-driven component work.
- `workspace-performance-audit` when the target is a whole monorepo rather than
  one surface.
```

**Disjoint triggers.** Both skills got a `when_to_use` list and a one-line pointer to the other:

| Phrasing | Routes to |
|---|---|
| slow React component, re-renders, props churn, `memo`/`useMemo`/`useCallback`, virtualize a list, DevTools Profiler flamegraph | `react-component-performance` only |
| slow endpoint, p95 latency, slow query, missing index, N+1, caching, background job, connection pooling, bundle size, CDN/cache headers, cold starts, load testing | `performance-expert` only |

This matches the routing `skills/refactor-dispatch/SKILL.md` already describes (`perf` → `performance-expert` for backend, `react-component-performance` for a slow component), which was previously contradicted by the two overlapping descriptions.

**Provenance correction.** `react-component-performance` derives from an individual's repo (`Dimillian/Skills`), so by `.agents/memory/system/skill-standards.md` it is **adapted**, not vendored. Its README `Local modifications` line now records the trigger rewrite; the workflow, checklist, and optimization patterns stay upstream-identical, so this is not a silent divergence from a vendor sync target.

Neither skill is deleted.

## Verification

- `metadata.version` and `plugin.json` version bumped `1.0.0 → 1.1.0` on both skills
- `bun run catalog:generate` — 168 skills, 32 commands, 13 bundles, 181 plugins (counts unchanged)
- `bun run marketplace:generate` — bundle snapshots and `marketplace.json` regenerated so the CI "bundles are current" gate passes
- `bash scripts/validate-skill-sync.sh` — **0 errors** across all 168 skills; both edited skills report 0 warnings individually
- `bun run lint` — clean (only the pre-existing biome `recommended` deprecation info)

No local builds or tests were run (MacBook Pro rule); PR CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and skill metadata only; no application runtime or auth changes. Risk is limited to possible mis-routing until agents pick up the new descriptions.
> 
> **Overview**
> Splits overlapping **performance** skills so agents route to one skill instead of two competing for the same prompts.
> 
> **`performance-expert`** is reframed as **backend, database, infrastructure, and delivery** (API latency, queries/indexes, N+1, caching, jobs, profiling, bundles/CDN). React render guidance (`memo`/`useMemo`/re-render sections) is **removed** from `SKILL.md` and `references/full-guide.md`. A **`## Contract`** block adds explicit delegation to `react-component-performance` and `workspace-performance-audit`. **`when_to_use`** triggers and marketplace descriptions are updated; version **1.0.0 → 1.1.0**.
> 
> **`react-component-performance`** gets sharper **render-time** `description`/`when_to_use`, a pointer to `performance-expert` for non-UI work, and README notes that trigger rewrites are local adaptations (workflow/checklist unchanged). Same version bump.
> 
> Changes are mirrored under **`skills/`**, **`bundles/`**, and **`.claude-plugin/marketplace.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a65f894c821ea8a0fd9208b532ef6b7960c1764d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified the separation between React render performance and backend, database, infrastructure, and delivery performance.
  - Added guidance for API latency, query optimization, caching, background jobs, CDN delivery, and infrastructure profiling.
  - Expanded React performance guidance for rendering issues, props churn, memoization, virtualization, and interaction lag.
  - Updated performance skill versions and descriptions to reflect their specialized scopes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->