### PR TITLE
fix: make six colliding skill trigger pairs disjoint

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -73,7 +73,7 @@
     {
       "name": "accessibility",
       "source": "./skills/accessibility",
-      "description": "Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues."
+      "description": "Applies WCAG 2.1 AA to web UI work and fixes what fails — semantic HTML, ARIA roles and states, keyboard access, focus management, contrast ratios, and screen-reader verification — while a component is being built or reviewed. Use when the user names accessibility, a11y, WCAG, ARIA, keyboard navigation, focus traps, screen readers, or contrast. For a scored multi-dimension quality report, use `audit`; for design-token consistency, use `design-consistency-auditor`."
     },
     {
       "name": "advanced-evaluation",
@@ -138,7 +138,7 @@
     {
       "name": "audit",
       "source": "./skills/audit",
-      "description": "Run technical quality checks across accessibility, performance, theming, responsive design, and anti-patterns. Generates a scored report with P0-P3 severity ratings and actionable plan. Use when the user wants an accessibility check, performance audit, or technical quality review."
+      "description": "Sweeps implemented frontend code across five dimensions at once — accessibility, performance, theming, responsive design, and anti-patterns — scoring each 0-4 and emitting a single P0-P3 report with a prioritized plan. Reports only; it changes no code. Reach for it as the broad first pass when no one dimension has been named. For a deep WCAG conformance pass, use `accessibility`; for design-token drift, use `design-consistency-auditor`."
     },
     {
       "name": "aws-infrastructure",
@@ -243,7 +243,7 @@
     {
       "name": "cto-advisor",
       "source": "./skills/cto-advisor",
-      "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Includes tech debt analyzer, team scaling calculator, engineering metrics frameworks, technology evaluation tools, and ADR templates. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy."
+      "description": "Advises engineering leadership on direction — architecture decisions recorded as ADRs, technology and vendor evaluation, team scaling ratios, and DORA/engineering-metric targets. Reasons from org-level indicators and frameworks, never from a repository scan. Use when the user asks which technology to adopt, how to structure or scale the engineering team, whether to write an ADR, what DORA targets to hold, or mentions CTO, technical leadership, technology strategy, vendor selection, or engineering metrics. To inventory and rank the debt already sitting in a codebase, use `tech-debt`."
     },
     {
       "name": "de-slop",
@@ -278,7 +278,7 @@
     {
       "name": "design-consistency-auditor",
       "source": "./skills/design-consistency-auditor",
-      "description": "Audits and maintains design system consistency across frontend applications — color palettes, UI/UX patterns, component styling, and accessibility. Triggers when asked to audit design consistency, review component styling, check color palette usage, validate accessibility compliance, or identify design debt."
+      "description": "Hunts design-token drift across a frontend — hardcoded hex values where semantic tokens belong, arbitrary spacing outside the scale, one-off classes duplicating a design-system component, and patterns that diverge screen to screen. Measures against the project's own tokens and class conventions, discovered from the codebase first rather than assumed. Triggers on audit design consistency, review component styling, check color palette usage, find hardcoded colors, or identify design debt. For a scored multi-dimension quality report, use `audit`; for WCAG conformance, use `accessibility`."
     },
     {
       "name": "design-dispatch",
@@ -368,7 +368,7 @@
     {
       "name": "gh-address-comments",
       "source": "./skills/gh-address-comments",
-      "description": "Resolves GitHub PR review and issue comments by fetching threads, mapping them to code, proposing fixes, and drafting replies for approval. Triggers when the user asks to address PR comments, respond to review feedback, fix review threads, or resolve GitHub comment requests."
+      "description": "Implements the fixes a PR review asked for — maps each thread to the code it touches, edits that code, and drafts a reply per thread for approval before anything is posted. Starts from feedback that is already understood; producing the read-only digest is `pr-comments`."
     },
     {
       "name": "gh-fix-ci",
@@ -453,7 +453,7 @@
     {
       "name": "layout",
       "source": "./skills/layout",
-      "description": "Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak visual hierarchy. Use when the user mentions layout feeling off, spacing issues, visual hierarchy, crowded UI, alignment problems, or wanting better composition."
+      "description": "Reworks the structure underneath a UI — spacing scale, visual hierarchy, grid and composition, rhythm, and density — turning monotonous or crowded arrangements into intentional ones. Applies while the composition itself is still wrong, ahead of any detail pass. Use when the user says the layout feels off, every section looks the same, the UI is crowded or too sparse, hierarchy is unclear, or nothing guides the eye. For the last-mile pass on a finished feature, use `polish`."
     },
     {
       "name": "linter-formatter-init",
@@ -553,7 +553,7 @@
     {
       "name": "polish",
       "source": "./skills/polish",
-      "description": "Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before shipping. Use when the user mentions polish, finishing touches, pre-launch review, something looks off, or wants to go from good to great."
+      "description": "Runs the last pass over a functionally complete feature — pixel alignment, interaction and loading states, empty and error states, copy consistency, transition smoothness, and micro-details measured against the design system. Requires the work to be finished first; it refines, it never restructures. Use when the user asks for polish, finishing touches, a pre-launch review, or wants to go from good to great. To fix the underlying composition instead, use `layout`."
     },
     {
       "name": "postgres-ops",
@@ -563,7 +563,7 @@
     {
       "name": "pr-comments",
       "source": "./skills/pr-comments",
-      "description": "Fetch a pull request's review and discussion comments and return a read-only digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out — without editing code or drafting replies. Use when the user asks what are the comments on my PR, summarize the review feedback, what's blocking this PR, what do I still need to address, or runs /pr comments."
+      "description": "Reads a pull request's review threads and returns a digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out. Strictly read-only: no code edits, no replies, no thread resolution. Reach for it to triage feedback before deciding what to fix; implementing those fixes is `gh-address-comments`."
     },
     {
       "name": "prd-dispatch",
@@ -578,12 +578,12 @@
     {
       "name": "prd-task-creator",
       "source": "./skills/prd-task-creator",
-      "description": "Create a well-written PRD, task, or GitHub issue/sub-issue for a feature, bug, or enhancement. Use when planning work, writing GitHub issues, breaking down epics into sub-issues, or creating local task files. Common prompts: create a task, write a PRD, open a GitHub issue, create a sub-issue, plan this feature, write up this bug, break this down into issues, I want to add X, implement Y."
+      "description": "Files work into a tracker — turns a feature, bug, or finished PRD into GitHub issues, linked sub-issues, or local task files, slicing epics into thin vertical slices sized for one PR each and tagged AFK or HITL. Starts once the requirements are settled; authoring the PRD document itself is `prd-writer`."
     },
     {
       "name": "prd-writer",
       "source": "./skills/prd-writer",
-      "description": "Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on \"write a PRD for X\", \"let's plan X\", \"scope this out\", \"what should X do\", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews."
+      "description": "Authors the PRD document itself — problem, scope boundaries, EARS acceptance criteria, and verification plan — as one self-contained contract a planning agent consumes without re-elicitation. Ends at the written PRD; slicing it into tracked issues is `prd-task-creator`."
     },
     {
       "name": "production-audit",
@@ -678,7 +678,7 @@
     {
       "name": "release",
       "source": "./skills/release",
-      "description": "Cut a release from the trunk (default branch) and generate plain-English patch notes. Determines the next semantic version from commits since the last tag, previews the release plan, then on confirmation either creates an annotated tag + GitHub release (tag mode) or dispatches the repo's guarded release workflow (dispatch mode, for repos whose production deploy is gated behind a workflow_dispatch promote gate). Trunk-based — there is no develop/staging branch promotion. Use when the user asks to cut a release, ship a release, tag a release, promote to production, release to production, generate release notes or a changelog, or runs /release."
+      "description": "Cuts the release itself — derives the next semantic version from commits since the last tag, writes plain-English patch notes, previews the plan, then on confirmation creates an annotated tag plus GitHub release, or dispatches the repo's guarded release workflow where production sits behind a workflow_dispatch promote gate. Trunk-based; no develop or staging branch promotion. Assumes the trunk is already green — to open a release PR or wait on required checks first, use `release-pr-gates`."
     },
     {
       "name": "release-cleanup",
@@ -693,7 +693,7 @@
     {
       "name": "release-pr-gates",
       "source": "./skills/release-pr-gates",
-      "description": "Gate a release on the trunk — verify required CI checks are green, then cut a release (semver tag + GitHub release) or open a release PR into the default branch. Deployment to staging and production environments is driven by CI/CD pipelines and tags, not branch PRs. Use when the user asks to release, open a release PR, cut a tag, wait for GitHub checks to go green, or verify the trunk is ready to release."
+      "description": "Holds a release at the gate — opens or reuses a release PR into the trunk, runs local format, lint, and type-check, watches required GitHub checks through to green, and summarizes the failing run's root cause when they are not. Tags only after the gate passes. Reach for it during the pre-merge wait; for version derivation and plain-English patch notes, use `release`."
     },
     {
       "name": "review-dispatch",
@@ -828,7 +828,7 @@
     {
       "name": "tech-debt",
       "source": "./skills/tech-debt",
-      "description": "Inventory, quantify, and prioritize technical debt into a register ranked by interest (how often it hurts) over principal (effort to fix). Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked about tech debt, what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request."
+      "description": "Inventories a real codebase and ranks its technical debt into a register scored by interest (how often it hurts) over principal (effort to fix), every item anchored to a file-and-line or a metric. Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request. For org-level technology strategy and architecture direction, use `cto-advisor`."
     },
     {
       "name": "test-dispatch",

--- a/bundles/dev-loop/skills/prd-task-creator/SKILL.md
+++ b/bundles/dev-loop/skills/prd-task-creator/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: prd-task-creator
-description: 'Create a well-written PRD, task, or GitHub issue/sub-issue for a feature, bug, or enhancement. Use when planning work, writing GitHub issues, breaking down epics into sub-issues, or creating local task files. Common prompts: create a task, write a PRD, open a GitHub issue, create a sub-issue, plan this feature, write up this bug, break this down into issues, I want to add X, implement Y.'
+description: 'Files work into a tracker — turns a feature, bug, or finished PRD into GitHub issues, linked sub-issues, or local task files, slicing epics into thin vertical slices sized for one PR each and tagged AFK or HITL. Starts once the requirements are settled; authoring the PRD document itself is `prd-writer`.'
 disable-model-invocation: true
 allowed-tools: Bash(gh *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "tasks, prd, github, ears"
+when_to_use: "create a task, open a GitHub issue, create a sub-issue, break this epic down into issues, file this PRD as work items, write up this bug as an issue"
 ---
 
 # PRD Task Creator
@@ -162,6 +163,7 @@ Show the draft PRD. Wait for "looks good" or edits. Then create.
 
 ## Related
 
+- `prd-writer` — author the PRD document first when requirements are not settled yet; this skill files what that one wrote
 - `spec-first` — spec-driven development before writing code
 - `tdd` — red-green-refactor execution for tasks with clear behavior
 - `gh-fix-ci` — fix CI on existing PRs

--- a/bundles/dev-loop/skills/prd-task-creator/plugin.json
+++ b/bundles/dev-loop/skills/prd-task-creator/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prd-task-creator",
-  "version": "1.2.0",
-  "description": "Write PRDs and tasks as GitHub issues, sub-issues, or local planning files.",
+  "version": "1.2.1",
+  "description": "File settled work into a tracker as GitHub issues, sub-issues, or local task files.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/dev-loop/skills/prd-writer/SKILL.md
+++ b/bundles/dev-loop/skills/prd-writer/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: prd-writer
 disable-model-invocation: true
-description: Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews.
+description: Authors the PRD document itself — problem, scope boundaries, EARS acceptance criteria, and verification plan — as one self-contained contract a planning agent consumes without re-elicitation. Ends at the written PRD; slicing it into tracked issues is `prd-task-creator`.
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "prd, planning, requirements, spec, scoping, ears"
+when_to_use: "write a PRD for X, draft a PRD, scope this out, what should X do, formalize this feature, flesh out this issue before planning"
 ---
 
 # PRD Writer
@@ -305,3 +306,7 @@ through the issue detail view. This is pure friction — the URL is already know
 ```
 
 Note: no `created`, `updated`, `status`, `complexity`, or `blast radius` fields in the body — the tracker and project board track those natively. No file path — the PRD lives in the issue body itself.
+
+## Related
+
+- `prd-task-creator` — file the finished PRD into a tracker and slice it into sub-issues sized for one PR each.

--- a/bundles/dev-loop/skills/prd-writer/plugin.json
+++ b/bundles/dev-loop/skills/prd-writer/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prd-writer",
-  "version": "1.2.0",
-  "description": "Write one-shot PRDs for planning agents with tracker issue and quality gates.",
+  "version": "1.2.1",
+  "description": "Author the PRD document itself with scope, EARS acceptance criteria, and a verification plan.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/dev-workflow/skills/release-pr-gates/SKILL.md
+++ b/bundles/dev-workflow/skills/release-pr-gates/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release-pr-gates
-description: Gate a release on the trunk — verify required CI checks are green, then cut a release (semver tag + GitHub release) or open a release PR into the default branch. Deployment to staging and production environments is driven by CI/CD pipelines and tags, not branch PRs. Use when the user asks to release, open a release PR, cut a tag, wait for GitHub checks to go green, or verify the trunk is ready to release.
+description: Holds a release at the gate — opens or reuses a release PR into the trunk, runs local format, lint, and type-check, watches required GitHub checks through to green, and summarizes the failing run's root cause when they are not. Tags only after the gate passes. Reach for it during the pre-merge wait; for version derivation and plain-English patch notes, use `release`.
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "release, github, pull-request, ci-cd, quality-gates"
+when_to_use: "open a release PR, wait for the checks to go green, are the release checks passing, is the trunk ready to release, gate this release on CI, which required check is failing"
 allowed-tools: Bash(git *) Bash(gh *)
 disable-model-invocation: true
 ---
@@ -59,6 +60,8 @@ Confirmation Required:
 Delegates To:
 
 - `gh-fix-ci` when checks fail
+- `release` once the gate is green and the cut needs semver derivation and
+  plain-English patch notes — this skill owns the wait, that one owns the cut
 - `changelog-generator` when a release body needs commit summaries
 - `deploy` after release gates pass and provider deployment is needed
 

--- a/bundles/dev-workflow/skills/release-pr-gates/plugin.json
+++ b/bundles/dev-workflow/skills/release-pr-gates/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "release-pr-gates",
-  "version": "1.1.0",
-  "description": "Verify release CI gates, then tag the trunk or open a release PR.",
+  "version": "1.1.1",
+  "description": "Open a release PR and hold the release until required CI checks go green.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/dev-workflow/skills/release/SKILL.md
+++ b/bundles/dev-workflow/skills/release/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release
-description: Cut a release from the trunk (default branch) and generate plain-English patch notes. Determines the next semantic version from commits since the last tag, previews the release plan, then on confirmation either creates an annotated tag + GitHub release (tag mode) or dispatches the repo's guarded release workflow (dispatch mode, for repos whose production deploy is gated behind a workflow_dispatch promote gate). Trunk-based — there is no develop/staging branch promotion. Use when the user asks to cut a release, ship a release, tag a release, promote to production, release to production, generate release notes or a changelog, or runs /release.
+description: Cuts the release itself — derives the next semantic version from commits since the last tag, writes plain-English patch notes, previews the plan, then on confirmation creates an annotated tag plus GitHub release, or dispatches the repo's guarded release workflow where production sits behind a workflow_dispatch promote gate. Trunk-based; no develop or staging branch promotion. Assumes the trunk is already green — to open a release PR or wait on required checks first, use `release-pr-gates`.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   tags: "git, github, release, tag, semver, changelog, patch-notes, trunk-based, ci-cd"
+when_to_use: "cut a release, ship a release, tag a release, promote to production, release to production, generate release notes, generate a changelog, /release"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
 ---
@@ -61,7 +62,8 @@ Confirmation Required:
 Delegates To:
 
 - `changelog-generator` when a richer or differently-formatted changelog is wanted
-- `release-pr-gates` to wait on required CI checks before cutting the release
+- `release-pr-gates` to open the release PR and wait on required CI checks before
+  this skill cuts anything — that skill owns the pre-merge gate, this one owns the cut
 - `gh-fix-ci` when the trunk's required checks are failing and the user wants them fixed
 - `release-cleanup` to prune merged feature branches and stale worktrees afterward
 - `deploy` / `deployment-composer` to ship the freshly cut tag to an environment

--- a/bundles/dev-workflow/skills/release/plugin.json
+++ b/bundles/dev-workflow/skills/release/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cut a trunk release with semantic versioning, patch notes, tags, and GitHub release.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/tech-debt/SKILL.md
+++ b/bundles/dev-workflow/skills/tech-debt/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: tech-debt
-description: Inventory, quantify, and prioritize technical debt into a register ranked by interest (how often it hurts) over principal (effort to fix). Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked about tech debt, what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request.
+description: Inventories a real codebase and ranks its technical debt into a register scored by interest (how often it hurts) over principal (effort to fix), every item anchored to a file-and-line or a metric. Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request. For org-level technology strategy and architecture direction, use `cto-advisor`.
 user-invocable: true
 argument-hint: "[directory, or 'issues' to file]"
 compatibility: Requires git; gh to file issues; optional bun/npm audit for dependency debt.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "tech-debt, refactor, prioritization, code-quality, maintenance"
   author: Ship Shit Dev
-when_to_use: "tech debt, technical debt, what to pay down, debt register, where is the codebase rotting, prioritize refactoring, debt backlog, /refactor debt"
+when_to_use: "what to pay down, debt register, where is the codebase rotting, scan this repo for tech debt, prioritize refactoring, debt backlog, /refactor debt"
 ---
 
 # Tech Debt
@@ -48,6 +48,8 @@ Delegates To:
 - `refactor-code` / `de-slop` / `stack-modernization` to actually pay down an item.
 - `roadmap-analyzer` when debt competes with features — it ranks both against revenue.
 - `roadmap-to-milestones` to schedule a debt-paydown milestone.
+- `cto-advisor` when the question is how much to invest overall, or which architecture
+  or technology to move toward — direction rather than inventory.
 
 ## Step 1 — Inventory debt from evidence
 

--- a/bundles/dev-workflow/skills/tech-debt/plugin.json
+++ b/bundles/dev-workflow/skills/tech-debt/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tech-debt",
-  "version": "1.0.0",
-  "description": "Inventory and prioritize technical debt into a register ranked by interest over principal.",
+  "version": "1.0.1",
+  "description": "Inventory a codebase and rank its technical debt into a register scored interest over principal.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/frontend/skills/accessibility/SKILL.md
+++ b/bundles/frontend/skills/accessibility/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: accessibility
-description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues.
+description: Applies WCAG 2.1 AA to web UI work and fixes what fails — semantic HTML, ARIA roles and states, keyboard access, focus management, contrast ratios, and screen-reader verification — while a component is being built or reviewed. Use when the user names accessibility, a11y, WCAG, ARIA, keyboard navigation, focus traps, screen readers, or contrast. For a scored multi-dimension quality report, use `audit`; for design-token consistency, use `design-consistency-auditor`.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "accessibility, a11y, wcag, aria, keyboard-navigation, screen-reader, inclusive-design"
 ---
 
@@ -37,3 +37,8 @@ Use when you're:
 ## References
 
 - [Full guide: WCAG patterns, component examples, and testing checklists](references/full-guide.md)
+
+## Related
+
+- `audit` — a scored 0-4 sweep across accessibility, performance, theming, responsive design, and anti-patterns when no single dimension is named.
+- `design-consistency-auditor` — token drift, hardcoded colors, and design-system divergence.

--- a/bundles/frontend/skills/accessibility/plugin.json
+++ b/bundles/frontend/skills/accessibility/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "accessibility",
-  "version": "1.0.0",
-  "description": "Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all pr",
+  "version": "1.0.1",
+  "description": "Apply WCAG 2.1 AA to web UI work and fix what fails, from ARIA to keyboard access.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/frontend/skills/audit/README.md
+++ b/bundles/frontend/skills/audit/README.md
@@ -14,6 +14,6 @@ Derived from **[pbakaus/impeccable](https://github.com/pbakaus/impeccable)** (Ap
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** removed the hard dependency on the parent `/impeccable` orchestrator skill (not part of this marketplace) and inlined a self-contained Context Gathering summary plus the AI-slop DON'T list, so the skill runs standalone.
+**Local modifications:** removed the hard dependency on the parent `/impeccable` orchestrator skill (not part of this marketplace) and inlined a self-contained Context Gathering summary plus the AI-slop DON'T list, so the skill runs standalone. Rewrote the description to name this skill as the broad multi-dimension sweep and added a Related section routing deep passes to `accessibility` and `design-consistency-auditor`, so the three do not compete on the same trigger phrasing.
 
 **Checking for upstream changes:** when *Upstream latest* is ahead of *Forked at*, diff [`skill/reference/audit.md`](https://github.com/pbakaus/impeccable/blob/main/skill/reference/audit.md) against tag `skill-v2.1.1`, port anything worth bringing home, then bump `metadata.upstream_version` and `metadata.last_synced` in `SKILL.md` and this table.

--- a/bundles/frontend/skills/audit/SKILL.md
+++ b/bundles/frontend/skills/audit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: audit
-description: Run technical quality checks across accessibility, performance, theming, responsive design, and anti-patterns. Generates a scored report with P0-P3 severity ratings and actionable plan. Use when the user wants an accessibility check, performance audit, or technical quality review.
+description: Sweeps implemented frontend code across five dimensions at once — accessibility, performance, theming, responsive design, and anti-patterns — scoring each 0-4 and emitting a single P0-P3 report with a prioritized plan. Reports only; it changes no code. Reach for it as the broad first pass when no one dimension has been named. For a deep WCAG conformance pass, use `accessibility`; for design-token drift, use `design-consistency-auditor`.
 user-invocable: true
 argument-hint: "[area (feature, page, component...)]"
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
   tags: "audit, quality, accessibility"
   source: https://github.com/pbakaus/impeccable/blob/main/skill/reference/audit.md
   upstream_version: skill-v2.1.1
@@ -160,3 +160,8 @@ Limit P3 findings to the top five unless the user asks for a complete backlog.
 - Skip positive findings (celebrate what works)
 - Forget to prioritize (everything can't be P0)
 - Report false positives without verification
+
+## Related
+
+- `accessibility` — go deeper than dimension 1 when the request is WCAG conformance, ARIA, keyboard access, or screen readers.
+- `design-consistency-auditor` — go deeper than dimension 3 when the request is token drift, hardcoded colors, or design-system divergence.

--- a/bundles/frontend/skills/audit/plugin.json
+++ b/bundles/frontend/skills/audit/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "audit",
-  "version": "2.1.1",
-  "description": "Run technical quality checks across accessibility, performance, theming, responsive design, and anti",
+  "version": "2.1.2",
+  "description": "Sweep frontend code across five technical dimensions and score it into one P0-P3 report.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/frontend/skills/design-consistency-auditor/SKILL.md
+++ b/bundles/frontend/skills/design-consistency-auditor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: design-consistency-auditor
-description: Audits and maintains design system consistency across frontend applications — color palettes, UI/UX patterns, component styling, and accessibility. Triggers when asked to audit design consistency, review component styling, check color palette usage, validate accessibility compliance, or identify design debt.
+description: Hunts design-token drift across a frontend — hardcoded hex values where semantic tokens belong, arbitrary spacing outside the scale, one-off classes duplicating a design-system component, and patterns that diverge screen to screen. Measures against the project's own tokens and class conventions, discovered from the codebase first rather than assumed. Triggers on audit design consistency, review component styling, check color palette usage, find hardcoded colors, or identify design debt. For a scored multi-dimension quality report, use `audit`; for WCAG conformance, use `accessibility`.
 metadata:
-  version: "1.0.0"
-  tags: "design, ux, ui, consistency, audit, tailwind, accessibility"
+  version: "1.0.1"
+  tags: "design, ux, ui, consistency, design-tokens, design-debt, tailwind"
 ---
 
 # Design Consistency Auditor
@@ -12,22 +12,22 @@ Before auditing, discover the project's frontend structure from documentation.
 
 Ensures:
 
-- Color palettes are used consistently
-- UI/UX patterns follow best practices
-- Components maintain visual harmony
-- Accessibility standards are met
-- Design system is properly applied
+- Color palettes are used consistently through semantic tokens
+- Spacing stays on the project's scale
+- Components maintain visual harmony across screens
+- The design system is applied instead of duplicated
 - No design debt accumulates
 
 ## When to Use
 
-- Auditing design consistency across apps
-- Reviewing color palette usage
-- Checking UI/UX patterns
-- Validating component styling
-- Ensuring accessibility compliance
-- Identifying design inconsistencies
-- Reviewing new features for design standards
+- Auditing design-token consistency across apps
+- Reviewing color palette usage and hunting hardcoded hex values
+- Checking UI/UX patterns for screen-to-screen divergence
+- Spotting one-off classes that duplicate a design-system component
+- Reviewing new features against the established design standards
+
+Accessibility conformance is a separate pass — use `accessibility` for WCAG, ARIA,
+keyboard access, and contrast.
 
 ## Quick Reference
 
@@ -87,3 +87,8 @@ Push for distinctive, branded designs with personality.
 ---
 
 **For detailed checklists, examples, reporting templates, and audit commands, see:** `references/full-guide.md`
+
+## Related
+
+- `audit` — a scored 0-4 sweep across accessibility, performance, theming, responsive design, and anti-patterns when no single dimension is named.
+- `accessibility` — WCAG 2.1 AA conformance, ARIA, keyboard access, and screen-reader verification.

--- a/bundles/frontend/skills/design-consistency-auditor/plugin.json
+++ b/bundles/frontend/skills/design-consistency-auditor/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-consistency-auditor",
-  "version": "1.0.0",
-  "description": "Audit and maintain design system consistency, UX/UI patterns, color palettes, and design best practi",
+  "version": "1.0.1",
+  "description": "Hunt design-token drift, hardcoded colors, and design-system divergence across a frontend.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/frontend/skills/layout/README.md
+++ b/bundles/frontend/skills/layout/README.md
@@ -14,6 +14,6 @@ Derived from **[pbakaus/impeccable](https://github.com/pbakaus/impeccable)** (Ap
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** vendored as a standalone marketplace plugin. No behavioral changes from upstream beyond provenance metadata; this skill never invoked `/impeccable`.
+**Local modifications:** adapted as a standalone marketplace plugin; this skill never invoked `/impeccable`. Rewrote the description to scope this skill to structural composition work (spacing scale, hierarchy, grid, rhythm, density) ahead of any detail pass, and added a Related section routing the last-mile pass to `polish`, so the two do not compete on the same trigger phrasing.
 
 **Checking for upstream changes:** when *Upstream latest* is ahead of *Forked at*, diff [`skill/reference/layout.md`](https://github.com/pbakaus/impeccable/blob/main/skill/reference/layout.md) against tag `skill-v2.1.1`, port anything worth bringing home, then bump `metadata.upstream_version` and `metadata.last_synced` in `SKILL.md` and this table.

--- a/bundles/frontend/skills/layout/SKILL.md
+++ b/bundles/frontend/skills/layout/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: layout
-description: Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak visual hierarchy. Use when the user mentions layout feeling off, spacing issues, visual hierarchy, crowded UI, alignment problems, or wanting better composition.
+description: Reworks the structure underneath a UI — spacing scale, visual hierarchy, grid and composition, rhythm, and density — turning monotonous or crowded arrangements into intentional ones. Applies while the composition itself is still wrong, ahead of any detail pass. Use when the user says the layout feels off, every section looks the same, the UI is crowded or too sparse, hierarchy is unclear, or nothing guides the eye. For the last-mile pass on a finished feature, use `polish`.
 user-invocable: true
 argument-hint: "[target]"
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
   tags: "layout, ux, frontend"
   source: https://github.com/pbakaus/impeccable/blob/main/skill/reference/layout.md
   upstream_version: skill-v2.1.1
@@ -121,3 +121,7 @@ Create a systematic plan:
 - **Breathing room**: Does the layout feel comfortable, not cramped or wasteful?
 - **Consistency**: Is the spacing system applied uniformly?
 - **Responsiveness**: Does the layout adapt gracefully across screen sizes?
+
+## Related
+
+- `polish` — the last-mile pass once the composition is right and the feature is functionally complete.

--- a/bundles/frontend/skills/layout/plugin.json
+++ b/bundles/frontend/skills/layout/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "layout",
-  "version": "2.1.1",
-  "description": "Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak v",
+  "version": "2.1.2",
+  "description": "Rework spacing scale, hierarchy, grid, rhythm, and density into an intentional composition.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/frontend/skills/polish/README.md
+++ b/bundles/frontend/skills/polish/README.md
@@ -14,6 +14,6 @@ Derived from **[pbakaus/impeccable](https://github.com/pbakaus/impeccable)** (Ap
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** vendored as a standalone marketplace plugin. No behavioral changes from upstream beyond provenance metadata; this skill never invoked `/impeccable`.
+**Local modifications:** adapted as a standalone marketplace plugin; this skill never invoked `/impeccable`. Rewrote the description to require a functionally complete feature and scope this skill to refinement rather than restructuring, and added a Related section routing composition problems to `layout`, so the two do not compete on the same trigger phrasing.
 
 **Checking for upstream changes:** when *Upstream latest* is ahead of *Forked at*, diff [`skill/reference/polish.md`](https://github.com/pbakaus/impeccable/blob/main/skill/reference/polish.md) against tag `skill-v2.1.1`, port anything worth bringing home, then bump `metadata.upstream_version` and `metadata.last_synced` in `SKILL.md` and this table.

--- a/bundles/frontend/skills/polish/SKILL.md
+++ b/bundles/frontend/skills/polish/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: polish
-description: Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before shipping. Use when the user mentions polish, finishing touches, pre-launch review, something looks off, or wants to go from good to great.
+description: Runs the last pass over a functionally complete feature — pixel alignment, interaction and loading states, empty and error states, copy consistency, transition smoothness, and micro-details measured against the design system. Requires the work to be finished first; it refines, it never restructures. Use when the user asks for polish, finishing touches, a pre-launch review, or wants to go from good to great. To fix the underlying composition instead, use `layout`.
 user-invocable: true
 argument-hint: "[target]"
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
   tags: "polish, ui, quality"
   source: https://github.com/pbakaus/impeccable/blob/main/skill/reference/polish.md
   upstream_version: skill-v2.1.1
@@ -225,3 +225,7 @@ After polishing, ensure code quality:
 - **Verify DRYness**: Look for duplication introduced during polishing and consolidate.
 
 Remember: You have impeccable attention to detail and exquisite taste. Polish until it feels effortless, looks intentional, and works flawlessly. Sweat the details - they matter.
+
+## Related
+
+- `layout` — fix the underlying spacing scale, hierarchy, and grid first when the composition itself is what feels wrong; polish refines, it does not restructure.

--- a/bundles/frontend/skills/polish/plugin.json
+++ b/bundles/frontend/skills/polish/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polish",
-  "version": "2.1.1",
-  "description": "Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before",
+  "version": "2.1.2",
+  "description": "Run the last detail pass over a functionally complete feature before it ships.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/gh-address-comments/SKILL.md
+++ b/bundles/github/skills/gh-address-comments/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: gh-address-comments
 description: >-
-  Resolves GitHub PR review and issue comments by fetching threads, mapping them
-  to code, proposing fixes, and drafting replies for approval. Triggers when the
-  user asks to address PR comments, respond to review feedback, fix review
-  threads, or resolve GitHub comment requests.
+  Implements the fixes a PR review asked for — maps each thread to the code it
+  touches, edits that code, and drafts a reply per thread for approval before
+  anything is posted. Starts from feedback that is already understood; producing
+  the read-only digest is `pr-comments`.
 disable-model-invocation: true
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, pull-requests, review-comments"
+when_to_use: "address the PR comments, fix the review feedback, implement the review suggestions, resolve these review threads, reply to the reviewer"
 ---
 
 # GH Address Comments
@@ -46,6 +47,8 @@ Confirmation Required:
 
 Delegates To:
 
+- `pr-comments` first when the threads have not been triaged yet — it produces the
+  read-only digest this skill then works through
 - `code-review` to validate proposed fixes
 - `qa-reviewer` before final response
 - `gh-fix-ci` if fixes cause or reveal CI failures

--- a/bundles/github/skills/gh-address-comments/plugin.json
+++ b/bundles/github/skills/gh-address-comments/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh-address-comments",
-  "version": "1.0.0",
-  "description": "Help address review or issue comments on the open GitHub PR for the current branch using gh CLI; ver",
+  "version": "1.0.1",
+  "description": "Implement the fixes a PR review asked for and draft a reply per thread for approval.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/pr-comments/SKILL.md
+++ b/bundles/github/skills/pr-comments/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: pr-comments
-description: "Fetch a pull request's review and discussion comments and return a read-only digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out — without editing code or drafting replies. Use when the user asks what are the comments on my PR, summarize the review feedback, what's blocking this PR, what do I still need to address, or runs /pr comments."
+description: "Reads a pull request's review threads and returns a digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out. Strictly read-only: no code edits, no replies, no thread resolution. Reach for it to triage feedback before deciding what to fix; implementing those fixes is `gh-address-comments`."
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, pull-requests, code-review, comments, triage, digest"
+when_to_use: "what are the comments on my PR, summarize the review feedback, what's blocking this PR, what do I still need to address, triage the review comments, /pr comments"
 allowed-tools: Bash(gh *) Bash(git *)
 disable-model-invocation: true
 ---

--- a/bundles/github/skills/pr-comments/plugin.json
+++ b/bundles/github/skills/pr-comments/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-comments",
-  "version": "1.0.0",
-  "description": "Fetch a PR's review comments as a read-only, severity-tagged, priority-ordered digest.",
+  "version": "1.0.1",
+  "description": "Read a PR's review threads into a severity-tagged, priority-ordered, read-only digest.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/release-pr-gates/SKILL.md
+++ b/bundles/github/skills/release-pr-gates/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release-pr-gates
-description: Gate a release on the trunk — verify required CI checks are green, then cut a release (semver tag + GitHub release) or open a release PR into the default branch. Deployment to staging and production environments is driven by CI/CD pipelines and tags, not branch PRs. Use when the user asks to release, open a release PR, cut a tag, wait for GitHub checks to go green, or verify the trunk is ready to release.
+description: Holds a release at the gate — opens or reuses a release PR into the trunk, runs local format, lint, and type-check, watches required GitHub checks through to green, and summarizes the failing run's root cause when they are not. Tags only after the gate passes. Reach for it during the pre-merge wait; for version derivation and plain-English patch notes, use `release`.
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "release, github, pull-request, ci-cd, quality-gates"
+when_to_use: "open a release PR, wait for the checks to go green, are the release checks passing, is the trunk ready to release, gate this release on CI, which required check is failing"
 allowed-tools: Bash(git *) Bash(gh *)
 disable-model-invocation: true
 ---
@@ -59,6 +60,8 @@ Confirmation Required:
 Delegates To:
 
 - `gh-fix-ci` when checks fail
+- `release` once the gate is green and the cut needs semver derivation and
+  plain-English patch notes — this skill owns the wait, that one owns the cut
 - `changelog-generator` when a release body needs commit summaries
 - `deploy` after release gates pass and provider deployment is needed
 

--- a/bundles/github/skills/release-pr-gates/plugin.json
+++ b/bundles/github/skills/release-pr-gates/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "release-pr-gates",
-  "version": "1.1.0",
-  "description": "Verify release CI gates, then tag the trunk or open a release PR.",
+  "version": "1.1.1",
+  "description": "Open a release PR and hold the release until required CI checks go green.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/release/SKILL.md
+++ b/bundles/github/skills/release/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release
-description: Cut a release from the trunk (default branch) and generate plain-English patch notes. Determines the next semantic version from commits since the last tag, previews the release plan, then on confirmation either creates an annotated tag + GitHub release (tag mode) or dispatches the repo's guarded release workflow (dispatch mode, for repos whose production deploy is gated behind a workflow_dispatch promote gate). Trunk-based — there is no develop/staging branch promotion. Use when the user asks to cut a release, ship a release, tag a release, promote to production, release to production, generate release notes or a changelog, or runs /release.
+description: Cuts the release itself — derives the next semantic version from commits since the last tag, writes plain-English patch notes, previews the plan, then on confirmation creates an annotated tag plus GitHub release, or dispatches the repo's guarded release workflow where production sits behind a workflow_dispatch promote gate. Trunk-based; no develop or staging branch promotion. Assumes the trunk is already green — to open a release PR or wait on required checks first, use `release-pr-gates`.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   tags: "git, github, release, tag, semver, changelog, patch-notes, trunk-based, ci-cd"
+when_to_use: "cut a release, ship a release, tag a release, promote to production, release to production, generate release notes, generate a changelog, /release"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
 ---
@@ -61,7 +62,8 @@ Confirmation Required:
 Delegates To:
 
 - `changelog-generator` when a richer or differently-formatted changelog is wanted
-- `release-pr-gates` to wait on required CI checks before cutting the release
+- `release-pr-gates` to open the release PR and wait on required CI checks before
+  this skill cuts anything — that skill owns the pre-merge gate, this one owns the cut
 - `gh-fix-ci` when the trunk's required checks are failing and the user wants them fixed
 - `release-cleanup` to prune merged feature branches and stale worktrees afterward
 - `deploy` / `deployment-composer` to ship the freshly cut tag to an environment

--- a/bundles/github/skills/release/plugin.json
+++ b/bundles/github/skills/release/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cut a trunk release with semantic versioning, patch notes, tags, and GitHub release.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/planning/skills/cto-advisor/SKILL.md
+++ b/bundles/planning/skills/cto-advisor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: cto-advisor
-description: Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Includes tech debt analyzer, team scaling calculator, engineering metrics frameworks, technology evaluation tools, and ADR templates. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.
+description: Advises engineering leadership on direction — architecture decisions recorded as ADRs, technology and vendor evaluation, team scaling ratios, and DORA/engineering-metric targets. Reasons from org-level indicators and frameworks, never from a repository scan. Use when the user asks which technology to adopt, how to structure or scale the engineering team, whether to write an ADR, what DORA targets to hold, or mentions CTO, technical leadership, technology strategy, vendor selection, or engineering metrics. To inventory and rank the debt already sitting in a codebase, use `tech-debt`.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "leadership, engineering, architecture, strategy, metrics"
 ---
 
@@ -12,7 +12,8 @@ metadata:
 ## When This Activates
 
 - User mentions CTO, technical leadership, or engineering leadership
-- User asks about tech debt or technical debt
+- User asks how much of the engineering budget to spend paying debt down —
+  the portfolio-level call, not the codebase inventory (`tech-debt` owns that)
 - User needs team scaling or hiring plans
 - User wants architecture decisions or ADRs
 - User asks about engineering metrics or DORA metrics
@@ -98,6 +99,10 @@ See `references/engineering_metrics.md`
 | `performance-expert` | Optimize system performance |
 | `security-expert` | Security architecture |
 | `testing-expert` | Testing strategy |
+
+## Related
+
+- `tech-debt` — scan a real codebase and rank its debt into a register; this skill sets the investment level, that one finds the items.
 
 ---
 

--- a/bundles/planning/skills/cto-advisor/plugin.json
+++ b/bundles/planning/skills/cto-advisor/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cto-advisor",
-  "version": "1.0.0",
-  "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy",
+  "version": "1.0.1",
+  "description": "Advise engineering leadership on architecture direction, ADRs, team scaling, and DORA metrics.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/planning/skills/prd-task-creator/SKILL.md
+++ b/bundles/planning/skills/prd-task-creator/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: prd-task-creator
-description: 'Create a well-written PRD, task, or GitHub issue/sub-issue for a feature, bug, or enhancement. Use when planning work, writing GitHub issues, breaking down epics into sub-issues, or creating local task files. Common prompts: create a task, write a PRD, open a GitHub issue, create a sub-issue, plan this feature, write up this bug, break this down into issues, I want to add X, implement Y.'
+description: 'Files work into a tracker — turns a feature, bug, or finished PRD into GitHub issues, linked sub-issues, or local task files, slicing epics into thin vertical slices sized for one PR each and tagged AFK or HITL. Starts once the requirements are settled; authoring the PRD document itself is `prd-writer`.'
 disable-model-invocation: true
 allowed-tools: Bash(gh *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "tasks, prd, github, ears"
+when_to_use: "create a task, open a GitHub issue, create a sub-issue, break this epic down into issues, file this PRD as work items, write up this bug as an issue"
 ---
 
 # PRD Task Creator
@@ -162,6 +163,7 @@ Show the draft PRD. Wait for "looks good" or edits. Then create.
 
 ## Related
 
+- `prd-writer` — author the PRD document first when requirements are not settled yet; this skill files what that one wrote
 - `spec-first` — spec-driven development before writing code
 - `tdd` — red-green-refactor execution for tasks with clear behavior
 - `gh-fix-ci` — fix CI on existing PRs

--- a/bundles/planning/skills/prd-task-creator/plugin.json
+++ b/bundles/planning/skills/prd-task-creator/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prd-task-creator",
-  "version": "1.2.0",
-  "description": "Write PRDs and tasks as GitHub issues, sub-issues, or local planning files.",
+  "version": "1.2.1",
+  "description": "File settled work into a tracker as GitHub issues, sub-issues, or local task files.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/planning/skills/prd-writer/SKILL.md
+++ b/bundles/planning/skills/prd-writer/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: prd-writer
 disable-model-invocation: true
-description: Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews.
+description: Authors the PRD document itself — problem, scope boundaries, EARS acceptance criteria, and verification plan — as one self-contained contract a planning agent consumes without re-elicitation. Ends at the written PRD; slicing it into tracked issues is `prd-task-creator`.
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "prd, planning, requirements, spec, scoping, ears"
+when_to_use: "write a PRD for X, draft a PRD, scope this out, what should X do, formalize this feature, flesh out this issue before planning"
 ---
 
 # PRD Writer
@@ -305,3 +306,7 @@ through the issue detail view. This is pure friction — the URL is already know
 ```
 
 Note: no `created`, `updated`, `status`, `complexity`, or `blast radius` fields in the body — the tracker and project board track those natively. No file path — the PRD lives in the issue body itself.
+
+## Related
+
+- `prd-task-creator` — file the finished PRD into a tracker and slice it into sub-issues sized for one PR each.

--- a/bundles/planning/skills/prd-writer/plugin.json
+++ b/bundles/planning/skills/prd-writer/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prd-writer",
-  "version": "1.2.0",
-  "description": "Write one-shot PRDs for planning agents with tracker issue and quality gates.",
+  "version": "1.2.1",
+  "description": "Author the PRD document itself with scope, EARS acceptance criteria, and a verification plan.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/accessibility/SKILL.md
+++ b/skills/accessibility/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: accessibility
-description: Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all projects are usable by everyone. Use when creating or reviewing UI components, adding keyboard navigation, checking color contrast, testing with screen readers, or auditing pages for accessibility issues.
+description: Applies WCAG 2.1 AA to web UI work and fixes what fails — semantic HTML, ARIA roles and states, keyboard access, focus management, contrast ratios, and screen-reader verification — while a component is being built or reviewed. Use when the user names accessibility, a11y, WCAG, ARIA, keyboard navigation, focus traps, screen readers, or contrast. For a scored multi-dimension quality report, use `audit`; for design-token consistency, use `design-consistency-auditor`.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "accessibility, a11y, wcag, aria, keyboard-navigation, screen-reader, inclusive-design"
 ---
 
@@ -37,3 +37,8 @@ Use when you're:
 ## References
 
 - [Full guide: WCAG patterns, component examples, and testing checklists](references/full-guide.md)
+
+## Related
+
+- `audit` — a scored 0-4 sweep across accessibility, performance, theming, responsive design, and anti-patterns when no single dimension is named.
+- `design-consistency-auditor` — token drift, hardcoded colors, and design-system divergence.

--- a/skills/accessibility/plugin.json
+++ b/skills/accessibility/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "accessibility",
-  "version": "1.0.0",
-  "description": "Expert in web accessibility (WCAG 2.1 AA compliance) for React/Next.js applications, ensuring all pr",
+  "version": "1.0.1",
+  "description": "Apply WCAG 2.1 AA to web UI work and fix what fails, from ARIA to keyboard access.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/audit/README.md
+++ b/skills/audit/README.md
@@ -14,6 +14,6 @@ Derived from **[pbakaus/impeccable](https://github.com/pbakaus/impeccable)** (Ap
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** removed the hard dependency on the parent `/impeccable` orchestrator skill (not part of this marketplace) and inlined a self-contained Context Gathering summary plus the AI-slop DON'T list, so the skill runs standalone.
+**Local modifications:** removed the hard dependency on the parent `/impeccable` orchestrator skill (not part of this marketplace) and inlined a self-contained Context Gathering summary plus the AI-slop DON'T list, so the skill runs standalone. Rewrote the description to name this skill as the broad multi-dimension sweep and added a Related section routing deep passes to `accessibility` and `design-consistency-auditor`, so the three do not compete on the same trigger phrasing.
 
 **Checking for upstream changes:** when *Upstream latest* is ahead of *Forked at*, diff [`skill/reference/audit.md`](https://github.com/pbakaus/impeccable/blob/main/skill/reference/audit.md) against tag `skill-v2.1.1`, port anything worth bringing home, then bump `metadata.upstream_version` and `metadata.last_synced` in `SKILL.md` and this table.

--- a/skills/audit/SKILL.md
+++ b/skills/audit/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: audit
-description: Run technical quality checks across accessibility, performance, theming, responsive design, and anti-patterns. Generates a scored report with P0-P3 severity ratings and actionable plan. Use when the user wants an accessibility check, performance audit, or technical quality review.
+description: Sweeps implemented frontend code across five dimensions at once — accessibility, performance, theming, responsive design, and anti-patterns — scoring each 0-4 and emitting a single P0-P3 report with a prioritized plan. Reports only; it changes no code. Reach for it as the broad first pass when no one dimension has been named. For a deep WCAG conformance pass, use `accessibility`; for design-token drift, use `design-consistency-auditor`.
 user-invocable: true
 argument-hint: "[area (feature, page, component...)]"
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
   tags: "audit, quality, accessibility"
   source: https://github.com/pbakaus/impeccable/blob/main/skill/reference/audit.md
   upstream_version: skill-v2.1.1
@@ -160,3 +160,8 @@ Limit P3 findings to the top five unless the user asks for a complete backlog.
 - Skip positive findings (celebrate what works)
 - Forget to prioritize (everything can't be P0)
 - Report false positives without verification
+
+## Related
+
+- `accessibility` — go deeper than dimension 1 when the request is WCAG conformance, ARIA, keyboard access, or screen readers.
+- `design-consistency-auditor` — go deeper than dimension 3 when the request is token drift, hardcoded colors, or design-system divergence.

--- a/skills/audit/plugin.json
+++ b/skills/audit/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "audit",
-  "version": "2.1.1",
-  "description": "Run technical quality checks across accessibility, performance, theming, responsive design, and anti",
+  "version": "2.1.2",
+  "description": "Sweep frontend code across five technical dimensions and score it into one P0-P3 report.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/cto-advisor/SKILL.md
+++ b/skills/cto-advisor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: cto-advisor
-description: Technical leadership guidance for engineering teams, architecture decisions, and technology strategy. Includes tech debt analyzer, team scaling calculator, engineering metrics frameworks, technology evaluation tools, and ADR templates. Use when assessing technical debt, scaling engineering teams, evaluating technologies, making architecture decisions, establishing engineering metrics, or when user mentions CTO, tech debt, technical debt, team scaling, architecture decisions, technology evaluation, engineering metrics, DORA metrics, or technology strategy.
+description: Advises engineering leadership on direction — architecture decisions recorded as ADRs, technology and vendor evaluation, team scaling ratios, and DORA/engineering-metric targets. Reasons from org-level indicators and frameworks, never from a repository scan. Use when the user asks which technology to adopt, how to structure or scale the engineering team, whether to write an ADR, what DORA targets to hold, or mentions CTO, technical leadership, technology strategy, vendor selection, or engineering metrics. To inventory and rank the debt already sitting in a codebase, use `tech-debt`.
 license: MIT
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "leadership, engineering, architecture, strategy, metrics"
 ---
 
@@ -12,7 +12,8 @@ metadata:
 ## When This Activates
 
 - User mentions CTO, technical leadership, or engineering leadership
-- User asks about tech debt or technical debt
+- User asks how much of the engineering budget to spend paying debt down —
+  the portfolio-level call, not the codebase inventory (`tech-debt` owns that)
 - User needs team scaling or hiring plans
 - User wants architecture decisions or ADRs
 - User asks about engineering metrics or DORA metrics
@@ -98,6 +99,10 @@ See `references/engineering_metrics.md`
 | `performance-expert` | Optimize system performance |
 | `security-expert` | Security architecture |
 | `testing-expert` | Testing strategy |
+
+## Related
+
+- `tech-debt` — scan a real codebase and rank its debt into a register; this skill sets the investment level, that one finds the items.
 
 ---
 

--- a/skills/cto-advisor/plugin.json
+++ b/skills/cto-advisor/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cto-advisor",
-  "version": "1.0.0",
-  "description": "Technical leadership guidance for engineering teams, architecture decisions, and technology strategy",
+  "version": "1.0.1",
+  "description": "Advise engineering leadership on architecture direction, ADRs, team scaling, and DORA metrics.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/design-consistency-auditor/SKILL.md
+++ b/skills/design-consistency-auditor/SKILL.md
@@ -1,9 +1,9 @@
 ---
 name: design-consistency-auditor
-description: Audits and maintains design system consistency across frontend applications — color palettes, UI/UX patterns, component styling, and accessibility. Triggers when asked to audit design consistency, review component styling, check color palette usage, validate accessibility compliance, or identify design debt.
+description: Hunts design-token drift across a frontend — hardcoded hex values where semantic tokens belong, arbitrary spacing outside the scale, one-off classes duplicating a design-system component, and patterns that diverge screen to screen. Measures against the project's own tokens and class conventions, discovered from the codebase first rather than assumed. Triggers on audit design consistency, review component styling, check color palette usage, find hardcoded colors, or identify design debt. For a scored multi-dimension quality report, use `audit`; for WCAG conformance, use `accessibility`.
 metadata:
-  version: "1.0.0"
-  tags: "design, ux, ui, consistency, audit, tailwind, accessibility"
+  version: "1.0.1"
+  tags: "design, ux, ui, consistency, design-tokens, design-debt, tailwind"
 ---
 
 # Design Consistency Auditor
@@ -12,22 +12,22 @@ Before auditing, discover the project's frontend structure from documentation.
 
 Ensures:
 
-- Color palettes are used consistently
-- UI/UX patterns follow best practices
-- Components maintain visual harmony
-- Accessibility standards are met
-- Design system is properly applied
+- Color palettes are used consistently through semantic tokens
+- Spacing stays on the project's scale
+- Components maintain visual harmony across screens
+- The design system is applied instead of duplicated
 - No design debt accumulates
 
 ## When to Use
 
-- Auditing design consistency across apps
-- Reviewing color palette usage
-- Checking UI/UX patterns
-- Validating component styling
-- Ensuring accessibility compliance
-- Identifying design inconsistencies
-- Reviewing new features for design standards
+- Auditing design-token consistency across apps
+- Reviewing color palette usage and hunting hardcoded hex values
+- Checking UI/UX patterns for screen-to-screen divergence
+- Spotting one-off classes that duplicate a design-system component
+- Reviewing new features against the established design standards
+
+Accessibility conformance is a separate pass — use `accessibility` for WCAG, ARIA,
+keyboard access, and contrast.
 
 ## Quick Reference
 
@@ -87,3 +87,8 @@ Push for distinctive, branded designs with personality.
 ---
 
 **For detailed checklists, examples, reporting templates, and audit commands, see:** `references/full-guide.md`
+
+## Related
+
+- `audit` — a scored 0-4 sweep across accessibility, performance, theming, responsive design, and anti-patterns when no single dimension is named.
+- `accessibility` — WCAG 2.1 AA conformance, ARIA, keyboard access, and screen-reader verification.

--- a/skills/design-consistency-auditor/plugin.json
+++ b/skills/design-consistency-auditor/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "design-consistency-auditor",
-  "version": "1.0.0",
-  "description": "Audit and maintain design system consistency, UX/UI patterns, color palettes, and design best practi",
+  "version": "1.0.1",
+  "description": "Hunt design-token drift, hardcoded colors, and design-system divergence across a frontend.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/gh-address-comments/SKILL.md
+++ b/skills/gh-address-comments/SKILL.md
@@ -1,14 +1,15 @@
 ---
 name: gh-address-comments
 description: >-
-  Resolves GitHub PR review and issue comments by fetching threads, mapping them
-  to code, proposing fixes, and drafting replies for approval. Triggers when the
-  user asks to address PR comments, respond to review feedback, fix review
-  threads, or resolve GitHub comment requests.
+  Implements the fixes a PR review asked for — maps each thread to the code it
+  touches, edits that code, and drafts a reply per thread for approval before
+  anything is posted. Starts from feedback that is already understood; producing
+  the read-only digest is `pr-comments`.
 disable-model-invocation: true
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, pull-requests, review-comments"
+when_to_use: "address the PR comments, fix the review feedback, implement the review suggestions, resolve these review threads, reply to the reviewer"
 ---
 
 # GH Address Comments
@@ -46,6 +47,8 @@ Confirmation Required:
 
 Delegates To:
 
+- `pr-comments` first when the threads have not been triaged yet — it produces the
+  read-only digest this skill then works through
 - `code-review` to validate proposed fixes
 - `qa-reviewer` before final response
 - `gh-fix-ci` if fixes cause or reveal CI failures

--- a/skills/gh-address-comments/plugin.json
+++ b/skills/gh-address-comments/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "gh-address-comments",
-  "version": "1.0.0",
-  "description": "Help address review or issue comments on the open GitHub PR for the current branch using gh CLI; ver",
+  "version": "1.0.1",
+  "description": "Implement the fixes a PR review asked for and draft a reply per thread for approval.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/layout/README.md
+++ b/skills/layout/README.md
@@ -14,6 +14,6 @@ Derived from **[pbakaus/impeccable](https://github.com/pbakaus/impeccable)** (Ap
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** vendored as a standalone marketplace plugin. No behavioral changes from upstream beyond provenance metadata; this skill never invoked `/impeccable`.
+**Local modifications:** adapted as a standalone marketplace plugin; this skill never invoked `/impeccable`. Rewrote the description to scope this skill to structural composition work (spacing scale, hierarchy, grid, rhythm, density) ahead of any detail pass, and added a Related section routing the last-mile pass to `polish`, so the two do not compete on the same trigger phrasing.
 
 **Checking for upstream changes:** when *Upstream latest* is ahead of *Forked at*, diff [`skill/reference/layout.md`](https://github.com/pbakaus/impeccable/blob/main/skill/reference/layout.md) against tag `skill-v2.1.1`, port anything worth bringing home, then bump `metadata.upstream_version` and `metadata.last_synced` in `SKILL.md` and this table.

--- a/skills/layout/SKILL.md
+++ b/skills/layout/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: layout
-description: Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak visual hierarchy. Use when the user mentions layout feeling off, spacing issues, visual hierarchy, crowded UI, alignment problems, or wanting better composition.
+description: Reworks the structure underneath a UI — spacing scale, visual hierarchy, grid and composition, rhythm, and density — turning monotonous or crowded arrangements into intentional ones. Applies while the composition itself is still wrong, ahead of any detail pass. Use when the user says the layout feels off, every section looks the same, the UI is crowded or too sparse, hierarchy is unclear, or nothing guides the eye. For the last-mile pass on a finished feature, use `polish`.
 user-invocable: true
 argument-hint: "[target]"
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
   tags: "layout, ux, frontend"
   source: https://github.com/pbakaus/impeccable/blob/main/skill/reference/layout.md
   upstream_version: skill-v2.1.1
@@ -121,3 +121,7 @@ Create a systematic plan:
 - **Breathing room**: Does the layout feel comfortable, not cramped or wasteful?
 - **Consistency**: Is the spacing system applied uniformly?
 - **Responsiveness**: Does the layout adapt gracefully across screen sizes?
+
+## Related
+
+- `polish` — the last-mile pass once the composition is right and the feature is functionally complete.

--- a/skills/layout/plugin.json
+++ b/skills/layout/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "layout",
-  "version": "2.1.1",
-  "description": "Improve layout, spacing, and visual rhythm. Fixes monotonous grids, inconsistent spacing, and weak v",
+  "version": "2.1.2",
+  "description": "Rework spacing scale, hierarchy, grid, rhythm, and density into an intentional composition.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/polish/README.md
+++ b/skills/polish/README.md
@@ -14,6 +14,6 @@ Derived from **[pbakaus/impeccable](https://github.com/pbakaus/impeccable)** (Ap
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** vendored as a standalone marketplace plugin. No behavioral changes from upstream beyond provenance metadata; this skill never invoked `/impeccable`.
+**Local modifications:** adapted as a standalone marketplace plugin; this skill never invoked `/impeccable`. Rewrote the description to require a functionally complete feature and scope this skill to refinement rather than restructuring, and added a Related section routing composition problems to `layout`, so the two do not compete on the same trigger phrasing.
 
 **Checking for upstream changes:** when *Upstream latest* is ahead of *Forked at*, diff [`skill/reference/polish.md`](https://github.com/pbakaus/impeccable/blob/main/skill/reference/polish.md) against tag `skill-v2.1.1`, port anything worth bringing home, then bump `metadata.upstream_version` and `metadata.last_synced` in `SKILL.md` and this table.

--- a/skills/polish/SKILL.md
+++ b/skills/polish/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: polish
-description: Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before shipping. Use when the user mentions polish, finishing touches, pre-launch review, something looks off, or wants to go from good to great.
+description: Runs the last pass over a functionally complete feature — pixel alignment, interaction and loading states, empty and error states, copy consistency, transition smoothness, and micro-details measured against the design system. Requires the work to be finished first; it refines, it never restructures. Use when the user asks for polish, finishing touches, a pre-launch review, or wants to go from good to great. To fix the underlying composition instead, use `layout`.
 user-invocable: true
 argument-hint: "[target]"
 metadata:
-  version: "2.1.1"
+  version: "2.1.2"
   tags: "polish, ui, quality"
   source: https://github.com/pbakaus/impeccable/blob/main/skill/reference/polish.md
   upstream_version: skill-v2.1.1
@@ -225,3 +225,7 @@ After polishing, ensure code quality:
 - **Verify DRYness**: Look for duplication introduced during polishing and consolidate.
 
 Remember: You have impeccable attention to detail and exquisite taste. Polish until it feels effortless, looks intentional, and works flawlessly. Sweat the details - they matter.
+
+## Related
+
+- `layout` — fix the underlying spacing scale, hierarchy, and grid first when the composition itself is what feels wrong; polish refines, it does not restructure.

--- a/skills/polish/plugin.json
+++ b/skills/polish/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "polish",
-  "version": "2.1.1",
-  "description": "Performs a final quality pass fixing alignment, spacing, consistency, and micro-detail issues before",
+  "version": "2.1.2",
+  "description": "Run the last detail pass over a functionally complete feature before it ships.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/pr-comments/SKILL.md
+++ b/skills/pr-comments/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: pr-comments
-description: "Fetch a pull request's review and discussion comments and return a read-only digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out — without editing code or drafting replies. Use when the user asks what are the comments on my PR, summarize the review feedback, what's blocking this PR, what do I still need to address, or runs /pr comments."
+description: "Reads a pull request's review threads and returns a digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out. Strictly read-only: no code edits, no replies, no thread resolution. Reach for it to triage feedback before deciding what to fix; implementing those fixes is `gh-address-comments`."
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "github, pull-requests, code-review, comments, triage, digest"
+when_to_use: "what are the comments on my PR, summarize the review feedback, what's blocking this PR, what do I still need to address, triage the review comments, /pr comments"
 allowed-tools: Bash(gh *) Bash(git *)
 disable-model-invocation: true
 ---

--- a/skills/pr-comments/plugin.json
+++ b/skills/pr-comments/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "pr-comments",
-  "version": "1.0.0",
-  "description": "Fetch a PR's review comments as a read-only, severity-tagged, priority-ordered digest.",
+  "version": "1.0.1",
+  "description": "Read a PR's review threads into a severity-tagged, priority-ordered, read-only digest.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/prd-task-creator/SKILL.md
+++ b/skills/prd-task-creator/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: prd-task-creator
-description: 'Create a well-written PRD, task, or GitHub issue/sub-issue for a feature, bug, or enhancement. Use when planning work, writing GitHub issues, breaking down epics into sub-issues, or creating local task files. Common prompts: create a task, write a PRD, open a GitHub issue, create a sub-issue, plan this feature, write up this bug, break this down into issues, I want to add X, implement Y.'
+description: 'Files work into a tracker — turns a feature, bug, or finished PRD into GitHub issues, linked sub-issues, or local task files, slicing epics into thin vertical slices sized for one PR each and tagged AFK or HITL. Starts once the requirements are settled; authoring the PRD document itself is `prd-writer`.'
 disable-model-invocation: true
 allowed-tools: Bash(gh *)
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "tasks, prd, github, ears"
+when_to_use: "create a task, open a GitHub issue, create a sub-issue, break this epic down into issues, file this PRD as work items, write up this bug as an issue"
 ---
 
 # PRD Task Creator
@@ -162,6 +163,7 @@ Show the draft PRD. Wait for "looks good" or edits. Then create.
 
 ## Related
 
+- `prd-writer` — author the PRD document first when requirements are not settled yet; this skill files what that one wrote
 - `spec-first` — spec-driven development before writing code
 - `tdd` — red-green-refactor execution for tasks with clear behavior
 - `gh-fix-ci` — fix CI on existing PRs

--- a/skills/prd-task-creator/plugin.json
+++ b/skills/prd-task-creator/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prd-task-creator",
-  "version": "1.2.0",
-  "description": "Write PRDs and tasks as GitHub issues, sub-issues, or local planning files.",
+  "version": "1.2.1",
+  "description": "File settled work into a tracker as GitHub issues, sub-issues, or local task files.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/prd-writer/SKILL.md
+++ b/skills/prd-writer/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: prd-writer
 disable-model-invocation: true
-description: Drafts, scopes, and formalizes features as PRDs — a planning agent can consume the output in one shot without re-elicitation. Triggers on "write a PRD for X", "let's plan X", "scope this out", "what should X do", or when a tracker issue needs to be fleshed out before planning. Do NOT use for code edits, debugging, or PR reviews.
+description: Authors the PRD document itself — problem, scope boundaries, EARS acceptance criteria, and verification plan — as one self-contained contract a planning agent consumes without re-elicitation. Ends at the written PRD; slicing it into tracked issues is `prd-task-creator`.
 metadata:
-  version: "1.2.0"
+  version: "1.2.1"
   tags: "prd, planning, requirements, spec, scoping, ears"
+when_to_use: "write a PRD for X, draft a PRD, scope this out, what should X do, formalize this feature, flesh out this issue before planning"
 ---
 
 # PRD Writer
@@ -305,3 +306,7 @@ through the issue detail view. This is pure friction — the URL is already know
 ```
 
 Note: no `created`, `updated`, `status`, `complexity`, or `blast radius` fields in the body — the tracker and project board track those natively. No file path — the PRD lives in the issue body itself.
+
+## Related
+
+- `prd-task-creator` — file the finished PRD into a tracker and slice it into sub-issues sized for one PR each.

--- a/skills/prd-writer/plugin.json
+++ b/skills/prd-writer/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "prd-writer",
-  "version": "1.2.0",
-  "description": "Write one-shot PRDs for planning agents with tracker issue and quality gates.",
+  "version": "1.2.1",
+  "description": "Author the PRD document itself with scope, EARS acceptance criteria, and a verification plan.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/release-pr-gates/SKILL.md
+++ b/skills/release-pr-gates/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release-pr-gates
-description: Gate a release on the trunk — verify required CI checks are green, then cut a release (semver tag + GitHub release) or open a release PR into the default branch. Deployment to staging and production environments is driven by CI/CD pipelines and tags, not branch PRs. Use when the user asks to release, open a release PR, cut a tag, wait for GitHub checks to go green, or verify the trunk is ready to release.
+description: Holds a release at the gate — opens or reuses a release PR into the trunk, runs local format, lint, and type-check, watches required GitHub checks through to green, and summarizes the failing run's root cause when they are not. Tags only after the gate passes. Reach for it during the pre-merge wait; for version derivation and plain-English patch notes, use `release`.
 compatibility: Requires git and GitHub CLI gh access to the target repository.
 metadata:
-  version: "1.1.0"
+  version: "1.1.1"
   tags: "release, github, pull-request, ci-cd, quality-gates"
+when_to_use: "open a release PR, wait for the checks to go green, are the release checks passing, is the trunk ready to release, gate this release on CI, which required check is failing"
 allowed-tools: Bash(git *) Bash(gh *)
 disable-model-invocation: true
 ---
@@ -59,6 +60,8 @@ Confirmation Required:
 Delegates To:
 
 - `gh-fix-ci` when checks fail
+- `release` once the gate is green and the cut needs semver derivation and
+  plain-English patch notes — this skill owns the wait, that one owns the cut
 - `changelog-generator` when a release body needs commit summaries
 - `deploy` after release gates pass and provider deployment is needed
 

--- a/skills/release-pr-gates/plugin.json
+++ b/skills/release-pr-gates/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "release-pr-gates",
-  "version": "1.1.0",
-  "description": "Verify release CI gates, then tag the trunk or open a release PR.",
+  "version": "1.1.1",
+  "description": "Open a release PR and hold the release until required CI checks go green.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/release/SKILL.md
+++ b/skills/release/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release
-description: Cut a release from the trunk (default branch) and generate plain-English patch notes. Determines the next semantic version from commits since the last tag, previews the release plan, then on confirmation either creates an annotated tag + GitHub release (tag mode) or dispatches the repo's guarded release workflow (dispatch mode, for repos whose production deploy is gated behind a workflow_dispatch promote gate). Trunk-based — there is no develop/staging branch promotion. Use when the user asks to cut a release, ship a release, tag a release, promote to production, release to production, generate release notes or a changelog, or runs /release.
+description: Cuts the release itself — derives the next semantic version from commits since the last tag, writes plain-English patch notes, previews the plan, then on confirmation creates an annotated tag plus GitHub release, or dispatches the repo's guarded release workflow where production sits behind a workflow_dispatch promote gate. Trunk-based; no develop or staging branch promotion. Assumes the trunk is already green — to open a release PR or wait on required checks first, use `release-pr-gates`.
 compatibility: Requires git, GitHub CLI gh, and jq access to the target repository.
 metadata:
-  version: "2.0.0"
+  version: "2.0.1"
   tags: "git, github, release, tag, semver, changelog, patch-notes, trunk-based, ci-cd"
+when_to_use: "cut a release, ship a release, tag a release, promote to production, release to production, generate release notes, generate a changelog, /release"
 allowed-tools: Bash(git *) Bash(gh *) Bash(jq *)
 disable-model-invocation: true
 ---
@@ -61,7 +62,8 @@ Confirmation Required:
 Delegates To:
 
 - `changelog-generator` when a richer or differently-formatted changelog is wanted
-- `release-pr-gates` to wait on required CI checks before cutting the release
+- `release-pr-gates` to open the release PR and wait on required CI checks before
+  this skill cuts anything — that skill owns the pre-merge gate, this one owns the cut
 - `gh-fix-ci` when the trunk's required checks are failing and the user wants them fixed
 - `release-cleanup` to prune merged feature branches and stale worktrees afterward
 - `deploy` / `deployment-composer` to ship the freshly cut tag to an environment

--- a/skills/release/plugin.json
+++ b/skills/release/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "release",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Cut a trunk release with semantic versioning, patch notes, tags, and GitHub release.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/tech-debt/SKILL.md
+++ b/skills/tech-debt/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: tech-debt
-description: Inventory, quantify, and prioritize technical debt into a register ranked by interest (how often it hurts) over principal (effort to fix). Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked about tech debt, what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request.
+description: Inventories a real codebase and ranks its technical debt into a register scored by interest (how often it hurts) over principal (effort to fix), every item anchored to a file-and-line or a metric. Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request. For org-level technology strategy and architecture direction, use `cto-advisor`.
 user-invocable: true
 argument-hint: "[directory, or 'issues' to file]"
 compatibility: Requires git; gh to file issues; optional bun/npm audit for dependency debt.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "tech-debt, refactor, prioritization, code-quality, maintenance"
   author: Ship Shit Dev
-when_to_use: "tech debt, technical debt, what to pay down, debt register, where is the codebase rotting, prioritize refactoring, debt backlog, /refactor debt"
+when_to_use: "what to pay down, debt register, where is the codebase rotting, scan this repo for tech debt, prioritize refactoring, debt backlog, /refactor debt"
 ---
 
 # Tech Debt
@@ -48,6 +48,8 @@ Delegates To:
 - `refactor-code` / `de-slop` / `stack-modernization` to actually pay down an item.
 - `roadmap-analyzer` when debt competes with features — it ranks both against revenue.
 - `roadmap-to-milestones` to schedule a debt-paydown milestone.
+- `cto-advisor` when the question is how much to invest overall, or which architecture
+  or technology to move toward — direction rather than inventory.
 
 ## Step 1 — Inventory debt from evidence
 

--- a/skills/tech-debt/plugin.json
+++ b/skills/tech-debt/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "tech-debt",
-  "version": "1.0.0",
-  "description": "Inventory and prioritize technical debt into a register ranked by interest over principal.",
+  "version": "1.0.1",
+  "description": "Inventory a codebase and rank its technical debt into a register scored interest over principal.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",


### PR DESCRIPTION
A duplicate-detection audit found six pairs of skills whose `description` / `when_to_use` fire on the same phrasing. **Every skill stays** — these are frontmatter-sharpening fixes only, not merges. Each pair now leads with words the other does not use, names its distinct moment-of-use, and carries a `Related` cross-reference so routing has somewhere to go.

## The six pairs

| Pair | Split |
|---|---|
| `cto-advisor` / `tech-debt` | Direction and investment level, reasoned from org-level indicators, vs an evidence-anchored inventory of a real codebase. `cto-advisor` drops every "tech debt" trigger phrase. |
| `prd-writer` / `prd-task-creator` | Authoring the PRD document itself vs filing settled requirements into a tracker as issues and sliced sub-issues. |
| `release` / `release-pr-gates` | Cutting the release — semver derivation plus patch notes — vs holding the pre-merge gate on required CI checks. |
| `pr-comments` / `gh-address-comments` | Read-only digest vs implementing the fixes. `gh-address-comments` no longer leads with "fetching threads". |
| `audit` / `design-consistency-auditor` / `accessibility` | The broad five-dimension sweep now routes deep passes to the two specialists; the specialists stop claiming each other's ground. `design-consistency-auditor` drops its accessibility triggers and its `accessibility` tag. |
| `layout` / `polish` | Structural composition, applied while the layout is still wrong, vs the last detail pass on a functionally complete feature. |

## Also in this change

- Trigger lists move out of `description` into `when_to_use` for the user-invoked skills, per the writing craft in `.agents/memory/system/skill-standards.md`.
- `metadata.version` patch-bumped on all 13 skills, kept in sync with each `plugin.json`.
- Local modifications recorded in the three impeccable-derived READMEs (`audit`, `layout`, `polish`) — the latter two previously claimed "no behavioral changes from upstream", which is no longer accurate.

## Verification

- `bun run catalog:generate` — no drift, generated files unchanged.
- `bash scripts/validate-skill-sync.sh` — **0 errors**; all 13 edited skills validate clean with zero warnings. The 28 warnings in the full run are pre-existing and on other skills.
- `bun run lint` — clean (only the pre-existing biome config deprecation notices).

No local tests, typechecks, or builds were run — CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and marketplace metadata only; no runtime or CI workflow logic changes.
> 
> **Overview**
> Sharpens **skill routing metadata** so six pairs (plus an `audit` / `accessibility` / `design-consistency-auditor` triplet) no longer share the same trigger phrasing. Each skill’s `description` now states a distinct moment-of-use, with **`Related`** cross-links and clearer **Delegates To** boundaries (e.g. `release` vs `release-pr-gates`, `prd-writer` vs `prd-task-creator`, `pr-comments` vs `gh-address-comments`).
> 
> Updates land in **`.claude-plugin/marketplace.json`**, matching **`SKILL.md` / `plugin.json`** under `skills/` and bundle copies (`dev-loop`, `dev-workflow`, `frontend`, `github`, `planning`). User-invoked skills gain **`when_to_use`** (triggers moved out of long descriptions per skill standards). **`metadata.version`** patch bumps stay in sync with each `plugin.json`; impeccable-derived **`audit` / `layout` / `polish` READMEs** note the routing-focused local changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a701fe4451c8cb2f392724f2ea8b07b5019dee99. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified skill scopes, usage guidance, workflow boundaries, and relationships across accessibility, auditing, design, planning, review, release, and technical-debt workflows.
  - Improved guidance for PRD authoring, task creation, review-comment handling, release gating, and release publication.
  - Added clearer routing between complementary skills and expanded invocation triggers.

- **Chores**
  - Updated marketplace descriptions and incremented versions for the affected skills and plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->