### PR TITLE
refactor: split open-source-checker and git-safety by moment-of-use

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -398,7 +398,7 @@
     {
       "name": "git-safety",
       "source": "./skills/git-safety",
-      "description": "Scans, cleans, and prevents secrets in git history across four modes: scan (detect sensitive files in the current state and history), clean (rewrite history to remove secrets using git-filter-repo or BFG), prevent (add .gitignore and pre-commit hooks), and full (all three in sequence). Use when the user asks to check for leaked credentials, scrub a secret from git history, force-push a cleaned repo, set up pre-commit secret prevention, or run a full git security audit."
+      "description": "Guards day-to-day git work in an existing repository: blocks secrets from entering a commit, gates destructive git operations before they run, installs ignore rules and pre-commit hooks, and drives the rotate-first response when a credential has already leaked."
     },
     {
       "name": "github-actions-author",
@@ -533,7 +533,7 @@
     {
       "name": "open-source-checker",
       "source": "./skills/open-source-checker",
-      "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release."
+      "description": "Audits a whole private repository once, at the decision to make it public. Runs four passes — license and attribution, secrets across the entire git history, private references (internal hostnames, employee emails, client and customer names, staging URLs), and publication readiness — then returns a publish or block verdict. Use when the user is preparing to open source a repository, asks whether a codebase is safe to publish, wants a pre-release audit before flipping a repo public, or needs to know what is still private in code that is about to ship publicly."
     },
     {
       "name": "package-architect",

--- a/bundles/github/skills/git-safety/SKILL.md
+++ b/bundles/github/skills/git-safety/SKILL.md
@@ -1,128 +1,189 @@
 ---
 name: git-safety
 description: >-
-  Scans, cleans, and prevents secrets in git history across four modes: scan
-  (detect sensitive files in the current state and history), clean (rewrite
-  history to remove secrets using git-filter-repo or BFG), prevent (add
-  .gitignore and pre-commit hooks), and full (all three in sequence). Use when
-  the user asks to check for leaked credentials, scrub a secret from git
-  history, force-push a cleaned repo, set up pre-commit secret prevention, or
-  run a full git security audit.
+  Guards day-to-day git work in an existing repository: blocks secrets from
+  entering a commit, gates destructive git operations before they run, installs
+  ignore rules and pre-commit hooks, and drives the rotate-first response when a
+  credential has already leaked.
 metadata:
-  version: "1.0.0"
-  tags: "git, security, secrets"
+  version: "1.1.0"
+  tags: "git, security, secrets, pre-commit"
+when_to_use: "about to commit, check what is staged, staged secret, pre-commit hook, pre-push check, force push, push --force, reset --hard, clean -fdx, rewrite git history, filter-repo, BFG, scrub a leaked credential, rotate a leaked key, git safety check"
 disable-model-invocation: true
 ---
 
-# Git Safety Skill
+# Git Safety
+
+Two guards, one repository you already work in every day:
+
+- **Staged guard** — nothing sensitive enters the next commit.
+- **Operation guard** — no destructive git command runs unconfirmed and unbacked.
+
+Both are recurring. They run at commit time and at push time, on every branch,
+forever. A one-time audit of a whole repository before it goes public is a
+different moment — see [Related](#related).
 
 ## Contract
 
 Inputs:
 
 - Repository root
-- Mode: scan, prevent, clean, or full
-- Optional leaked path, secret pattern, or affected ref range
+- Mode: `scan`, `guard`, `prevent`, `clean`, or `full`
+- For `clean`: the leaked path or secret string, and the refs it touches
 
 Outputs:
 
-- Sensitive file/history findings
-- Rotation and remediation checklist
-- Commands required for prevention or history cleanup
+- Staged findings with a block/allow verdict per file
+- Destructive-operation risk assessment and backup command
+- Rotation checklist for anything already pushed
 
 Creates/Modifies:
 
-- Scan mode: no file changes
-- Prevent mode: `.gitignore` and optional hook updates
-- Clean mode: rewritten git history only after explicit confirmation
+- `scan` and `guard`: no file changes
+- `prevent`: `.gitignore`, `.env.example`, and hook files
+- `clean`: rewritten git history, only after explicit confirmation
 
 External Side Effects:
 
-- May force-push rewritten history in clean mode
-- May require credential rotation outside the repository
+- May force-push rewritten history in `clean` mode
+- Requires credential rotation on systems outside the repository
 
 Confirmation Required:
 
-- Before history rewriting
-- Before force-pushing
-- Before changing hooks or ignore rules in shared repos
+- Before rewriting history
+- Before force-pushing or any push that discards remote commits
+- Before `reset --hard`, `clean -fdx`, or branch/tag deletion
+- Before changing hooks or ignore rules in a shared repository
 
 Delegates To:
 
+- `open-source-checker` before publishing a private repository
 - `security-audit` for broader application-security review
-- `open-source-checker` before publishing a private repo
 
-## CRITICAL WARNING
+## Rotate first
 
-**Removing secrets from git history does NOT make them safe!**
+Removing a secret from git history does **not** make it safe. Once pushed:
 
-Even after cleaning git history:
+- Bots scrape new pushes within seconds
+- Archive and mirror services may hold snapshots
+- Forks keep the original history
+- CI/CD logs may hold the value
 
-- GitHub is scraped by bots within seconds of a push
-- Archive services may have captured snapshots
-- Forks retain the original history
-- CI/CD logs may contain the values
+Rotate the credential at its source before touching history. History rewriting
+is cleanup, never containment. The bound: the old value is rejected by the
+issuing system.
 
-**ALWAYS rotate leaked credentials immediately.** Cleaning history is NOT enough.
+## Modes
 
-## Modes of Operation
+| Mode | Moment | Ends when |
+|------|--------|-----------|
+| `scan` | Before committing | Every staged file and added line is cleared or flagged |
+| `guard` | Before a destructive command | Blast radius stated, backup made, operator confirmed |
+| `prevent` | Once per repo, then on drift | Ignore rules and hook block a known-bad test commit |
+| `clean` | After a confirmed leak, post-rotation | Secret absent from every ref, collaborators notified |
+| `full` | New repo onboarding | `scan` → `prevent` complete |
 
-### 1. `/git-safety scan` - Detect Sensitive Files
+### `scan` — staged guard
 
-Scan repository for sensitive files in current state and git history.
-
-### 2. `/git-safety clean` - Remove from History
-
-Remove sensitive files using git-filter-repo or BFG.
-
-### 3. `/git-safety prevent` - Set Up Prevention
-
-Configure .gitignore and pre-commit hooks.
-
-### 4. `/git-safety full` - Complete Audit
-
-Run all three operations in sequence.
-
-## Sensitive File Patterns
-
-```
-.env, .env.*, credentials.json, service-account*.json
-*.pem, *.key, id_rsa*, secrets.*, .npmrc, *.secret
-```
-
-## Quick Commands
-
-**Scan for sensitive files in history:**
+Scope is the working tree and the staged diff, not history.
 
 ```bash
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -iE 'env|secret|credential|key'
+# Files about to be committed
+git diff --cached --name-only
+
+# Sensitive filenames among them
+git diff --cached --name-only | grep -iE '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|secret)$|credentials|service-account|id_rsa|id_ed25519|\.npmrc$|kubeconfig'
+
+# Secret-shaped values in added lines only
+git diff --cached -U0 | grep -E '^\+' | grep -iE '(api[_-]?key|secret[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|password)[^a-z]{0,4}[=:][^=:]{8,}'
+
+# Untracked files sitting in the tree that must never be added
+git status --porcelain --untracked-files=all | grep -E '^\?\?' | grep -iE '\.env|\.pem$|\.key$|credentials|secrets\.'
 ```
 
-**Remove .env from all history:**
+Verdict per finding: **block** (real credential), **allow** (placeholder,
+fixture, or example), or **ask** when the value cannot be classified from the
+diff alone. Report the file and line for each block. Ends when every staged path
+carries a verdict.
+
+### `guard` — destructive operation gate
+
+Any of these rewrites or discards work that git cannot recover for a
+collaborator:
+
+| Command | Discards |
+|---------|----------|
+| `git push --force` / `--force-with-lease` | Remote commits others may hold |
+| `git filter-repo`, `bfg` | Every commit hash in the repository |
+| `git reset --hard` | Uncommitted work in the tree and index |
+| `git clean -fdx` | Untracked files, including local `.env` |
+| `git checkout -- <path>` | Uncommitted edits to that path |
+| `git branch -D`, `git push origin --delete` | Unmerged commits on that ref |
+| `git rebase` on a pushed branch | Published commits under collaborators |
+
+Before running one:
+
+1. **State the blast radius** — which refs change, whose clones break, what is
+   unrecoverable.
+2. **Back up** — `git clone --mirror . ../repo-backup-$(date +%Y%m%d)` for any
+   history rewrite; `git stash -u` before a `reset --hard` or `clean -fdx`.
+3. **Prefer the reversible form** — `--force-with-lease` over `--force`,
+   `git revert` over `reset --hard` on a pushed branch, `git stash` over
+   `checkout --`.
+4. **Confirm with the operator**, quoting the exact command.
+
+Ends when the operator confirms against a stated blast radius, or the reversible
+alternative is used instead.
+
+### `prevent` — make the guard automatic
+
+Add the ignore rules, write the pre-commit hook, and create `.env.example`.
+Patterns, the full hook script, and `git secrets` setup are in
+`references/full-guide.md`.
+
+Ends when a deliberate test commit of a dummy `.env` is rejected by the hook.
+
+### `clean` — rewrite history after a leak
+
+Runs only after rotation is confirmed, and only inside the `guard` gate above.
 
 ```bash
-git filter-repo --path .env --invert-paths --force
-git push origin --force --all
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+git filter-repo --path .env --invert-paths
+git push origin --force --all && git push origin --force --tags
 ```
 
-**Add to .gitignore:**
+Verify:
 
 ```bash
-echo -e "\n.env\n.env.*\n*.pem\n*.key\ncredentials.json" >> .gitignore
+git log --all --full-history -- .env     # empty
+git log -p --all -S '<rotated-value>'    # empty
 ```
 
-## Emergency Response
+Ends when both verifications return empty and every collaborator has re-cloned.
 
-If you've leaked credentials:
+## Emergency response
 
-1. **IMMEDIATELY rotate the credential**
-2. Check access logs
-3. Run `/git-safety clean`
-4. Force push cleaned history
-5. Notify team to re-clone
-6. Update .gitignore
-7. Set up pre-commit hooks
+A credential is in a pushed commit:
+
+1. Rotate the credential. Nothing else counts until this is done.
+2. Check the provider's access logs for use of the old value.
+3. Run `clean` to strip it from history.
+4. Force-push through the `guard` gate.
+5. Tell collaborators to re-clone; forks and open PRs keep the old history.
+6. Run `prevent` so the same file cannot be staged again.
+7. Write down what leaked, when, and what was rotated.
+
+## Related
+
+- `open-source-checker` — the one-time audit before a private repository is
+  published: license and attribution, secrets across the entire history,
+  internal hostnames and employee references. Run it once, at the publish
+  decision; run `git-safety` at every commit thereafter.
+- `security-audit` — application-level vulnerability review, not git state.
 
 ---
 
-**For complete scan commands, cleaning process with git-filter-repo/BFG, pre-commit hook setup, .gitignore templates, platform-specific guidance, and detailed emergency checklist, see:** `references/full-guide.md`
+**Full sensitive-file patterns, the complete pre-commit hook script, `.gitignore`
+template, `git secrets` setup, BFG alternative, and platform notes:**
+`references/full-guide.md`

--- a/bundles/github/skills/git-safety/plugin.json
+++ b/bundles/github/skills/git-safety/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-safety",
-  "version": "1.0.0",
-  "description": "Scan, clean, and prevent secrets in git history and repository state.",
+  "version": "1.1.0",
+  "description": "Block secrets from entering a commit and gate destructive git operations.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/git-safety/references/full-guide.md
+++ b/bundles/github/skills/git-safety/references/full-guide.md
@@ -1,10 +1,20 @@
-# Git Safety - Full Guide
+# Git Safety — Full Guide
 
-## 1. SCAN - Detect Sensitive Files
+Reference material for the two recurring guards: what must never enter a commit,
+and what must never run without confirmation.
 
-### Sensitive File Patterns
+Scope note: this guide covers the **ongoing** moment — commit time, push time,
+and leak response in a repository you already work in. The one-time audit of a
+whole repository before publication (license, attribution, full-history sweep,
+internal references) belongs to the `open-source-checker` skill.
 
-```bash
+---
+
+## 1. Sensitive File Patterns
+
+Filenames that should never be staged:
+
+```
 # Environment files
 .env
 .env.*
@@ -28,12 +38,10 @@ id_ecdsa*
 .aws/config
 .gcp/credentials.json
 .azure/credentials
+kubeconfig
+.kube/config
 
-# Database
-*.sql (check for passwords)
-database.yml (check for passwords)
-
-# API/Secret files
+# API/secret files
 secrets.yml
 secrets.json
 *.secret
@@ -41,217 +49,156 @@ api_keys.*
 auth.json
 
 # Package manager tokens
-.npmrc (with auth tokens)
+.npmrc
 .pypirc
 .gem/credentials
+.docker/config.json
 
 # Other
-*.log (may contain secrets)
 .htpasswd
 .netrc
-.docker/config.json
-kubeconfig
+*.log          # may contain secrets
+*.sql          # may contain passwords or production data
+database.yml   # may contain passwords
 ```
 
-### Scan Commands
+Allowlist the safe siblings explicitly: `.env.example`, `.env.template`,
+`schema.sql`, `migrations/*.sql`.
 
-**Step 1: Check current working directory**
+---
+
+## 2. Staged Guard Commands
+
+### 2.1 What is about to be committed
 
 ```bash
-# List potentially sensitive files in current state
-find . -type f \( \
-  -name ".env" -o \
-  -name ".env.*" -o \
-  -name "*.env" -o \
-  -name "credentials.json" -o \
-  -name "service-account*.json" -o \
-  -name "*.pem" -o \
-  -name "*.key" -o \
-  -name "id_rsa*" -o \
-  -name "secrets.*" -o \
-  -name ".npmrc" -o \
-  -name "*.secret" \
-\) 2>/dev/null | grep -v node_modules | grep -v .git
+# Names only
+git diff --cached --name-only
+
+# With status letters (A/M/D)
+git diff --cached --name-status
+
+# Full added content, no context lines
+git diff --cached -U0
 ```
 
-**Step 2: Check git history for sensitive files**
+### 2.2 Sensitive filenames in the staged set
 
 ```bash
-# Search all commits for sensitive filenames
-git log --all --full-history --diff-filter=A -- \
-  "*.env" ".env" ".env.*" \
-  "credentials.json" "service-account*.json" \
-  "*.pem" "*.key" "id_rsa*" \
-  "secrets.*" ".npmrc" "*.secret" \
-  --name-only --pretty=format:"%h %s" 2>/dev/null
-
-# Alternative: List all files ever committed
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -E '\.(env|pem|key|secret)$|credentials|secrets\.|id_rsa'
+git diff --cached --name-only | grep -iE \
+  '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|secret)$|credentials|service-account|id_rsa|id_ed25519|\.npmrc$|kubeconfig'
 ```
 
-**Step 3: Search for secrets in file contents**
+### 2.3 Secret-shaped values in added lines
+
+Scan only lines the commit adds — existing lines are history's problem, not this
+commit's.
 
 ```bash
-# Search for common secret patterns in tracked files
-git grep -E "(api[_-]?key|apikey|secret[_-]?key|password|passwd|pwd|token|auth[_-]?token|access[_-]?token|private[_-]?key|client[_-]?secret)" --cached -- ':!*.lock' ':!package-lock.json' ':!yarn.lock' 2>/dev/null | head -50
+# Generic assignment shapes
+git diff --cached -U0 | grep -E '^\+' | grep -iE \
+  '(api[_-]?key|apikey|secret[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|password|passwd)[^a-z]{0,4}[=:][^=:]{8,}'
 
-# Search git history for secret patterns (expensive but thorough)
-git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock' 2>/dev/null | head -100
+# Private key material
+git diff --cached -U0 | grep -E '^\+' | grep -E 'BEGIN (RSA|EC|OPENSSH|PGP)? ?PRIVATE KEY'
+
+# Vendor key prefixes (extend for the providers you use)
+git diff --cached -U0 | grep -E '^\+' | grep -E \
+  'AKIA[0-9A-Z]{16}|gh[pousr]_[A-Za-z0-9]{36}|xox[baprs]-[0-9A-Za-z-]{10,}|AIza[0-9A-Za-z_-]{35}'
+
+# Credentials embedded in a connection URI (scheme split so this file does not
+# itself contain a URI-shaped literal that trips downstream secret scanners)
+git diff --cached -U0 | grep -E '^\+' | grep -E '[a-z]+:'"//"'[^:@/]+:[^:@/]+@'
 ```
 
-**Step 4: Check .gitignore coverage**
+### 2.4 Untracked files sitting in the tree
+
+Not staged today, easy to `git add -A` tomorrow:
 
 ```bash
-# Verify sensitive patterns are in .gitignore
+git status --porcelain --untracked-files=all \
+  | grep -E '^\?\?' \
+  | grep -iE '\.env|\.pem$|\.key$|credentials|secrets\.'
+```
+
+### 2.5 Ignore-rule coverage
+
+```bash
 for pattern in ".env" ".env.*" "*.pem" "*.key" "credentials.json" "secrets.*"; do
-  if ! grep -q "$pattern" .gitignore 2>/dev/null; then
-    echo "Missing from .gitignore: $pattern"
-  fi
+  grep -q -- "$pattern" .gitignore 2>/dev/null || echo "Missing from .gitignore: $pattern"
 done
 ```
 
-### Scan Report Format
+### 2.6 Verdict format
 
 ```
-## Git Safety Scan Results
+## Staged Guard — <branch>, <n> files staged
 
-### Current Directory
-- [ ] No sensitive files found
-- [X] Found: .env.local (not tracked - OK)
-- [!] Found: credentials.json (TRACKED - DANGER)
+BLOCK  src/config.ts:42        live-looking API key in an added line
+BLOCK  credentials.json        forbidden filename, newly added
+ASK    tests/fixtures/key.pem  private key — confirm it is a throwaway test key
+ALLOW  .env.example            placeholder values only
 
-### Git History
-- [ ] No sensitive files in history
-- [!] Found in history: .env (commit abc1234, 2024-01-15)
-- [!] Found in history: api-keys.json (commit def5678, 2024-02-20)
+Untracked but present: .env.local (ignored — OK)
+.gitignore gaps: *.pem, credentials.json
 
-### Secret Patterns in Code
-- [ ] No hardcoded secrets detected
-- [!] Possible API key in: src/config.ts:42
-
-### .gitignore Coverage
-- [X] .env patterns covered
-- [ ] Missing: *.pem
-- [ ] Missing: credentials.json
-
-### Recommendations
-1. [URGENT] Rotate any exposed credentials immediately
-2. Run `/git-safety clean` to remove files from history
-3. Run `/git-safety prevent` to update .gitignore
+Next: unstage the two BLOCK paths, then rerun.
 ```
 
 ---
 
-## 2. CLEAN - Remove from Git History
+## 3. Destructive Operation Gate
 
-### Prerequisites Check
+### 3.1 Blast radius by command
 
-```bash
-# Check if git-filter-repo is installed (preferred)
-which git-filter-repo
+| Command | Rewrites | Discards | Recoverable via |
+|---------|----------|----------|-----------------|
+| `git push --force` | Remote refs | Remote commits others hold | Their local reflog only |
+| `git push --force-with-lease` | Remote refs | Same, but aborts on unseen updates | Preferred form |
+| `git filter-repo` / `bfg` | All commit hashes | Nothing, if mirrored first | Mirror backup |
+| `git reset --hard` | Index and tree | Uncommitted work | `git stash` beforehand |
+| `git clean -fdx` | Tree | Untracked files, local `.env` | Nothing |
+| `git checkout -- <path>` | Tree | Uncommitted edits to that path | Nothing |
+| `git branch -D` | Local ref | Unmerged commits | Local reflog, ~90 days |
+| `git push origin --delete` | Remote ref | Unmerged commits on the remote | Nothing reliable |
+| `git rebase` on a pushed branch | Local history | Published commit identity | Force-push follows |
 
-# Check if BFG is available (alternative)
-which bfg
-```
-
-### Installation (if needed)
-
-```bash
-# Install git-filter-repo (recommended)
-pip install git-filter-repo
-
-# Or via Homebrew on macOS
-brew install git-filter-repo
-
-# BFG alternative (Java required)
-brew install bfg
-```
-
-### Cleaning Process
-
-**IMPORTANT: Before cleaning, ensure:**
-
-1. All team members have pushed their changes
-2. You have a backup of the repository
-3. You understand this rewrites history (force push required)
-
-**Step 1: Create backup**
+### 3.2 Backup commands
 
 ```bash
-# Clone a backup
+# Before any history rewrite
 git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# Before reset --hard or clean -fdx
+git stash push --include-untracked -m "pre-destructive-op $(date +%FT%T)"
+
+# Before deleting a branch, keep a pointer
+git tag archive/<branch-name> <branch-name>
 ```
 
-**Step 2: Remove specific files with git-filter-repo**
+### 3.3 Reversible alternatives
+
+| Instead of | Use | Why |
+|-----------|-----|-----|
+| `push --force` | `push --force-with-lease` | Aborts if the remote moved since your last fetch |
+| `reset --hard` on a pushed branch | `git revert <sha>` | Adds a commit; collaborators keep their history |
+| `checkout -- <path>` | `git stash push <path>` | Recoverable from the stash list |
+| `clean -fdx` | `git clean -nd` first | Dry run lists what would be deleted |
+| `branch -D` | `git branch -d` | Refuses when the branch has unmerged commits |
+
+### 3.4 Dry runs
 
 ```bash
-# Remove a single file from all history
-git filter-repo --path .env --invert-paths
-
-# Remove multiple files
-git filter-repo --path .env --path credentials.json --path secrets.yml --invert-paths
-
-# Remove by pattern
-git filter-repo --path-glob '*.env' --invert-paths
-git filter-repo --path-glob '*.pem' --invert-paths
-```
-
-**Step 3: Alternative - BFG Repo Cleaner**
-
-```bash
-# Remove specific file
-bfg --delete-files .env
-
-# Remove files matching pattern
-bfg --delete-files '*.pem'
-
-# Remove files containing secrets (by content)
-bfg --replace-text passwords.txt  # File containing patterns to remove
-```
-
-**Step 4: Clean up and force push**
-
-```bash
-# Expire old references
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-
-# Force push to remote (DESTRUCTIVE - requires --force)
-# WARNING: This rewrites history for ALL collaborators
-git push origin --force --all
-git push origin --force --tags
-```
-
-**Step 5: Notify team**
-All collaborators must:
-
-```bash
-# Delete local repo and re-clone
-rm -rf local-repo
-git clone <remote-url>
-
-# OR rebase on new history (advanced)
-git fetch origin
-git rebase origin/main
-```
-
-### Post-Clean Verification
-
-```bash
-# Verify file is gone from all history
-git log --all --full-history -- .env
-# Should return empty
-
-# Verify content is gone
-git log -p --all -S 'YOUR_SECRET_VALUE' --source
-# Should return empty
+git clean -nd                          # list what clean would remove
+git push --force-with-lease --dry-run  # show refs that would move
+git filter-repo --path .env --invert-paths --dry-run
 ```
 
 ---
 
-## 3. PREVENT - Set Up Protection
+## 4. Prevention Setup
 
-### Update .gitignore
+### 4.1 `.gitignore` template
 
 ```gitignore
 # Environment files
@@ -315,59 +262,52 @@ Thumbs.db
 .vscode/settings.json
 ```
 
-### Set Up Pre-commit Hook
+### 4.2 Pre-commit hook
 
 Create `.git/hooks/pre-commit`:
 
 ```bash
 #!/bin/bash
-# Pre-commit hook to prevent committing sensitive files
+# Block sensitive files and secret-shaped values from entering a commit.
 
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-# Files that should never be committed
 FORBIDDEN_FILES=(
-  ".env"
-  "credentials.json"
-  "secrets.yml"
-  "secrets.json"
-  "*.pem"
-  "*.key"
+  "(^|/)\.env($|\.)"
+  "credentials\.json"
+  "service-account.*\.json"
+  "secrets\.(yml|json)"
+  "\.(pem|key|p12|pfx)$"
   "id_rsa"
-  ".npmrc"
+  "^\.npmrc$"
 )
 
-# Patterns that indicate secrets in file content
 SECRET_PATTERNS=(
-  "PRIVATE KEY"
-  "api_key.*=.*['\"][a-zA-Z0-9]"
-  "apiKey.*:.*['\"][a-zA-Z0-9]"
-  "password.*=.*['\"][^'\"]+['\"]"
-  "secret.*=.*['\"][a-zA-Z0-9]"
-  "AWS_SECRET"
-  "ANTHROPIC_API_KEY"
-  "OPENAI_API_KEY"
+  "BEGIN (RSA|EC|OPENSSH|PGP)? ?PRIVATE KEY"
+  "(api[_-]?key|apikey)[^a-z]{0,4}[=:][^=:]{8,}"
+  "(secret[_-]?key|client[_-]?secret)[^a-z]{0,4}[=:][^=:]{8,}"
+  "password[^a-z]{0,4}[=:]['\"][^'\"]{6,}['\"]"
+  "AKIA[0-9A-Z]{16}"
+  "gh[pousr]_[A-Za-z0-9]{36}"
 )
 
 ERRORS=0
 
-# Check for forbidden files
 for pattern in "${FORBIDDEN_FILES[@]}"; do
   files=$(git diff --cached --name-only | grep -E "$pattern" || true)
   if [ -n "$files" ]; then
-    echo -e "${RED}ERROR: Attempting to commit forbidden file matching '$pattern':${NC}"
+    echo -e "${RED}BLOCKED: forbidden file matching '$pattern':${NC}"
     echo "$files"
     ERRORS=$((ERRORS + 1))
   fi
 done
 
-# Check for secret patterns in staged content
 for pattern in "${SECRET_PATTERNS[@]}"; do
   matches=$(git diff --cached -U0 | grep -E "^\+" | grep -iE "$pattern" || true)
   if [ -n "$matches" ]; then
-    echo -e "${YELLOW}WARNING: Possible secret detected matching '$pattern':${NC}"
+    echo -e "${YELLOW}BLOCKED: possible secret matching '$pattern':${NC}"
     echo "$matches" | head -5
     ERRORS=$((ERRORS + 1))
   fi
@@ -375,86 +315,229 @@ done
 
 if [ $ERRORS -gt 0 ]; then
   echo ""
-  echo -e "${RED}Commit blocked due to potential secrets.${NC}"
-  echo "If this is a false positive, use: git commit --no-verify"
-  echo "But first, verify these files don't contain real secrets!"
+  echo -e "${RED}Commit blocked. Rotate anything real before retrying.${NC}"
+  echo "False positive? Confirm the value is fake, then: git commit --no-verify"
   exit 1
 fi
 
 exit 0
 ```
 
-Make executable:
+Make it executable and prove it bites:
 
 ```bash
 chmod +x .git/hooks/pre-commit
+
+# Verification: this must be rejected
+printf 'API_KEY=abcd1234efgh5678\n' > .env.hooktest
+git add -f .env.hooktest && git commit -m "hook test"   # expect: BLOCKED
+git reset && rm .env.hooktest
 ```
 
-### Set Up git-secrets (Optional - AWS)
+### 4.3 Shared hooks via pre-commit framework
+
+`.git/hooks/` is not committed, so teammates get nothing. Use a tracked config:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+```
 
 ```bash
-# Install git-secrets
-brew install git-secrets
+pip install pre-commit
+pre-commit install
+```
 
-# Set up for AWS patterns
+### 4.4 `git secrets`
+
+```bash
+brew install git-secrets
 git secrets --install
 git secrets --register-aws
-
-# Add custom patterns
 git secrets --add 'ANTHROPIC_API_KEY.*=.*sk-ant-'
 git secrets --add 'OPENAI_API_KEY.*=.*sk-'
 ```
 
-### Create .env.example Template
+### 4.5 `.env.example` template
 
 ```bash
-# .env.example - Safe template for environment variables
-# Copy to .env and fill in your values
-# NEVER commit .env files!
+# .env.example — safe template. Copy to .env and fill in real values.
+# .env itself is ignored and must never be staged.
 
-# API Keys
 ANTHROPIC_API_KEY=your_key_here
 OPENAI_API_KEY=your_key_here
-
-# Database
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DBNAME
-
-# Auth
+DATABASE_URL=postgresql:"//"USER:PASSWORD@HOST:5432/DBNAME
 JWT_SECRET=generate_a_secure_random_string
 SESSION_SECRET=generate_another_secure_string
 ```
 
+### 4.6 Server-side backstops
+
+- **GitHub** — enable secret scanning and push protection in repository
+  settings; store CI values in Actions secrets.
+- **GitLab** — enable the Secret Detection CI/CD component; use CI/CD variables.
+- **Vercel / Netlify** — set environment variables in the dashboard, never in
+  the repository.
+
+Push protection rejects the push before the value reaches the remote, which is
+the only control that prevents exposure rather than reacting to it.
+
+### 4.7 CI secret scanning
+
+A hook only runs on machines that installed it. CI catches what slipped past —
+including commits pushed with `--no-verify`.
+
+```yaml
+# .github/workflows/secret-scan.yml
+name: Secret Scan
+on: [push, pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history, or the scan sees one commit
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+```yaml
+# .gitlab-ci.yml
+include:
+  - template: Jobs/Secret-Detection.gitlab-ci.yml
+
+secret_detection:
+  variables:
+    SECRET_DETECTION_HISTORIC_SCAN: "true"
+```
+
+`fetch-depth: 0` is the line that matters. A shallow checkout scans only the tip
+commit and reports clean on a repository full of leaked keys.
+
 ---
 
-## Handling Specific Platforms
+## 5. History Rewrite (post-rotation only)
 
-### GitHub
+Rewriting is cleanup. The credential must already be rotated.
 
-- Enable secret scanning in repository settings
-- Use GitHub Actions secrets for CI/CD
-- Consider using GitHub's push protection
+### 5.1 Prerequisites
 
-### GitLab
+```bash
+which git-filter-repo || pip install git-filter-repo   # or: brew install git-filter-repo
+which bfg            || brew install bfg               # Java alternative
+```
 
-- Enable Secret Detection CI/CD component
-- Use CI/CD variables for secrets
+Before starting: every collaborator has pushed, a mirror backup exists, and the
+operator has confirmed the force-push.
 
-### Vercel/Netlify
+### 5.2 git-filter-repo
 
-- Use environment variables in dashboard
-- Never commit production secrets
+```bash
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# Remove one path from every commit
+git filter-repo --path .env --invert-paths
+
+# Several paths
+git filter-repo --path .env --path credentials.json --path secrets.yml --invert-paths
+
+# By glob
+git filter-repo --path-glob '*.pem' --invert-paths
+
+# Redact a value while keeping the file
+git filter-repo --replace-text expressions.txt
+# expressions.txt:
+#   literal:<the-rotated-value>==>[REDACTED]
+#   regex:AKIA[0-9A-Z]{16}==>[REDACTED_AWS_KEY]
+```
+
+### 5.3 BFG alternative
+
+```bash
+bfg --delete-files .env
+bfg --delete-files '*.pem'
+bfg --replace-text passwords.txt
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+```
+
+### 5.4 Force-push and verify
+
+```bash
+git push origin --force --all
+git push origin --force --tags
+
+git log --all --full-history -- .env       # expect empty
+git log -p --all -S '<rotated-value>'      # expect empty
+```
+
+### 5.5 Collaborator recovery
+
+```bash
+# Safest
+rm -rf <clone> && git clone <remote-url>
+
+# Advanced, for a clean local branch only
+git fetch origin && git rebase origin/main
+```
+
+Open pull requests and forks keep the old history. Close and reopen PRs from
+re-cloned branches; ask fork owners to delete or re-fork.
 
 ---
 
-## Emergency Response Checklist
+## 6. Emergency Response Checklist
 
-If you've leaked credentials:
+Within minutes:
 
-1. **IMMEDIATELY rotate the credential** (this is the only real fix)
-2. Check access logs for unauthorized usage
-3. Run `/git-safety clean` to remove from history
-4. Force push the cleaned history
-5. Notify affected team members to re-clone
-6. Update .gitignore to prevent recurrence
-7. Set up pre-commit hooks
-8. Document the incident
+- [ ] Rotate the credential at the issuing provider
+- [ ] Confirm the old value is rejected
+- [ ] Revoke active sessions or tokens derived from it
+
+Within hours:
+
+- [ ] Read provider access logs for use of the old value
+- [ ] Identify every ref, fork, and CI log holding the value
+- [ ] Check whether the repository is public or was ever public
+
+Within a day:
+
+- [ ] Rewrite history (section 5)
+- [ ] Force-push through the operation gate
+- [ ] Notify collaborators to re-clone
+- [ ] Install ignore rules and hooks (section 4)
+- [ ] Record what leaked, when, how, and what was rotated
+
+---
+
+## 7. Quick Reference
+
+```bash
+# === STAGED GUARD ===
+git diff --cached --name-only
+git diff --cached -U0 | grep -E '^\+' | grep -iE '(api[_-]?key|password|secret|token)[^a-z]{0,4}[=:]'
+
+# === OPERATION GUARD ===
+git clean -nd                                    # dry run
+git stash push --include-untracked               # before reset --hard
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# === PREVENTION ===
+chmod +x .git/hooks/pre-commit
+pre-commit install
+git secrets --install && git secrets --register-aws
+
+# === REWRITE (post-rotation) ===
+git filter-repo --path .env --invert-paths
+git push origin --force --all
+```
+
+For the pre-publication audit of a whole repository — license, attribution,
+full-history secret sweep, internal hostnames and employee references — use the
+`open-source-checker` skill instead.

--- a/bundles/security/skills/git-safety/SKILL.md
+++ b/bundles/security/skills/git-safety/SKILL.md
@@ -1,128 +1,189 @@
 ---
 name: git-safety
 description: >-
-  Scans, cleans, and prevents secrets in git history across four modes: scan
-  (detect sensitive files in the current state and history), clean (rewrite
-  history to remove secrets using git-filter-repo or BFG), prevent (add
-  .gitignore and pre-commit hooks), and full (all three in sequence). Use when
-  the user asks to check for leaked credentials, scrub a secret from git
-  history, force-push a cleaned repo, set up pre-commit secret prevention, or
-  run a full git security audit.
+  Guards day-to-day git work in an existing repository: blocks secrets from
+  entering a commit, gates destructive git operations before they run, installs
+  ignore rules and pre-commit hooks, and drives the rotate-first response when a
+  credential has already leaked.
 metadata:
-  version: "1.0.0"
-  tags: "git, security, secrets"
+  version: "1.1.0"
+  tags: "git, security, secrets, pre-commit"
+when_to_use: "about to commit, check what is staged, staged secret, pre-commit hook, pre-push check, force push, push --force, reset --hard, clean -fdx, rewrite git history, filter-repo, BFG, scrub a leaked credential, rotate a leaked key, git safety check"
 disable-model-invocation: true
 ---
 
-# Git Safety Skill
+# Git Safety
+
+Two guards, one repository you already work in every day:
+
+- **Staged guard** — nothing sensitive enters the next commit.
+- **Operation guard** — no destructive git command runs unconfirmed and unbacked.
+
+Both are recurring. They run at commit time and at push time, on every branch,
+forever. A one-time audit of a whole repository before it goes public is a
+different moment — see [Related](#related).
 
 ## Contract
 
 Inputs:
 
 - Repository root
-- Mode: scan, prevent, clean, or full
-- Optional leaked path, secret pattern, or affected ref range
+- Mode: `scan`, `guard`, `prevent`, `clean`, or `full`
+- For `clean`: the leaked path or secret string, and the refs it touches
 
 Outputs:
 
-- Sensitive file/history findings
-- Rotation and remediation checklist
-- Commands required for prevention or history cleanup
+- Staged findings with a block/allow verdict per file
+- Destructive-operation risk assessment and backup command
+- Rotation checklist for anything already pushed
 
 Creates/Modifies:
 
-- Scan mode: no file changes
-- Prevent mode: `.gitignore` and optional hook updates
-- Clean mode: rewritten git history only after explicit confirmation
+- `scan` and `guard`: no file changes
+- `prevent`: `.gitignore`, `.env.example`, and hook files
+- `clean`: rewritten git history, only after explicit confirmation
 
 External Side Effects:
 
-- May force-push rewritten history in clean mode
-- May require credential rotation outside the repository
+- May force-push rewritten history in `clean` mode
+- Requires credential rotation on systems outside the repository
 
 Confirmation Required:
 
-- Before history rewriting
-- Before force-pushing
-- Before changing hooks or ignore rules in shared repos
+- Before rewriting history
+- Before force-pushing or any push that discards remote commits
+- Before `reset --hard`, `clean -fdx`, or branch/tag deletion
+- Before changing hooks or ignore rules in a shared repository
 
 Delegates To:
 
+- `open-source-checker` before publishing a private repository
 - `security-audit` for broader application-security review
-- `open-source-checker` before publishing a private repo
 
-## CRITICAL WARNING
+## Rotate first
 
-**Removing secrets from git history does NOT make them safe!**
+Removing a secret from git history does **not** make it safe. Once pushed:
 
-Even after cleaning git history:
+- Bots scrape new pushes within seconds
+- Archive and mirror services may hold snapshots
+- Forks keep the original history
+- CI/CD logs may hold the value
 
-- GitHub is scraped by bots within seconds of a push
-- Archive services may have captured snapshots
-- Forks retain the original history
-- CI/CD logs may contain the values
+Rotate the credential at its source before touching history. History rewriting
+is cleanup, never containment. The bound: the old value is rejected by the
+issuing system.
 
-**ALWAYS rotate leaked credentials immediately.** Cleaning history is NOT enough.
+## Modes
 
-## Modes of Operation
+| Mode | Moment | Ends when |
+|------|--------|-----------|
+| `scan` | Before committing | Every staged file and added line is cleared or flagged |
+| `guard` | Before a destructive command | Blast radius stated, backup made, operator confirmed |
+| `prevent` | Once per repo, then on drift | Ignore rules and hook block a known-bad test commit |
+| `clean` | After a confirmed leak, post-rotation | Secret absent from every ref, collaborators notified |
+| `full` | New repo onboarding | `scan` → `prevent` complete |
 
-### 1. `/git-safety scan` - Detect Sensitive Files
+### `scan` — staged guard
 
-Scan repository for sensitive files in current state and git history.
-
-### 2. `/git-safety clean` - Remove from History
-
-Remove sensitive files using git-filter-repo or BFG.
-
-### 3. `/git-safety prevent` - Set Up Prevention
-
-Configure .gitignore and pre-commit hooks.
-
-### 4. `/git-safety full` - Complete Audit
-
-Run all three operations in sequence.
-
-## Sensitive File Patterns
-
-```
-.env, .env.*, credentials.json, service-account*.json
-*.pem, *.key, id_rsa*, secrets.*, .npmrc, *.secret
-```
-
-## Quick Commands
-
-**Scan for sensitive files in history:**
+Scope is the working tree and the staged diff, not history.
 
 ```bash
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -iE 'env|secret|credential|key'
+# Files about to be committed
+git diff --cached --name-only
+
+# Sensitive filenames among them
+git diff --cached --name-only | grep -iE '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|secret)$|credentials|service-account|id_rsa|id_ed25519|\.npmrc$|kubeconfig'
+
+# Secret-shaped values in added lines only
+git diff --cached -U0 | grep -E '^\+' | grep -iE '(api[_-]?key|secret[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|password)[^a-z]{0,4}[=:][^=:]{8,}'
+
+# Untracked files sitting in the tree that must never be added
+git status --porcelain --untracked-files=all | grep -E '^\?\?' | grep -iE '\.env|\.pem$|\.key$|credentials|secrets\.'
 ```
 
-**Remove .env from all history:**
+Verdict per finding: **block** (real credential), **allow** (placeholder,
+fixture, or example), or **ask** when the value cannot be classified from the
+diff alone. Report the file and line for each block. Ends when every staged path
+carries a verdict.
+
+### `guard` — destructive operation gate
+
+Any of these rewrites or discards work that git cannot recover for a
+collaborator:
+
+| Command | Discards |
+|---------|----------|
+| `git push --force` / `--force-with-lease` | Remote commits others may hold |
+| `git filter-repo`, `bfg` | Every commit hash in the repository |
+| `git reset --hard` | Uncommitted work in the tree and index |
+| `git clean -fdx` | Untracked files, including local `.env` |
+| `git checkout -- <path>` | Uncommitted edits to that path |
+| `git branch -D`, `git push origin --delete` | Unmerged commits on that ref |
+| `git rebase` on a pushed branch | Published commits under collaborators |
+
+Before running one:
+
+1. **State the blast radius** — which refs change, whose clones break, what is
+   unrecoverable.
+2. **Back up** — `git clone --mirror . ../repo-backup-$(date +%Y%m%d)` for any
+   history rewrite; `git stash -u` before a `reset --hard` or `clean -fdx`.
+3. **Prefer the reversible form** — `--force-with-lease` over `--force`,
+   `git revert` over `reset --hard` on a pushed branch, `git stash` over
+   `checkout --`.
+4. **Confirm with the operator**, quoting the exact command.
+
+Ends when the operator confirms against a stated blast radius, or the reversible
+alternative is used instead.
+
+### `prevent` — make the guard automatic
+
+Add the ignore rules, write the pre-commit hook, and create `.env.example`.
+Patterns, the full hook script, and `git secrets` setup are in
+`references/full-guide.md`.
+
+Ends when a deliberate test commit of a dummy `.env` is rejected by the hook.
+
+### `clean` — rewrite history after a leak
+
+Runs only after rotation is confirmed, and only inside the `guard` gate above.
 
 ```bash
-git filter-repo --path .env --invert-paths --force
-git push origin --force --all
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+git filter-repo --path .env --invert-paths
+git push origin --force --all && git push origin --force --tags
 ```
 
-**Add to .gitignore:**
+Verify:
 
 ```bash
-echo -e "\n.env\n.env.*\n*.pem\n*.key\ncredentials.json" >> .gitignore
+git log --all --full-history -- .env     # empty
+git log -p --all -S '<rotated-value>'    # empty
 ```
 
-## Emergency Response
+Ends when both verifications return empty and every collaborator has re-cloned.
 
-If you've leaked credentials:
+## Emergency response
 
-1. **IMMEDIATELY rotate the credential**
-2. Check access logs
-3. Run `/git-safety clean`
-4. Force push cleaned history
-5. Notify team to re-clone
-6. Update .gitignore
-7. Set up pre-commit hooks
+A credential is in a pushed commit:
+
+1. Rotate the credential. Nothing else counts until this is done.
+2. Check the provider's access logs for use of the old value.
+3. Run `clean` to strip it from history.
+4. Force-push through the `guard` gate.
+5. Tell collaborators to re-clone; forks and open PRs keep the old history.
+6. Run `prevent` so the same file cannot be staged again.
+7. Write down what leaked, when, and what was rotated.
+
+## Related
+
+- `open-source-checker` — the one-time audit before a private repository is
+  published: license and attribution, secrets across the entire history,
+  internal hostnames and employee references. Run it once, at the publish
+  decision; run `git-safety` at every commit thereafter.
+- `security-audit` — application-level vulnerability review, not git state.
 
 ---
 
-**For complete scan commands, cleaning process with git-filter-repo/BFG, pre-commit hook setup, .gitignore templates, platform-specific guidance, and detailed emergency checklist, see:** `references/full-guide.md`
+**Full sensitive-file patterns, the complete pre-commit hook script, `.gitignore`
+template, `git secrets` setup, BFG alternative, and platform notes:**
+`references/full-guide.md`

--- a/bundles/security/skills/git-safety/plugin.json
+++ b/bundles/security/skills/git-safety/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-safety",
-  "version": "1.0.0",
-  "description": "Scan, clean, and prevent secrets in git history and repository state.",
+  "version": "1.1.0",
+  "description": "Block secrets from entering a commit and gate destructive git operations.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/security/skills/git-safety/references/full-guide.md
+++ b/bundles/security/skills/git-safety/references/full-guide.md
@@ -1,10 +1,20 @@
-# Git Safety - Full Guide
+# Git Safety — Full Guide
 
-## 1. SCAN - Detect Sensitive Files
+Reference material for the two recurring guards: what must never enter a commit,
+and what must never run without confirmation.
 
-### Sensitive File Patterns
+Scope note: this guide covers the **ongoing** moment — commit time, push time,
+and leak response in a repository you already work in. The one-time audit of a
+whole repository before publication (license, attribution, full-history sweep,
+internal references) belongs to the `open-source-checker` skill.
 
-```bash
+---
+
+## 1. Sensitive File Patterns
+
+Filenames that should never be staged:
+
+```
 # Environment files
 .env
 .env.*
@@ -28,12 +38,10 @@ id_ecdsa*
 .aws/config
 .gcp/credentials.json
 .azure/credentials
+kubeconfig
+.kube/config
 
-# Database
-*.sql (check for passwords)
-database.yml (check for passwords)
-
-# API/Secret files
+# API/secret files
 secrets.yml
 secrets.json
 *.secret
@@ -41,217 +49,156 @@ api_keys.*
 auth.json
 
 # Package manager tokens
-.npmrc (with auth tokens)
+.npmrc
 .pypirc
 .gem/credentials
+.docker/config.json
 
 # Other
-*.log (may contain secrets)
 .htpasswd
 .netrc
-.docker/config.json
-kubeconfig
+*.log          # may contain secrets
+*.sql          # may contain passwords or production data
+database.yml   # may contain passwords
 ```
 
-### Scan Commands
+Allowlist the safe siblings explicitly: `.env.example`, `.env.template`,
+`schema.sql`, `migrations/*.sql`.
 
-**Step 1: Check current working directory**
+---
+
+## 2. Staged Guard Commands
+
+### 2.1 What is about to be committed
 
 ```bash
-# List potentially sensitive files in current state
-find . -type f \( \
-  -name ".env" -o \
-  -name ".env.*" -o \
-  -name "*.env" -o \
-  -name "credentials.json" -o \
-  -name "service-account*.json" -o \
-  -name "*.pem" -o \
-  -name "*.key" -o \
-  -name "id_rsa*" -o \
-  -name "secrets.*" -o \
-  -name ".npmrc" -o \
-  -name "*.secret" \
-\) 2>/dev/null | grep -v node_modules | grep -v .git
+# Names only
+git diff --cached --name-only
+
+# With status letters (A/M/D)
+git diff --cached --name-status
+
+# Full added content, no context lines
+git diff --cached -U0
 ```
 
-**Step 2: Check git history for sensitive files**
+### 2.2 Sensitive filenames in the staged set
 
 ```bash
-# Search all commits for sensitive filenames
-git log --all --full-history --diff-filter=A -- \
-  "*.env" ".env" ".env.*" \
-  "credentials.json" "service-account*.json" \
-  "*.pem" "*.key" "id_rsa*" \
-  "secrets.*" ".npmrc" "*.secret" \
-  --name-only --pretty=format:"%h %s" 2>/dev/null
-
-# Alternative: List all files ever committed
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -E '\.(env|pem|key|secret)$|credentials|secrets\.|id_rsa'
+git diff --cached --name-only | grep -iE \
+  '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|secret)$|credentials|service-account|id_rsa|id_ed25519|\.npmrc$|kubeconfig'
 ```
 
-**Step 3: Search for secrets in file contents**
+### 2.3 Secret-shaped values in added lines
+
+Scan only lines the commit adds — existing lines are history's problem, not this
+commit's.
 
 ```bash
-# Search for common secret patterns in tracked files
-git grep -E "(api[_-]?key|apikey|secret[_-]?key|password|passwd|pwd|token|auth[_-]?token|access[_-]?token|private[_-]?key|client[_-]?secret)" --cached -- ':!*.lock' ':!package-lock.json' ':!yarn.lock' 2>/dev/null | head -50
+# Generic assignment shapes
+git diff --cached -U0 | grep -E '^\+' | grep -iE \
+  '(api[_-]?key|apikey|secret[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|password|passwd)[^a-z]{0,4}[=:][^=:]{8,}'
 
-# Search git history for secret patterns (expensive but thorough)
-git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock' 2>/dev/null | head -100
+# Private key material
+git diff --cached -U0 | grep -E '^\+' | grep -E 'BEGIN (RSA|EC|OPENSSH|PGP)? ?PRIVATE KEY'
+
+# Vendor key prefixes (extend for the providers you use)
+git diff --cached -U0 | grep -E '^\+' | grep -E \
+  'AKIA[0-9A-Z]{16}|gh[pousr]_[A-Za-z0-9]{36}|xox[baprs]-[0-9A-Za-z-]{10,}|AIza[0-9A-Za-z_-]{35}'
+
+# Credentials embedded in a connection URI (scheme split so this file does not
+# itself contain a URI-shaped literal that trips downstream secret scanners)
+git diff --cached -U0 | grep -E '^\+' | grep -E '[a-z]+:'"//"'[^:@/]+:[^:@/]+@'
 ```
 
-**Step 4: Check .gitignore coverage**
+### 2.4 Untracked files sitting in the tree
+
+Not staged today, easy to `git add -A` tomorrow:
 
 ```bash
-# Verify sensitive patterns are in .gitignore
+git status --porcelain --untracked-files=all \
+  | grep -E '^\?\?' \
+  | grep -iE '\.env|\.pem$|\.key$|credentials|secrets\.'
+```
+
+### 2.5 Ignore-rule coverage
+
+```bash
 for pattern in ".env" ".env.*" "*.pem" "*.key" "credentials.json" "secrets.*"; do
-  if ! grep -q "$pattern" .gitignore 2>/dev/null; then
-    echo "Missing from .gitignore: $pattern"
-  fi
+  grep -q -- "$pattern" .gitignore 2>/dev/null || echo "Missing from .gitignore: $pattern"
 done
 ```
 
-### Scan Report Format
+### 2.6 Verdict format
 
 ```
-## Git Safety Scan Results
+## Staged Guard — <branch>, <n> files staged
 
-### Current Directory
-- [ ] No sensitive files found
-- [X] Found: .env.local (not tracked - OK)
-- [!] Found: credentials.json (TRACKED - DANGER)
+BLOCK  src/config.ts:42        live-looking API key in an added line
+BLOCK  credentials.json        forbidden filename, newly added
+ASK    tests/fixtures/key.pem  private key — confirm it is a throwaway test key
+ALLOW  .env.example            placeholder values only
 
-### Git History
-- [ ] No sensitive files in history
-- [!] Found in history: .env (commit abc1234, 2024-01-15)
-- [!] Found in history: api-keys.json (commit def5678, 2024-02-20)
+Untracked but present: .env.local (ignored — OK)
+.gitignore gaps: *.pem, credentials.json
 
-### Secret Patterns in Code
-- [ ] No hardcoded secrets detected
-- [!] Possible API key in: src/config.ts:42
-
-### .gitignore Coverage
-- [X] .env patterns covered
-- [ ] Missing: *.pem
-- [ ] Missing: credentials.json
-
-### Recommendations
-1. [URGENT] Rotate any exposed credentials immediately
-2. Run `/git-safety clean` to remove files from history
-3. Run `/git-safety prevent` to update .gitignore
+Next: unstage the two BLOCK paths, then rerun.
 ```
 
 ---
 
-## 2. CLEAN - Remove from Git History
+## 3. Destructive Operation Gate
 
-### Prerequisites Check
+### 3.1 Blast radius by command
 
-```bash
-# Check if git-filter-repo is installed (preferred)
-which git-filter-repo
+| Command | Rewrites | Discards | Recoverable via |
+|---------|----------|----------|-----------------|
+| `git push --force` | Remote refs | Remote commits others hold | Their local reflog only |
+| `git push --force-with-lease` | Remote refs | Same, but aborts on unseen updates | Preferred form |
+| `git filter-repo` / `bfg` | All commit hashes | Nothing, if mirrored first | Mirror backup |
+| `git reset --hard` | Index and tree | Uncommitted work | `git stash` beforehand |
+| `git clean -fdx` | Tree | Untracked files, local `.env` | Nothing |
+| `git checkout -- <path>` | Tree | Uncommitted edits to that path | Nothing |
+| `git branch -D` | Local ref | Unmerged commits | Local reflog, ~90 days |
+| `git push origin --delete` | Remote ref | Unmerged commits on the remote | Nothing reliable |
+| `git rebase` on a pushed branch | Local history | Published commit identity | Force-push follows |
 
-# Check if BFG is available (alternative)
-which bfg
-```
-
-### Installation (if needed)
-
-```bash
-# Install git-filter-repo (recommended)
-pip install git-filter-repo
-
-# Or via Homebrew on macOS
-brew install git-filter-repo
-
-# BFG alternative (Java required)
-brew install bfg
-```
-
-### Cleaning Process
-
-**IMPORTANT: Before cleaning, ensure:**
-
-1. All team members have pushed their changes
-2. You have a backup of the repository
-3. You understand this rewrites history (force push required)
-
-**Step 1: Create backup**
+### 3.2 Backup commands
 
 ```bash
-# Clone a backup
+# Before any history rewrite
 git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# Before reset --hard or clean -fdx
+git stash push --include-untracked -m "pre-destructive-op $(date +%FT%T)"
+
+# Before deleting a branch, keep a pointer
+git tag archive/<branch-name> <branch-name>
 ```
 
-**Step 2: Remove specific files with git-filter-repo**
+### 3.3 Reversible alternatives
+
+| Instead of | Use | Why |
+|-----------|-----|-----|
+| `push --force` | `push --force-with-lease` | Aborts if the remote moved since your last fetch |
+| `reset --hard` on a pushed branch | `git revert <sha>` | Adds a commit; collaborators keep their history |
+| `checkout -- <path>` | `git stash push <path>` | Recoverable from the stash list |
+| `clean -fdx` | `git clean -nd` first | Dry run lists what would be deleted |
+| `branch -D` | `git branch -d` | Refuses when the branch has unmerged commits |
+
+### 3.4 Dry runs
 
 ```bash
-# Remove a single file from all history
-git filter-repo --path .env --invert-paths
-
-# Remove multiple files
-git filter-repo --path .env --path credentials.json --path secrets.yml --invert-paths
-
-# Remove by pattern
-git filter-repo --path-glob '*.env' --invert-paths
-git filter-repo --path-glob '*.pem' --invert-paths
-```
-
-**Step 3: Alternative - BFG Repo Cleaner**
-
-```bash
-# Remove specific file
-bfg --delete-files .env
-
-# Remove files matching pattern
-bfg --delete-files '*.pem'
-
-# Remove files containing secrets (by content)
-bfg --replace-text passwords.txt  # File containing patterns to remove
-```
-
-**Step 4: Clean up and force push**
-
-```bash
-# Expire old references
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-
-# Force push to remote (DESTRUCTIVE - requires --force)
-# WARNING: This rewrites history for ALL collaborators
-git push origin --force --all
-git push origin --force --tags
-```
-
-**Step 5: Notify team**
-All collaborators must:
-
-```bash
-# Delete local repo and re-clone
-rm -rf local-repo
-git clone <remote-url>
-
-# OR rebase on new history (advanced)
-git fetch origin
-git rebase origin/main
-```
-
-### Post-Clean Verification
-
-```bash
-# Verify file is gone from all history
-git log --all --full-history -- .env
-# Should return empty
-
-# Verify content is gone
-git log -p --all -S 'YOUR_SECRET_VALUE' --source
-# Should return empty
+git clean -nd                          # list what clean would remove
+git push --force-with-lease --dry-run  # show refs that would move
+git filter-repo --path .env --invert-paths --dry-run
 ```
 
 ---
 
-## 3. PREVENT - Set Up Protection
+## 4. Prevention Setup
 
-### Update .gitignore
+### 4.1 `.gitignore` template
 
 ```gitignore
 # Environment files
@@ -315,59 +262,52 @@ Thumbs.db
 .vscode/settings.json
 ```
 
-### Set Up Pre-commit Hook
+### 4.2 Pre-commit hook
 
 Create `.git/hooks/pre-commit`:
 
 ```bash
 #!/bin/bash
-# Pre-commit hook to prevent committing sensitive files
+# Block sensitive files and secret-shaped values from entering a commit.
 
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-# Files that should never be committed
 FORBIDDEN_FILES=(
-  ".env"
-  "credentials.json"
-  "secrets.yml"
-  "secrets.json"
-  "*.pem"
-  "*.key"
+  "(^|/)\.env($|\.)"
+  "credentials\.json"
+  "service-account.*\.json"
+  "secrets\.(yml|json)"
+  "\.(pem|key|p12|pfx)$"
   "id_rsa"
-  ".npmrc"
+  "^\.npmrc$"
 )
 
-# Patterns that indicate secrets in file content
 SECRET_PATTERNS=(
-  "PRIVATE KEY"
-  "api_key.*=.*['\"][a-zA-Z0-9]"
-  "apiKey.*:.*['\"][a-zA-Z0-9]"
-  "password.*=.*['\"][^'\"]+['\"]"
-  "secret.*=.*['\"][a-zA-Z0-9]"
-  "AWS_SECRET"
-  "ANTHROPIC_API_KEY"
-  "OPENAI_API_KEY"
+  "BEGIN (RSA|EC|OPENSSH|PGP)? ?PRIVATE KEY"
+  "(api[_-]?key|apikey)[^a-z]{0,4}[=:][^=:]{8,}"
+  "(secret[_-]?key|client[_-]?secret)[^a-z]{0,4}[=:][^=:]{8,}"
+  "password[^a-z]{0,4}[=:]['\"][^'\"]{6,}['\"]"
+  "AKIA[0-9A-Z]{16}"
+  "gh[pousr]_[A-Za-z0-9]{36}"
 )
 
 ERRORS=0
 
-# Check for forbidden files
 for pattern in "${FORBIDDEN_FILES[@]}"; do
   files=$(git diff --cached --name-only | grep -E "$pattern" || true)
   if [ -n "$files" ]; then
-    echo -e "${RED}ERROR: Attempting to commit forbidden file matching '$pattern':${NC}"
+    echo -e "${RED}BLOCKED: forbidden file matching '$pattern':${NC}"
     echo "$files"
     ERRORS=$((ERRORS + 1))
   fi
 done
 
-# Check for secret patterns in staged content
 for pattern in "${SECRET_PATTERNS[@]}"; do
   matches=$(git diff --cached -U0 | grep -E "^\+" | grep -iE "$pattern" || true)
   if [ -n "$matches" ]; then
-    echo -e "${YELLOW}WARNING: Possible secret detected matching '$pattern':${NC}"
+    echo -e "${YELLOW}BLOCKED: possible secret matching '$pattern':${NC}"
     echo "$matches" | head -5
     ERRORS=$((ERRORS + 1))
   fi
@@ -375,86 +315,229 @@ done
 
 if [ $ERRORS -gt 0 ]; then
   echo ""
-  echo -e "${RED}Commit blocked due to potential secrets.${NC}"
-  echo "If this is a false positive, use: git commit --no-verify"
-  echo "But first, verify these files don't contain real secrets!"
+  echo -e "${RED}Commit blocked. Rotate anything real before retrying.${NC}"
+  echo "False positive? Confirm the value is fake, then: git commit --no-verify"
   exit 1
 fi
 
 exit 0
 ```
 
-Make executable:
+Make it executable and prove it bites:
 
 ```bash
 chmod +x .git/hooks/pre-commit
+
+# Verification: this must be rejected
+printf 'API_KEY=abcd1234efgh5678\n' > .env.hooktest
+git add -f .env.hooktest && git commit -m "hook test"   # expect: BLOCKED
+git reset && rm .env.hooktest
 ```
 
-### Set Up git-secrets (Optional - AWS)
+### 4.3 Shared hooks via pre-commit framework
+
+`.git/hooks/` is not committed, so teammates get nothing. Use a tracked config:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+```
 
 ```bash
-# Install git-secrets
-brew install git-secrets
+pip install pre-commit
+pre-commit install
+```
 
-# Set up for AWS patterns
+### 4.4 `git secrets`
+
+```bash
+brew install git-secrets
 git secrets --install
 git secrets --register-aws
-
-# Add custom patterns
 git secrets --add 'ANTHROPIC_API_KEY.*=.*sk-ant-'
 git secrets --add 'OPENAI_API_KEY.*=.*sk-'
 ```
 
-### Create .env.example Template
+### 4.5 `.env.example` template
 
 ```bash
-# .env.example - Safe template for environment variables
-# Copy to .env and fill in your values
-# NEVER commit .env files!
+# .env.example — safe template. Copy to .env and fill in real values.
+# .env itself is ignored and must never be staged.
 
-# API Keys
 ANTHROPIC_API_KEY=your_key_here
 OPENAI_API_KEY=your_key_here
-
-# Database
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DBNAME
-
-# Auth
+DATABASE_URL=postgresql:"//"USER:PASSWORD@HOST:5432/DBNAME
 JWT_SECRET=generate_a_secure_random_string
 SESSION_SECRET=generate_another_secure_string
 ```
 
+### 4.6 Server-side backstops
+
+- **GitHub** — enable secret scanning and push protection in repository
+  settings; store CI values in Actions secrets.
+- **GitLab** — enable the Secret Detection CI/CD component; use CI/CD variables.
+- **Vercel / Netlify** — set environment variables in the dashboard, never in
+  the repository.
+
+Push protection rejects the push before the value reaches the remote, which is
+the only control that prevents exposure rather than reacting to it.
+
+### 4.7 CI secret scanning
+
+A hook only runs on machines that installed it. CI catches what slipped past —
+including commits pushed with `--no-verify`.
+
+```yaml
+# .github/workflows/secret-scan.yml
+name: Secret Scan
+on: [push, pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history, or the scan sees one commit
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+```yaml
+# .gitlab-ci.yml
+include:
+  - template: Jobs/Secret-Detection.gitlab-ci.yml
+
+secret_detection:
+  variables:
+    SECRET_DETECTION_HISTORIC_SCAN: "true"
+```
+
+`fetch-depth: 0` is the line that matters. A shallow checkout scans only the tip
+commit and reports clean on a repository full of leaked keys.
+
 ---
 
-## Handling Specific Platforms
+## 5. History Rewrite (post-rotation only)
 
-### GitHub
+Rewriting is cleanup. The credential must already be rotated.
 
-- Enable secret scanning in repository settings
-- Use GitHub Actions secrets for CI/CD
-- Consider using GitHub's push protection
+### 5.1 Prerequisites
 
-### GitLab
+```bash
+which git-filter-repo || pip install git-filter-repo   # or: brew install git-filter-repo
+which bfg            || brew install bfg               # Java alternative
+```
 
-- Enable Secret Detection CI/CD component
-- Use CI/CD variables for secrets
+Before starting: every collaborator has pushed, a mirror backup exists, and the
+operator has confirmed the force-push.
 
-### Vercel/Netlify
+### 5.2 git-filter-repo
 
-- Use environment variables in dashboard
-- Never commit production secrets
+```bash
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# Remove one path from every commit
+git filter-repo --path .env --invert-paths
+
+# Several paths
+git filter-repo --path .env --path credentials.json --path secrets.yml --invert-paths
+
+# By glob
+git filter-repo --path-glob '*.pem' --invert-paths
+
+# Redact a value while keeping the file
+git filter-repo --replace-text expressions.txt
+# expressions.txt:
+#   literal:<the-rotated-value>==>[REDACTED]
+#   regex:AKIA[0-9A-Z]{16}==>[REDACTED_AWS_KEY]
+```
+
+### 5.3 BFG alternative
+
+```bash
+bfg --delete-files .env
+bfg --delete-files '*.pem'
+bfg --replace-text passwords.txt
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+```
+
+### 5.4 Force-push and verify
+
+```bash
+git push origin --force --all
+git push origin --force --tags
+
+git log --all --full-history -- .env       # expect empty
+git log -p --all -S '<rotated-value>'      # expect empty
+```
+
+### 5.5 Collaborator recovery
+
+```bash
+# Safest
+rm -rf <clone> && git clone <remote-url>
+
+# Advanced, for a clean local branch only
+git fetch origin && git rebase origin/main
+```
+
+Open pull requests and forks keep the old history. Close and reopen PRs from
+re-cloned branches; ask fork owners to delete or re-fork.
 
 ---
 
-## Emergency Response Checklist
+## 6. Emergency Response Checklist
 
-If you've leaked credentials:
+Within minutes:
 
-1. **IMMEDIATELY rotate the credential** (this is the only real fix)
-2. Check access logs for unauthorized usage
-3. Run `/git-safety clean` to remove from history
-4. Force push the cleaned history
-5. Notify affected team members to re-clone
-6. Update .gitignore to prevent recurrence
-7. Set up pre-commit hooks
-8. Document the incident
+- [ ] Rotate the credential at the issuing provider
+- [ ] Confirm the old value is rejected
+- [ ] Revoke active sessions or tokens derived from it
+
+Within hours:
+
+- [ ] Read provider access logs for use of the old value
+- [ ] Identify every ref, fork, and CI log holding the value
+- [ ] Check whether the repository is public or was ever public
+
+Within a day:
+
+- [ ] Rewrite history (section 5)
+- [ ] Force-push through the operation gate
+- [ ] Notify collaborators to re-clone
+- [ ] Install ignore rules and hooks (section 4)
+- [ ] Record what leaked, when, how, and what was rotated
+
+---
+
+## 7. Quick Reference
+
+```bash
+# === STAGED GUARD ===
+git diff --cached --name-only
+git diff --cached -U0 | grep -E '^\+' | grep -iE '(api[_-]?key|password|secret|token)[^a-z]{0,4}[=:]'
+
+# === OPERATION GUARD ===
+git clean -nd                                    # dry run
+git stash push --include-untracked               # before reset --hard
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# === PREVENTION ===
+chmod +x .git/hooks/pre-commit
+pre-commit install
+git secrets --install && git secrets --register-aws
+
+# === REWRITE (post-rotation) ===
+git filter-repo --path .env --invert-paths
+git push origin --force --all
+```
+
+For the pre-publication audit of a whole repository — license, attribution,
+full-history secret sweep, internal hostnames and employee references — use the
+`open-source-checker` skill instead.

--- a/bundles/security/skills/open-source-checker/SKILL.md
+++ b/bundles/security/skills/open-source-checker/SKILL.md
@@ -1,54 +1,253 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
+description: >-
+  Audits a whole private repository once, at the decision to make it public.
+  Runs four passes — license and attribution, secrets across the entire git
+  history, private references (internal hostnames, employee emails, client and
+  customer names, staging URLs), and publication readiness — then returns a
+  publish or block verdict. Use when the user is preparing to open source a
+  repository, asks whether a codebase is safe to publish, wants a pre-release
+  audit before flipping a repo public, or needs to know what is still private in
+  code that is about to ship publicly.
 metadata:
-  version: "1.0.1"
-  tags: "open-source, security, secrets"
+  version: "1.1.0"
+  tags: "open-source, publishing, license, audit"
+when_to_use: "open source this repo, make this repository public, is this safe to publish, pre-release audit, what is private in this codebase, check licensing before publishing, going public with this code"
 ---
 
 # Open Source Checker
 
-## When to Use
+The publish gate. This runs **once**, on a repository that has lived its whole
+life private, at the moment someone proposes making it public. Everything in a
+private repo was written on the assumption nobody outside would read it —
+comments, hostnames, client names, and every commit ever made. This audit finds
+what that assumption left behind.
 
-Use when you're:
+Four passes, then a verdict. The recurring commit-time guard is a different
+skill — see [Related](#related).
 
-- Preparing to open source a repository
-- Reviewing code for exposed secrets
-- Auditing codebase for sensitive data
-- Performing security audits before public release
-- Setting up pre-commit hooks for secret detection
+## Contract
 
-## What to Check
+Inputs:
 
-### Critical Items
+- Repository root, with full history fetched (`git fetch --all --tags`)
+- Intended public license, if already chosen
+- Names to treat as private: company domains, client names, internal hostnames
 
-- API keys (OpenAI, Stripe, AWS, GitHub tokens)
-- Database credentials and connection strings
-- Private keys and certificates (`.pem`, `.key`)
-- Personal information (emails, phone numbers)
-- Environment files (`.env` should be gitignored)
+Outputs:
 
-### Git History (CRITICAL)
+- Per-pass findings with file, line or commit, and severity
+- A publish / block verdict with the blocking set enumerated
+- A rotation list and a history-rewrite list, handed to `git-safety`
 
-- Secrets remain in git history even after deletion
-- Must scan all branches, tags, and deleted files
-- Use `gitleaks`, `truffleHog`, or `git-secrets`
+Creates/Modifies:
 
-## Quick Workflow
+- Nothing. This audit is read-only.
 
-1. **File scan**: Check for secret files, patterns
-2. **Code analysis**: Search for hardcoded secrets
-3. **Git history**: Scan entire history with tools
-4. **Setup hooks**: Prevent future commits with secrets
-5. **Clean history**: Use `git-filter-repo` if needed
+External Side Effects:
 
-## Tools
+- None. Remediation is delegated, not performed here.
 
-- `gitleaks`: Best for git history scanning
-- `truffleHog`: Alternative history scanner
-- `git-secrets`: AWS-focused with pre-commit hooks
-- `detect-secrets`: Baseline-based detection
+Confirmation Required:
 
-## References
+- Before the repository is flipped public — the verdict is advice, the flip is
+  the owner's action
 
-- [Full guide: Patterns, scanning workflow, git hooks, cleanup](references/full-guide.md)
+Delegates To:
+
+- `git-safety` to rotate credentials, rewrite history, and install the ongoing
+  commit-time guard
+- `security-audit` for application-level vulnerability review
+
+## Preflight
+
+The audit is only as complete as the refs present locally.
+
+```bash
+git fetch --all --tags --prune
+git log --all --oneline | wc -l    # commits in scope
+git branch -a && git tag -l        # refs in scope
+git stash list                     # stashes are not in --all
+```
+
+Ends when every remote branch and tag is present locally.
+
+---
+
+## Pass 1 — License and attribution
+
+A private repo needs no license. A public one that ships without a clear one is
+legally unusable by anyone who finds it, and code borrowed under one license
+cannot always be re-published under another.
+
+Check:
+
+- **`LICENSE` file present** at the root, matching what the owner intends
+- **Dependency licenses compatible** with the intended outgoing license —
+  copyleft (GPL, AGPL) dependencies constrain a permissive release
+- **Vendored and copy-pasted code attributed** — snippets lifted from Stack
+  Overflow, blog posts, or another repo carry their origin's terms
+- **Copyright headers** consistent, and naming the right entity
+- **Employer ownership** settled if the code was written on company time
+
+```bash
+ls LICENSE* COPYING* 2>/dev/null
+bunx license-checker --summary                      # JS dependency licenses
+grep -rniE 'copyright|\(c\) [0-9]{4}|SPDX-License' --include='*.*' -l . | head -30
+grep -rniE 'adapted from|based on|taken from|source: http' --include='*.*' . | head -30
+```
+
+Ends when the outgoing license is named, every dependency license is compatible
+with it, and every borrowed block is attributed or removed.
+
+---
+
+## Pass 2 — Secrets in history
+
+Deleting a secret from the working tree leaves it in every commit that ever held
+it. Publishing the repo publishes those commits.
+
+Scan every ref, not just `HEAD`:
+
+```bash
+# Automated sweep across all history — start here
+gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+
+# Every file that ever existed
+git log --all --pretty=format: --name-only --diff-filter=A | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.|id_rsa'
+
+# Files deleted from the tree but alive in history
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials'
+
+# Content search across every commit
+git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock'
+git log -p --all -G 'AKIA[0-9A-Z]{16}' --source
+```
+
+Also sweep the places `--all` misses: stashes, merge commits, and every tag.
+Commands in `references/full-guide.md` §3.
+
+Every hit is a **rotation item first** and a history-rewrite item second.
+Cleaning history does not un-leak a credential that was ever pushed.
+
+Ends when gitleaks and truffleHog both return clean across full history, and
+every earlier hit has a confirmed rotation.
+
+---
+
+## Pass 3 — Private references
+
+The pass with no tooling, and the one that leaks the most. These are not
+credentials; they are facts about the company that only made sense inside it.
+
+| Category | What to look for |
+|----------|------------------|
+| Internal hosts | `*.internal`, `*.corp`, `*.local`, VPN hostnames, RFC1918 IPs |
+| Internal services | Jira/Linear ticket URLs, internal wikis, admin dashboards |
+| People | Employee emails, personal emails, names in TODO and FIXME comments |
+| Customers | Client names, logos, contract terms, customer data in fixtures |
+| Infrastructure | Account IDs, bucket names, cluster names, staging URLs |
+| Commercial | Pricing logic, unreleased product names, internal roadmap notes |
+| Commit metadata | Author emails on every commit — these become public too |
+
+```bash
+# Internal domains and hosts (substitute your own)
+grep -rniE '@(yourcompany|internal|corp)\.(com|net|local)' . | grep -v node_modules
+grep -rniE '\b(10|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]+\.[0-9]+\b' . | grep -v node_modules
+
+# People and intent left in comments
+grep -rniE '(TODO|FIXME|HACK|XXX|NOTE)[:( ].*(ask|per|@[a-z]+)' --include='*.*' . | head -40
+
+# Author identities that ship with the history
+git log --all --format='%ae' | sort -u
+git log --all --format='%an <%ae>' | sort -u | head -30
+```
+
+Judge each hit by one question: **would a stranger reading this learn something
+the company would not say publicly?** A staging URL is a finding. A public docs
+link is not.
+
+Ends when every category has been searched and each hit is redacted, replaced
+with a neutral placeholder, or explicitly accepted by the owner.
+
+---
+
+## Pass 4 — Publication readiness
+
+What a stranger finds in the first thirty seconds:
+
+- **README** written for an outsider — what it is, how to run it, no "ask the
+  team in #eng" instructions
+- **`.env.example`** present and complete, so setup is possible without internal
+  access
+- **Docs** free of links to internal wikis, dashboards, and runbooks
+- **Issue and PR templates** that do not route to internal processes
+- **CI config** referencing only secrets a fork could plausibly supply, and no
+  internal registry or runner
+- **Test fixtures** carrying synthetic data, not production exports
+- **Repository settings** — an existing `.github/` config may expose internal
+  team names in `CODEOWNERS`
+
+```bash
+ls README* .env.example .github/ 2>/dev/null
+grep -rniE 'internal|confidential|do not distribute|proprietary' README* docs/ 2>/dev/null
+cat .github/CODEOWNERS 2>/dev/null
+```
+
+Ends when a reader with no internal access can install, run, and contribute from
+what is in the repository.
+
+---
+
+## Verdict
+
+Report one of two outcomes. No middle state — "mostly clean" publishes secrets.
+
+**BLOCK** — enumerate every blocking finding:
+
+```
+BLOCK — 3 blockers
+
+License   No LICENSE file; two AGPL dependencies conflict with intended MIT
+History   AWS key in commit a1b2c3d (deleted in e4f5g6h, still in history)
+Private   Client name "Acme Corp" in 14 files and 3 commit messages
+
+Rotate now:      AWS key AKIA…  (leak precedes any rewrite)
+Then hand to:    git-safety clean — strip .env from all refs, force-push
+Re-run this audit after the rewrite; commit hashes will have changed.
+```
+
+**PUBLISH** — state what was verified, so the verdict is auditable:
+
+```
+PUBLISH
+
+License   MIT at root; 214 deps all permissive; 2 adapted blocks attributed
+History   gitleaks + truffleHog clean across 1,847 commits, 12 branches, 40 tags
+Private   No internal hosts, customer names, or employee emails outside git authorship
+Ready     README, .env.example, CI runs on a fork without internal secrets
+
+Note: 4 distinct author emails remain in commit history and will be public.
+Next: install the ongoing commit-time guard — git-safety prevent
+```
+
+A rewrite invalidates every commit hash in the findings, so re-run passes 2 and
+3 after `git-safety` finishes.
+
+## Related
+
+- `git-safety` — the recurring guard for a repository already in daily use:
+  blocks secrets from entering the next commit, gates force-pushes and history
+  rewrites, and installs ignore rules and pre-commit hooks. It also performs the
+  rotation and history rewrite this audit hands off. Run it at every commit;
+  run this audit once, at the publish decision.
+- `security-audit` — application-level vulnerability review of the code itself.
+
+---
+
+**Full credential-pattern catalog, all-refs history commands (stashes, merges,
+tags, branches), license-compatibility matrix, private-reference search recipes,
+and the report template:** `references/full-guide.md`

--- a/bundles/security/skills/open-source-checker/plugin.json
+++ b/bundles/security/skills/open-source-checker/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.1",
-  "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
+  "version": "1.1.0",
+  "description": "Audit a private repo before publishing: license, history secrets, private references.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/security/skills/open-source-checker/references/full-guide.md
+++ b/bundles/security/skills/open-source-checker/references/full-guide.md
@@ -1,1446 +1,537 @@
-# Open Source Security Checker - Full Guide
+# Open Source Checker — Full Guide
 
-Comprehensive guide for detecting and removing sensitive information from codebases before open sourcing.
+Reference material for the publish gate: the one-time audit of a private
+repository at the moment it is proposed for public release.
 
----
-
-## 1. What to Check
-
-### 1.1 API Keys and Tokens
-
-API keys are the most common leaked secret. Check for:
-
-- **OpenAI**: `sk-...` (48 characters)
-- **Anthropic**: `sk-ant-...`
-- **Stripe**: `sk_live_...`, `sk_test_...`, `pk_live_...`, `pk_test_...`
-- **AWS**: Access Key ID (`AKIA...`), Secret Access Key
-- **GitHub**: `ghp_...`, `gho_...`, `ghu_...`, `ghs_...`, `ghr_...`
-- **Google**: `AIza...` (39 characters)
-- **Slack**: `xoxb-...`, `xoxp-...`, `xoxa-...`
-- **Twilio**: Account SID (`AC...`), Auth Token
-- **SendGrid**: `SG....`
-- **Firebase**: Various patterns in config objects
-- **Vercel**: `vercel_...`
-- **npm**: `npm_...`
-
-### 1.2 Database Credentials
-
-- Connection strings with embedded passwords
-- MongoDB URIs: `mongodb+srv://USER:PASSWORD@HOST`
-- PostgreSQL: `postgresql://USER:PASSWORD@HOST:PORT/DB`
-- MySQL: `mysql://USER:PASSWORD@HOST:PORT/DB`
-- Redis: `redis://:PASSWORD@HOST:PORT`
-
-### 1.3 Private Keys and Certificates
-
-```
-# File extensions to check
-*.pem
-*.key
-*.p12
-*.pfx
-*.cer
-*.crt
-id_rsa
-id_rsa.pub
-id_ed25519
-id_ecdsa
-*.keystore
-*.jks
-```
-
-### 1.4 Personal Information
-
-- Email addresses (especially internal/company emails)
-- Phone numbers
-- Physical addresses
-- Names in comments (developer names, client names)
-- IP addresses (especially internal network IPs)
-- License keys
-
-### 1.5 Environment Files
-
-```
-.env
-.env.local
-.env.development
-.env.production
-.env.staging
-.env.test
-.envrc
-*.env
-.env.*
-```
-
-### 1.6 Configuration Files
-
-```
-# Cloud provider configs
-.aws/credentials
-.aws/config
-.gcp/credentials.json
-.azure/credentials
-kubeconfig
-.kube/config
-
-# Package manager auth
-.npmrc (with auth tokens)
-.yarnrc.yml (with auth)
-.pypirc
-.gem/credentials
-.docker/config.json
-
-# Application configs
-config/secrets.yml
-config/credentials.yml.enc
-database.yml (check for passwords)
-secrets.json
-api_keys.json
-auth.json
-```
-
-### 1.7 Code Comments
-
-Developers often leave sensitive information in comments:
-
-```bash
-# Search for common patterns in comments
-grep -rn "TODO.*password" --include="*.ts" --include="*.js"
-grep -rn "FIXME.*key" --include="*.ts" --include="*.js"
-grep -rn "// .*secret" --include="*.ts" --include="*.js"
-grep -rn "password.*=" --include="*.ts" --include="*.js"
-```
-
-### 1.8 Git History
-
-**CRITICAL**: Deleted files and previous commits still contain secrets.
-
-```bash
-# Files deleted from repo but in history
-git log --all --full-history --diff-filter=D -- "*.env" ".env" "secrets.*"
-
-# Commits that modified sensitive files
-git log --all --oneline -- "*.env" "*.pem" "*.key" "credentials.*"
-```
+Scope note: this guide covers what changes **once**, when a repository crosses
+from private to public. Commit-time secret blocking, destructive-operation
+gating, ignore rules, pre-commit hooks, and the history rewrite itself belong to
+the `git-safety` skill and are not repeated here.
 
 ---
 
-## 2. Common Patterns to Detect
+## 1. Preflight — Establish the Audit Scope
 
-### 2.1 API Key Patterns
+An audit that misses a ref misses everything in it. Fetch first.
 
-```regex
-# Generic API key patterns
-[aA][pP][iI][_-]?[kK][eE][yY].*['\"][a-zA-Z0-9]{16,}['\"]
-[aA][pP][iI][_-]?[sS][eE][cC][rR][eE][tT].*['\"][a-zA-Z0-9]{16,}['\"]
+```bash
+git fetch --all --tags --prune
 
-# AWS Access Key ID
-AKIA[0-9A-Z]{16}
-
-# AWS Secret Access Key
-[a-zA-Z0-9+/]{40}
-
-# GitHub Token
-gh[pousr]_[A-Za-z0-9_]{36,}
-
-# Generic Secret Key
-[sS][eE][cC][rR][eE][tT][_-]?[kK][eE][yY].*['\"][a-zA-Z0-9]{16,}['\"]
-
-# Bearer Token
-[bB][eE][aA][rR][eE][rR][\s]+[a-zA-Z0-9\-_\.]{20,}
-
-# JWT Token
-eyJ[a-zA-Z0-9\-_]+\.eyJ[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+
-
-# OpenAI API Key
-sk-[a-zA-Z0-9]{48}
-
-# Anthropic API Key
-sk-ant-[a-zA-Z0-9\-_]{40,}
-
-# Stripe API Key
-sk_(live|test)_[a-zA-Z0-9]{24,}
-pk_(live|test)_[a-zA-Z0-9]{24,}
-
-# Slack Token
-xox[baprs]-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]{24}
-
-# Google API Key
-AIza[0-9A-Za-z\-_]{35}
-
-# SendGrid API Key
-SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
+# Scope of the audit
+git log --all --oneline | wc -l              # commits
+git branch -a | wc -l                        # branches, local + remote
+git tag -l | wc -l                           # tags
+git stash list                               # NOT covered by --all
+git count-objects -vH                        # repo size; large packs hide old blobs
 ```
 
-### 2.2 Password Patterns
+Record these numbers. The verdict cites them, and they are what makes a
+`PUBLISH` verdict auditable rather than a vibe.
 
-```regex
-# Password assignments
-[pP][aA][sS][sS][wW][oO][rR][dD].*[=:].*['\"][^'\"]{4,}['\"]
+Two refs that hide content from `--all`:
 
-# DB Password
-[dD][bB][_-]?[pP][aA][sS][sS][wW][oO][rR][dD].*[=:].*['\"][^'\"]+['\"]
+```bash
+# Dangling and unreachable objects — a deleted branch's commits may still exist
+git fsck --lost-found --unreachable 2>/dev/null | head -20
 
-# Admin Password
-[aA][dD][mM][iI][nN][_-]?[pP][aA][sS][sS].*[=:].*['\"][^'\"]+['\"]
-
-# Generic password in URL
-://[^:]+:[^@]+@
+# Notes, if the team used them
+git log --all --show-notes='*' --oneline | head
 ```
 
-### 2.3 Connection String Patterns
-
-```regex
-# NOTE: schemes are written with the colon inside brackets, followed by two
-# slashes, so this file itself never contains a URI-shaped literal that trips
-# secret scanners (secretlint, gitleaks) in consuming repositories.
-
-# MongoDB
-mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
-
-# PostgreSQL
-postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
-
-# MySQL
-mysql[:]//[^:]+:[^@]+@[^/]+
-
-# Redis
-redis[:]//:[^@]+@[^/]+
-
-# Generic database URL
-DATABASE_URL.*[=:].*['\"][^'\"]+['\"]
-```
-
-### 2.4 Email Patterns
-
-```regex
-# Email addresses
-[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
-
-# Specific internal domains (customize for your org)
-[a-zA-Z0-9._%+-]+@(company|internal)\.com
-```
-
-### 2.5 Private Key Patterns
-
-```regex
-# RSA Private Key
------BEGIN RSA PRIVATE KEY-----
-
-# EC Private Key
------BEGIN EC PRIVATE KEY-----
-
-# Generic Private Key
------BEGIN PRIVATE KEY-----
-
-# OpenSSH Private Key
------BEGIN OPENSSH PRIVATE KEY-----
-
-# PGP Private Key
------BEGIN PGP PRIVATE KEY BLOCK-----
-```
+If the repository will be published by pushing a fresh clone rather than
+flipping visibility, unreachable objects will not travel — note which path the
+owner intends, because it changes what is in scope.
 
 ---
 
-## 3. Scanning Workflow
+## 2. License and Attribution
 
-### 3.1 File System Scan
-
-**Step 1: Find sensitive file types**
+### 2.1 The outgoing license
 
 ```bash
-# Find all potentially sensitive files
-find . -type f \( \
-  -name ".env" -o \
-  -name ".env.*" -o \
-  -name "*.env" -o \
-  -name "credentials.json" -o \
-  -name "service-account*.json" -o \
-  -name "*.pem" -o \
-  -name "*.key" -o \
-  -name "*.p12" -o \
-  -name "*.pfx" -o \
-  -name "id_rsa*" -o \
-  -name "id_ed25519*" -o \
-  -name "id_ecdsa*" -o \
-  -name "secrets.*" -o \
-  -name "*.secret" -o \
-  -name ".npmrc" -o \
-  -name ".pypirc" -o \
-  -name "kubeconfig" -o \
-  -name ".htpasswd" -o \
-  -name ".netrc" \
-\) 2>/dev/null | grep -v node_modules | grep -v .git | grep -v vendor
+ls -1 LICENSE* COPYING* NOTICE* 2>/dev/null
+head -5 LICENSE 2>/dev/null
+grep -i '"license"' package.json 2>/dev/null
 ```
 
-**Step 2: Check if sensitive files are tracked**
+A public repository with no license grants no rights. Readers may look but
+legally may not use, fork, or contribute. Confirm the owner has picked one
+before the audit passes.
+
+### 2.2 Dependency license compatibility
+
+The outgoing license cannot be more permissive than what the strongest incoming
+dependency license allows.
 
 ```bash
-# Check git status of each found file
-for file in $(find . -name ".env*" -o -name "*.pem" -o -name "*.key" 2>/dev/null | grep -v node_modules); do
-  if git ls-files --error-unmatch "$file" 2>/dev/null; then
-    echo "TRACKED (DANGER): $file"
-  else
-    echo "Untracked (safe): $file"
-  fi
-done
+# JavaScript / TypeScript
+bunx license-checker --summary
+bunx license-checker --failOn 'GPL-3.0;AGPL-3.0;SSPL-1.0'
+
+# Python
+pip-licenses --summary
+
+# Rust
+cargo license --tsv | cut -f6 | sort | uniq -c
+
+# Go
+go-licenses report ./... 2>/dev/null
 ```
 
-### 3.2 Code Pattern Analysis
+| Dependency license | Publishing under MIT / Apache-2.0 |
+|--------------------|-----------------------------------|
+| MIT, ISC, BSD-2/3 | Compatible. Keep the notice files. |
+| Apache-2.0 | Compatible. Preserve `NOTICE` and patent terms. |
+| MPL-2.0 | Compatible at file granularity; modified MPL files stay MPL. |
+| LGPL | Compatible when dynamically linked; static linking pulls obligations in. |
+| GPL-2.0 / GPL-3.0 | **Incompatible.** Distributing the combined work requires GPL. |
+| AGPL-3.0 | **Incompatible**, and network use counts as distribution. |
+| SSPL, BUSL, Elastic | **Not open source.** Source-available; check the terms directly. |
+| "UNLICENSED" / none | **Blocker.** No grant exists — remove or get written permission. |
 
-**Step 1: Search for hardcoded secrets**
+Devtime-only dependencies (test runners, linters, build tools) do not ship in
+the artifact and rarely constrain the outgoing license. Runtime dependencies do.
+Check which bucket each copyleft hit falls in before calling it a blocker.
+
+### 2.3 Borrowed and vendored code
+
+Snippets pasted from elsewhere carry their origin's terms whether or not anyone
+recorded that.
 
 ```bash
-# Search for API key patterns
-git grep -E "(api[_-]?key|apikey|api[_-]?secret).*[=:].*['\"][a-zA-Z0-9]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb'
+grep -rniE 'adapted from|based on|copied from|taken from|source: https?:' \
+  --include='*.*' . | grep -v node_modules | head -40
 
-# Search for password patterns
-git grep -E "(password|passwd|pwd).*[=:].*['\"][^'\"]+['\"]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb' ':!*.lock' ':!package-lock.json'
+# Vendored trees that are not dependency-managed
+find . -type d \( -name vendor -o -name third_party -o -name external \) \
+  -not -path '*/node_modules/*'
 
-# Search for secret patterns
-git grep -E "(secret|token|auth).*[=:].*['\"][a-zA-Z0-9]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb'
-
-# Search for private keys
-git grep -E "-----BEGIN.*PRIVATE KEY-----" -- '*'
+# License headers already present
+grep -rl 'SPDX-License-Identifier' --include='*.*' . | grep -v node_modules | head -20
 ```
 
-**Step 2: Search for specific provider patterns**
+For each hit: attribute it in a `NOTICE` or header, replace it with original
+code, or remove it.
+
+### 2.4 Copyright ownership
 
 ```bash
-# AWS
-git grep -E "AKIA[0-9A-Z]{16}" -- '*'
-
-# GitHub
-git grep -E "gh[pousr]_[A-Za-z0-9_]{36,}" -- '*'
-
-# OpenAI
-git grep -E "sk-[a-zA-Z0-9]{48}" -- '*'
-
-# Stripe
-git grep -E "sk_(live|test)_[a-zA-Z0-9]{24,}" -- '*'
+grep -rniE 'copyright.*[0-9]{4}' --include='*.*' . | grep -v node_modules \
+  | sed -E 's/.*[Cc]opyright[^A-Za-z]*//' | sort -u | head -20
 ```
 
-### 3.3 Content Analysis
+Confirm the named entity is the one publishing, that the year range is current,
+and that headers are consistent. Code written under an employment agreement may
+not be the author's to release — settle that before the flip, not after.
 
-**Automated scanning with gitleaks**
+Ends when: license chosen and present, no incompatible runtime dependency, every
+borrowed block attributed, copyright naming the publishing entity.
+
+---
+
+## 3. Secrets Across Full History
+
+### 3.1 Tooling does the pattern matching
+
+Hand-written regexes work for a staged diff of five files. They do not work
+across thousands of commits — the false-negative rate is what gets repositories
+burned. Run scanners over full history and triage their output.
+
+**gitleaks**
 
 ```bash
-# Install gitleaks
-brew install gitleaks
-
-# Scan current directory
+# Full history, every ref
 gitleaks detect --source . --verbose
 
-# Scan with report
-gitleaks detect --source . --report-format json --report-path ./gitleaks-report.json
+# Machine-readable, for triage
+gitleaks detect --source . --report-format json --report-path gitleaks.json
+
+# Bound the scan to a range when re-auditing after a rewrite
+gitleaks detect --source . --log-opts="HEAD~200..HEAD"
+
+# Custom allowlist for known-fake fixture values
+gitleaks detect --source . --config .gitleaks.toml
 ```
 
-**Automated scanning with truffleHog**
+```toml
+# .gitleaks.toml — allowlist fixtures, never real values
+[extend]
+useDefault = true
 
-```bash
-# Install truffleHog
-pip install trufflehog
+[[rules]]
+id = "internal-domain"
+description = "Internal hostname"
+regex = '''[a-z0-9-]+\.(internal|corp|local)\b'''
 
-# Scan filesystem
-trufflehog filesystem . --only-verified
-
-# Scan with JSON output
-trufflehog filesystem . --json > trufflehog-report.json
+[allowlist]
+paths = [
+  '''tests/fixtures/.*''',
+  '''.*\.example$''',
+]
 ```
 
-### 3.4 Git History Check
-
-See dedicated section below.
-
----
-
-## 4. Git History Scanning (CRITICAL)
-
-This is the most commonly overlooked step. Secrets removed from current files remain in git history indefinitely.
-
-### 4.1 Essential Commands
-
-**Find all files ever committed**
+**truffleHog** — verifies candidates against the live provider, so a hit means
+the credential still works.
 
 ```bash
-# List all files that have ever existed in the repo
+trufflehog git file://. --only-verified
+trufflehog git file://. --include-detectors all      # widen, more noise
+trufflehog git https://github.com/org/repo.git       # after publication, as a check
+```
+
+Run both. gitleaks has better entropy coverage; truffleHog tells you which hits
+are live. A verified truffleHog hit is a rotate-now item.
+
+### 3.2 All-refs commands the scanners complement
+
+```bash
+# Every file that ever existed in the repository
 git log --all --pretty=format: --name-only --diff-filter=A | sort -u
-```
 
-**Search for sensitive filenames in history**
-
-```bash
-# Find when sensitive files were added
-git log --all --full-history --diff-filter=A -- \
-  "*.env" ".env" ".env.*" \
-  "credentials.json" "service-account*.json" \
-  "*.pem" "*.key" "id_rsa*" \
-  "secrets.*" ".npmrc" "*.secret" \
-  --name-only --oneline
-
-# More detailed with dates
+# Sensitive filenames, with when they were added
 git log --all --full-history --diff-filter=A \
   --pretty=format:"%h %ad %s" --date=short -- \
-  "*.env" "credentials.json" "*.pem" "*.key"
-```
+  "*.env" ".env" ".env.*" "credentials.json" "service-account*.json" \
+  "*.pem" "*.key" "id_rsa*" "secrets.*" ".npmrc" "*.secret"
 
-**Search for secret patterns in git history**
-
-```bash
-# Search commits that added/removed content matching pattern
+# Content added or removed anywhere in history
 git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock'
-
-# Search for specific secret value (if known)
-git log -p --all -S 'sk-ant-abc123...' --source
-
-# Search using regex
 git log -p --all -G 'AKIA[0-9A-Z]{16}' --source
 ```
 
-**View content of deleted files**
+### 3.3 Files deleted from the tree
+
+The most common miss: someone removed `.env` in a later commit and assumed that
+handled it.
 
 ```bash
-# Find when a file was deleted
-git log --all --full-history -- path/to/deleted/file.env
+# Everything ever deleted
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.'
 
-# View the file content at a specific commit
-git show <commit-hash>:path/to/deleted/file.env
-
-# View the last version before deletion
+# Recover the content of a deleted file to judge severity
 git log --all --full-history --diff-filter=D -- path/to/file.env
 git show <commit-before-deletion>:path/to/file.env
 ```
 
-### 4.2 Automated Tools for History Scanning
+### 3.4 Stashes
 
-**gitleaks (Recommended)**
-
-```bash
-# Full history scan
-gitleaks detect --source . --verbose
-
-# Scan specific commit range
-gitleaks detect --source . --log-opts="HEAD~50..HEAD"
-
-# Generate baseline (for existing repos)
-gitleaks detect --source . --baseline-path .gitleaks-baseline.json
-
-# Custom config
-gitleaks detect --source . --config .gitleaks.toml
-```
-
-**truffleHog**
+`--all` does not cover the stash reflog. Stashes are local, so they do not
+travel on publication — but they reveal what was being handled carelessly, and
+the same values usually landed in a commit somewhere.
 
 ```bash
-# Scan git history
-trufflehog git file://. --only-verified
-
-# Scan remote repository
-trufflehog git https://github.com/org/repo.git
-
-# Include unverified findings
-trufflehog git file://. --include-detectors all
-```
-
-**git-secrets (AWS-focused)**
-
-```bash
-# Install
-brew install git-secrets
-
-# Register AWS patterns
-git secrets --register-aws
-
-# Scan history
-git secrets --scan-history
-
-# Scan specific file
-git secrets --scan path/to/file
-```
-
-### 4.3 Checking Deleted Files
-
-```bash
-# List all deleted files in history
-git log --all --pretty=format: --name-only --diff-filter=D | sort -u
-
-# Filter for sensitive patterns
-git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.'
-
-# For each deleted sensitive file, check its content
-for file in $(git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.env$'); do
-  echo "=== $file ==="
-  git log --all --full-history -1 --format="%H" -- "$file" | xargs -I {} git show {}^:"$file" 2>/dev/null || echo "Could not retrieve"
+git stash list
+for i in $(seq 0 $(($(git stash list | wc -l) - 1))); do
+  echo "=== stash@{$i} ==="
+  git stash show -p "stash@{$i}" 2>/dev/null | grep -iE '(api.?key|password|secret|token)' || true
 done
 ```
 
-### 4.4 Checking Merge Commits
+### 3.5 Merge commits
 
-Merge commits can contain secrets that weren't in either branch:
+A merge commit can introduce content present in neither parent — a conflict
+resolved by hand-typing a value.
 
 ```bash
-# List all merge commits
-git log --all --merges --oneline
-
-# Check a specific merge for changes
-git show --stat <merge-commit-hash>
-
-# Diff merge against its parents
+git log --all --merges --oneline | head -30
 git diff <merge-commit>^1..<merge-commit>
 git diff <merge-commit>^2..<merge-commit>
 ```
 
-### 4.5 Checking Stashes
-
-Stashes are often forgotten and may contain secrets:
+### 3.6 Every branch and tag
 
 ```bash
-# List all stashes
-git stash list
-
-# Show stash content
-git stash show -p stash@{0}
-
-# Check all stashes for sensitive patterns
-for i in $(seq 0 $(git stash list | wc -l)); do
-  echo "=== Stash $i ==="
-  git stash show -p stash@{$i} 2>/dev/null | grep -iE "(api.?key|password|secret|token)" || true
+for branch in $(git branch -a | sed 's/^[* ]*//' | grep -v HEAD); do
+  hits=$(git ls-tree -r --name-only "$branch" 2>/dev/null | grep -iE '\.(env|pem|key)$')
+  [ -n "$hits" ] && printf '=== %s ===\n%s\n' "$branch" "$hits"
 done
-```
 
-### 4.6 Checking All Branches
-
-```bash
-# List all branches (local and remote)
-git branch -a
-
-# Scan each branch for sensitive files
-for branch in $(git branch -a | sed 's/^[\* ]*//' | grep -v HEAD); do
-  echo "=== Branch: $branch ==="
-  git ls-tree -r --name-only "$branch" 2>/dev/null | grep -iE '\.(env|pem|key)$' || true
-done
-```
-
-### 4.7 Checking Tags
-
-```bash
-# List all tags
-git tag -l
-
-# Check files in each tag
 for tag in $(git tag -l); do
-  echo "=== Tag: $tag ==="
-  git ls-tree -r --name-only "$tag" 2>/dev/null | grep -iE '\.(env|pem|key)$' || true
+  hits=$(git ls-tree -r --name-only "$tag" 2>/dev/null | grep -iE '\.(env|pem|key)$')
+  [ -n "$hits" ] && printf '=== tag %s ===\n%s\n' "$tag" "$hits"
 done
+```
+
+Stale release branches are frequently the only ref still holding a config file
+that `main` cleaned up years ago.
+
+### 3.7 Triage
+
+For each finding, record: the value's provider, the commit that introduced it,
+whether the repository was ever public or shared, and whether truffleHog
+verified it as live.
+
+| Finding | Action |
+|---------|--------|
+| Live credential, any ref | Rotate immediately, then rewrite. Blocker. |
+| Dead or already-rotated credential | Rewrite for hygiene. Blocker until confirmed dead. |
+| Fixture or documented placeholder | Allowlist it in `.gitleaks.toml`. Not a blocker. |
+| Internal-only value with no external auth (a dev seed password) | Judgment call; usually rewrite. |
+
+Rotation and history rewriting are performed by the `git-safety` skill. This
+audit produces the list; it does not run the rewrite.
+
+Ends when: both scanners return clean across full history, every earlier hit has
+a confirmed rotation, and stashes, merges, branches, and tags are each swept.
+
+---
+
+## 4. Private References
+
+No scanner finds these. They are not credentials — they are internal facts that
+were never meant to leave, and they are the pass that most often produces
+findings in an otherwise clean repository.
+
+### 4.1 Internal hosts and networks
+
+```bash
+# Internal TLDs
+grep -rniE '\.(internal|corp|intranet|local|lan)\b' . | grep -v node_modules | head -40
+
+# RFC1918 addresses
+grep -rniE '\b(10\.[0-9]+|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]+\.[0-9]+\b' . \
+  | grep -v node_modules | head -40
+
+# Staging and internal environments
+grep -rniE '(staging|preprod|internal|admin|vpn)[.-][a-z0-9-]+\.(com|net|io|dev)' . \
+  | grep -v node_modules | head -40
+```
+
+`127.0.0.1` and `localhost` are fine. A hostname that only resolves inside the
+company is a finding.
+
+### 4.2 People
+
+```bash
+# Company and personal email addresses in source
+grep -rniE '[a-z0-9._%+-]+@(yourcompany|gmail|outlook)\.[a-z]{2,}' . \
+  | grep -v node_modules | head -40
+
+# Intent and blame left in comments
+grep -rniE '(TODO|FIXME|HACK|XXX|NOTE)[:( ].*(ask|per|check with|@[a-z]+)' \
+  --include='*.*' . | grep -v node_modules | head -40
+
+# Slack and ticket references
+grep -rniE '(slack\.com/archives|#[a-z-]+-team|JIRA-[0-9]+|[A-Z]{2,}-[0-9]{2,})' . \
+  | grep -v node_modules | head -40
+```
+
+### 4.3 Commit metadata
+
+Every author name and email in history becomes public with the repository. This
+is frequently overlooked because it is not in any file.
+
+```bash
+git log --all --format='%an <%ae>' | sort -u
+git log --all --format='%cn <%ce>' | sort -u
+```
+
+Options: accept it (most open-source projects do), or normalize identities with
+a `.mailmap` — which changes the display name, not the underlying commit object.
+Genuinely removing an email from history requires a rewrite via `git-safety`.
+
+```
+# .mailmap — display name and address remapping
+Real Name <public@example.com> <internal@yourcompany.local>
+```
+
+Get consent from each contributor before publishing their address.
+
+### 4.4 Customers and commercial detail
+
+```bash
+# Client names — supply the list; no generic pattern finds these
+for name in "Acme Corp" "BigClient" "ProjectCodename"; do
+  echo "=== $name ==="
+  grep -rniF "$name" . --exclude-dir=node_modules --exclude-dir=.git | head -10
+  git log --all --oneline --grep="$name" | head -10
+done
+
+# Production data leaked into fixtures
+grep -rniE '(ssn|social.security|credit.?card|passport|date.?of.?birth)' \
+  --include='*.json' --include='*.csv' --include='*.sql' . | head -20
+```
+
+Also check: pricing and discount logic, unreleased product names, feature flags
+naming unannounced work, and comments describing internal roadmap or headcount.
+
+### 4.5 Infrastructure identifiers
+
+```bash
+grep -rniE '\b[0-9]{12}\b' --include='*.tf' --include='*.yml' --include='*.yaml' . | head -20   # AWS account IDs
+grep -rniE '(s3://|arn:aws:|projects/[a-z0-9-]+/)' . | grep -v node_modules | head -30
+grep -rniE '(cluster|namespace|bucket)[-_ ]?(name)?[=: ]+["\x27][a-z0-9-]+' . | head -20
+```
+
+Account IDs and bucket names are not secrets, but they narrow an attacker's
+target list. Decide deliberately rather than by omission.
+
+### 4.6 The judgment rule
+
+For each hit, ask: **would a stranger reading this learn something the company
+would not say publicly?**
+
+- A link to public documentation — not a finding.
+- A link to the internal runbook wiki — finding.
+- `localhost:3000` — not a finding.
+- `deploy-01.eng.corp` — finding.
+- A generic `TODO: refactor` — not a finding.
+- `TODO: ask Priya why the Acme contract needs this` — finding, twice over.
+
+Ends when: every category above has been searched and each hit is redacted,
+replaced with a neutral placeholder, or explicitly accepted by the owner.
+
+---
+
+## 5. Publication Readiness
+
+### 5.1 The first thirty seconds
+
+```bash
+ls -1 README* CONTRIBUTING* CODE_OF_CONDUCT* SECURITY* .env.example 2>/dev/null
+grep -rniE 'internal|confidential|do not distribute|proprietary|ask the team|#eng' \
+  README* docs/ 2>/dev/null | head -20
+```
+
+A README written for colleagues assumes access a stranger does not have. Rewrite
+onboarding steps that route through internal Slack, wikis, or VPN.
+
+### 5.2 Can an outsider actually run it?
+
+- `.env.example` lists every variable the app reads, with safe placeholders
+- Setup instructions reference public package registries only
+- No step requires an internal service, VPN, or SSO tenant
+- Seed and fixture data is synthetic
+
+```bash
+# Variables the code reads, versus what the example documents
+grep -rhoE 'process\.env\.[A-Z_]+|os\.environ\[.[A-Z_]+' src/ 2>/dev/null \
+  | grep -oE '[A-Z_]{3,}' | sort -u > /tmp/used-vars
+grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > /tmp/documented-vars
+comm -23 /tmp/used-vars /tmp/documented-vars     # read but undocumented
+```
+
+### 5.3 CI and repository configuration
+
+```bash
+cat .github/CODEOWNERS 2>/dev/null                 # internal team handles
+grep -rniE 'secrets\.[A-Z_]+' .github/workflows/ | sort -u
+grep -rniE '(registry|repository|runs-on).*(internal|corp|self-hosted)' .github/ 2>/dev/null
+cat .github/ISSUE_TEMPLATE/* 2>/dev/null | grep -iE 'internal|jira|slack'
+```
+
+Workflows referencing self-hosted runners or an internal registry will fail on
+every fork. Either make them fork-safe or gate them behind a condition.
+
+### 5.4 Repository-level settings
+
+Not visible in the tree, and worth checking before the flip:
+
+- Wiki content and its history
+- Existing issues and pull-request discussions — these become public too
+- Release artifacts and their notes
+- Repository description, topics, and homepage URL
+- Branch protection and required-check names that reference internal systems
+
+Ends when: a reader with no internal access can install, run, and contribute
+from what is in the repository.
+
+---
+
+## 6. Verdict Report Template
+
+```markdown
+# Open Source Readiness — <repo>
+
+Audited: <date> · Scope: <n> commits, <n> branches, <n> tags, <n> stashes
+
+## Verdict: BLOCK | PUBLISH
+
+## Pass 1 — License and attribution
+- Outgoing license: <MIT | none — BLOCKER>
+- Dependency conflicts: <n> (<list AGPL/GPL runtime deps>)
+- Unattributed borrowed code: <n> locations
+
+## Pass 2 — Secrets in history
+- gitleaks: <n> findings · truffleHog verified: <n>
+- Introduced in: <commits> · Deleted-but-present: <files>
+- Rotation required: <list>
+
+## Pass 3 — Private references
+- Internal hosts: <n> · Employee references: <n>
+- Customer names: <n> files, <n> commit messages
+- Distinct author emails in history: <n>
+
+## Pass 4 — Publication readiness
+- README outsider-ready: <yes/no> · .env.example complete: <yes/no>
+- CI fork-safe: <yes/no> · CODEOWNERS internal handles: <n>
+
+## Blockers
+1. <finding> → <action> → <owner>
+
+## Handoff
+- Rotate now: <credentials>
+- Then run: git-safety clean — <paths to strip>
+- Re-run passes 2 and 3 after the rewrite (commit hashes change)
 ```
 
 ---
 
-## 5. Cleaning Git History
+## 7. Re-Audit After a Rewrite
 
-**WARNING**: Before cleaning history:
-
-1. **Rotate all leaked credentials immediately** - cleaning history does NOT make secrets safe
-2. Create a backup of the repository
-3. Notify all collaborators
-4. Understand that this rewrites history and requires force push
-
-### 5.1 Using git-filter-repo (Recommended)
-
-**Installation**
+A history rewrite changes every commit hash downstream of the earliest rewritten
+commit. Findings referencing old hashes are stale, and the rewrite itself can
+introduce new problems.
 
 ```bash
-# pip
-pip install git-filter-repo
+# Confirm the value is gone from every ref
+git log --all --full-history -- .env             # expect empty
+git log -p --all -S '<rotated-value>' --source   # expect empty
 
-# Homebrew
-brew install git-filter-repo
-
-# Verify installation
-git filter-repo --version
-```
-
-**Remove specific files**
-
-```bash
-# Create backup first
-git clone --mirror . ../repo-backup-$(date +%Y%m%d)
-
-# Remove a single file
-git filter-repo --path .env --invert-paths
-
-# Remove multiple files
-git filter-repo --path .env --path .env.local --path credentials.json --invert-paths
-
-# Remove by pattern (glob)
-git filter-repo --path-glob '*.env' --invert-paths
-git filter-repo --path-glob '*.pem' --invert-paths
-
-# Remove by regex
-git filter-repo --path-regex '.*\.env(\..*)?' --invert-paths
-```
-
-**Remove content by pattern**
-
-```bash
-# Replace text in all files (useful for removing specific secrets)
-git filter-repo --replace-text expressions.txt
-
-# Where expressions.txt contains:
-# literal:sk-ant-api123abc==>[REDACTED]
-# regex:AKIA[0-9A-Z]{16}==>[REDACTED_AWS_KEY]
-```
-
-**Remove entire directories**
-
-```bash
-git filter-repo --path secrets/ --invert-paths
-git filter-repo --path config/credentials/ --invert-paths
-```
-
-### 5.2 Using BFG Repo-Cleaner
-
-**Installation**
-
-```bash
-# Homebrew
-brew install bfg
-
-# Or download JAR
-curl -L -o bfg.jar https://repo1.maven.org/maven2/com/madgag/bfg/1.14.0/bfg-1.14.0.jar
-```
-
-**Remove files by name**
-
-```bash
-# Clone a fresh mirror
-git clone --mirror git@github.com:org/repo.git
-
-cd repo.git
-
-# Remove files by name
-bfg --delete-files .env
-bfg --delete-files "*.pem"
-bfg --delete-files credentials.json
-
-# Clean up
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-```
-
-**Remove content by pattern**
-
-```bash
-# Create a file with patterns to remove
-echo "sk-ant-api123abc" > passwords.txt
-echo "AKIAIOSFODNN7EXAMPLE" >> passwords.txt
-
-# Replace matching content
-bfg --replace-text passwords.txt
-
-# Clean up
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-```
-
-**Remove files by size**
-
-```bash
-# Remove files larger than 100M
-bfg --strip-blobs-bigger-than 100M
-```
-
-### 5.3 Fresh Repository Approach
-
-When history is too compromised, start fresh:
-
-```bash
-# Create new repo with clean history
-mkdir new-repo
-cd new-repo
-git init
-
-# Copy current files (excluding secrets)
-rsync -av --exclude='.git' --exclude='.env*' --exclude='*.pem' --exclude='*.key' ../old-repo/ .
-
-# Create initial commit
-git add .
-git commit -m "Initial commit (clean history)"
-
-# Push to new remote (or rename old one)
-git remote add origin git@github.com:org/new-repo.git
-git push -u origin main
-```
-
-### 5.4 Force Push After Cleaning
-
-```bash
-# After cleaning with git-filter-repo or BFG
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-
-# Force push ALL branches
-git push origin --force --all
-
-# Force push ALL tags
-git push origin --force --tags
-```
-
-### 5.5 Notify Collaborators
-
-All collaborators must re-clone or rebase:
-
-```bash
-# Option 1: Re-clone (safest)
-rm -rf local-repo
-git clone git@github.com:org/repo.git
-
-# Option 2: Fetch and reset (advanced)
-git fetch origin
-git reset --hard origin/main
-git clean -fd
-```
-
-### 5.6 Verify Cleanup
-
-```bash
-# Verify file is gone from all history
-git log --all --full-history -- .env
-# Should return empty
-
-# Verify content pattern is gone
-git log -p --all -S 'your-secret-value' --source
-# Should return empty
-
-# Run gitleaks again
+# Re-run the scanners against the new history
 gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+
+# Confirm the ref counts match pre-rewrite expectations
+git log --all --oneline | wc -l
+git tag -l | wc -l
+```
+
+Verify against a fresh clone of the rewritten remote, not the local working
+copy — the local repository keeps the old objects in its reflog and packs until
+they are pruned, which can mask an incomplete rewrite.
+
+```bash
+git clone --mirror <remote-url> /tmp/verify-clone
+gitleaks detect --source /tmp/verify-clone --verbose
 ```
 
 ---
 
-## 6. Git Hooks and Pre-Commit Hooks
-
-### 6.1 git-secrets
-
-**Installation and setup**
+## 8. Quick Reference
 
 ```bash
-# Install
-brew install git-secrets
+# === PREFLIGHT ===
+git fetch --all --tags --prune
+git log --all --oneline | wc -l
 
-# Install hooks in repository
-git secrets --install
+# === PASS 1: LICENSE ===
+ls LICENSE* && bunx license-checker --failOn 'GPL-3.0;AGPL-3.0'
 
-# Register AWS patterns
-git secrets --register-aws
-
-# Add custom patterns
-git secrets --add 'sk-ant-[a-zA-Z0-9\-_]{40,}'
-git secrets --add 'sk-[a-zA-Z0-9]{48}'
-git secrets --add 'ghp_[A-Za-z0-9_]{36,}'
-git secrets --add 'ANTHROPIC_API_KEY.*=.*sk-ant-'
-git secrets --add 'OPENAI_API_KEY.*=.*sk-'
-
-# Add allowed patterns (false positives)
-git secrets --add --allowed 'sk-ant-example-key-not-real'
-```
-
-**Configuration file** (`.git/config` or global):
-
-```gitconfig
-[secrets]
-    providers = git secrets --aws-provider
-    patterns = sk-ant-[a-zA-Z0-9\\-_]{40,}
-    patterns = sk-[a-zA-Z0-9]{48}
-    patterns = ghp_[A-Za-z0-9_]{36,}
-    allowed = example-api-key
-```
-
-### 6.2 gitleaks Pre-Commit Hook
-
-**Using pre-commit framework**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.1
-    hooks:
-      - id: gitleaks
-```
-
-```bash
-# Install pre-commit
-pip install pre-commit
-
-# Install hooks
-pre-commit install
-```
-
-**Custom gitleaks configuration**
-
-```toml
-# .gitleaks.toml
-title = "Gitleaks Custom Config"
-
-[allowlist]
-description = "Global allowlist"
-paths = [
-    '''\.env\.example$''',
-    '''\.env\.template$''',
-]
-
-[[rules]]
-id = "anthropic-api-key"
-description = "Anthropic API Key"
-regex = '''sk-ant-[a-zA-Z0-9\-_]{40,}'''
-tags = ["key", "anthropic"]
-
-[[rules]]
-id = "openai-api-key"
-description = "OpenAI API Key"
-regex = '''sk-[a-zA-Z0-9]{48}'''
-tags = ["key", "openai"]
-
-[[rules]]
-id = "generic-api-key"
-description = "Generic API Key"
-regex = '''(?i)(api[_-]?key|apikey)['":\s]*[=:]\s*['"][a-zA-Z0-9]{16,}['"]'''
-tags = ["key", "generic"]
-
-[[rules]]
-id = "generic-password"
-description = "Generic Password"
-regex = '''(?i)(password|passwd|pwd)['":\s]*[=:]\s*['"][^'"]{4,}['"]'''
-tags = ["password"]
-```
-
-### 6.3 detect-secrets
-
-**Installation and baseline**
-
-```bash
-# Install
-pip install detect-secrets
-
-# Generate baseline
-detect-secrets scan > .secrets.baseline
-
-# Audit baseline (mark false positives)
-detect-secrets audit .secrets.baseline
-
-# Update baseline after adding new secrets
-detect-secrets scan --baseline .secrets.baseline
-```
-
-**Pre-commit hook**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
-    hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
-```
-
-### 6.4 Husky (Node.js Projects)
-
-**Installation**
-
-```bash
-# Install husky
-npm install --save-dev husky
-
-# Initialize husky
-npx husky init
-```
-
-**Pre-commit hook for secrets**
-
-```bash
-# Create pre-commit hook
-cat > .husky/pre-commit << 'EOF'
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-# Check for secrets with gitleaks
-if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose
-  if [ $? -ne 0 ]; then
-    echo "Secrets detected! Commit blocked."
-    exit 1
-  fi
-fi
-
-# Check for forbidden files
-FORBIDDEN_PATTERNS=".env .env.* *.pem *.key credentials.json secrets.*"
-for pattern in $FORBIDDEN_PATTERNS; do
-  if git diff --cached --name-only | grep -E "$pattern"; then
-    echo "ERROR: Attempting to commit forbidden file: $pattern"
-    exit 1
-  fi
-done
-
-exit 0
-EOF
-
-chmod +x .husky/pre-commit
-```
-
-### 6.5 Custom Pre-Commit Hook Script
-
-```bash
-#!/bin/bash
-# .git/hooks/pre-commit
-
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-NC='\033[0m'
-
-echo "Running secret detection..."
-
-# Forbidden file patterns
-FORBIDDEN_FILES=(
-  ".env"
-  ".env.*"
-  "*.env"
-  "credentials.json"
-  "*-credentials.json"
-  "service-account*.json"
-  "secrets.yml"
-  "secrets.json"
-  "*.pem"
-  "*.key"
-  "*.p12"
-  "*.pfx"
-  "id_rsa"
-  "id_rsa.*"
-  "id_ed25519"
-  "id_ecdsa"
-  ".npmrc"
-  ".pypirc"
-)
-
-# Secret patterns to detect in content
-SECRET_PATTERNS=(
-  "-----BEGIN.*PRIVATE KEY-----"
-  "api[_-]?key.*[=:].*['\"][a-zA-Z0-9]{16,}['\"]"
-  "password.*[=:].*['\"][^'\"]{4,}['\"]"
-  "secret.*[=:].*['\"][a-zA-Z0-9]{16,}['\"]"
-  "sk-ant-[a-zA-Z0-9\-_]{40,}"
-  "sk-[a-zA-Z0-9]{48}"
-  "AKIA[0-9A-Z]{16}"
-  "ghp_[A-Za-z0-9_]{36,}"
-  "xox[baprs]-[0-9]{10,}"
-)
-
-ERRORS=0
-
-# Check for forbidden files
-for pattern in "${FORBIDDEN_FILES[@]}"; do
-  files=$(git diff --cached --name-only | grep -E "^$pattern$|/$pattern$" || true)
-  if [ -n "$files" ]; then
-    echo -e "${RED}ERROR: Forbidden file pattern '$pattern' detected:${NC}"
-    echo "$files"
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-# Check for secret patterns in staged content
-for pattern in "${SECRET_PATTERNS[@]}"; do
-  matches=$(git diff --cached -U0 | grep -E "^\+" | grep -E "$pattern" || true)
-  if [ -n "$matches" ]; then
-    echo -e "${YELLOW}WARNING: Possible secret detected (pattern: $pattern):${NC}"
-    echo "$matches" | head -3
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-# Run gitleaks if available
-if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose --redact
-  if [ $? -ne 0 ]; then
-    ERRORS=$((ERRORS + 1))
-  fi
-fi
-
-if [ $ERRORS -gt 0 ]; then
-  echo ""
-  echo -e "${RED}===============================================${NC}"
-  echo -e "${RED}COMMIT BLOCKED: $ERRORS potential secret(s) found${NC}"
-  echo -e "${RED}===============================================${NC}"
-  echo ""
-  echo "If these are false positives, you can:"
-  echo "  1. Add to .gitleaks.toml allowlist"
-  echo "  2. Use: git commit --no-verify (NOT RECOMMENDED)"
-  echo ""
-  exit 1
-fi
-
-echo -e "${GREEN}No secrets detected. Proceeding with commit.${NC}"
-exit 0
-```
-
-```bash
-# Make executable
-chmod +x .git/hooks/pre-commit
-```
-
----
-
-## 7. CI/CD Integration
-
-### 7.1 GitHub Actions
-
-```yaml
-# .github/workflows/secrets-scan.yml
-name: Secret Scanning
-
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-
-jobs:
-  gitleaks:
-    name: Gitleaks Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # Optional for enterprise
-
-  trufflehog:
-    name: TruffleHog Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --only-verified
-
-  detect-secrets:
-    name: Detect Secrets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install detect-secrets
-        run: pip install detect-secrets
-
-      - name: Run detect-secrets
-        run: |
-          detect-secrets scan --baseline .secrets.baseline
-          detect-secrets audit --report --baseline .secrets.baseline
-```
-
-### 7.2 GitLab CI
-
-```yaml
-# .gitlab-ci.yml
-stages:
-  - security
-
-gitleaks:
-  stage: security
-  image: zricethezav/gitleaks:latest
-  script:
-    - gitleaks detect --source . --verbose --report-format json --report-path gitleaks-report.json
-  artifacts:
-    reports:
-      secret_detection: gitleaks-report.json
-    when: always
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
-
-secret_detection:
-  stage: security
-  image: registry.gitlab.com/gitlab-org/security-products/analyzers/secrets:latest
-  script:
-    - /analyzer run
-  artifacts:
-    reports:
-      secret_detection: gl-secret-detection-report.json
-```
-
-### 7.3 CircleCI
-
-```yaml
-# .circleci/config.yml
-version: 2.1
-
-orbs:
-  gitleaks: upsidr/gitleaks@2.0.0
-
-jobs:
-  secret-scan:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Install gitleaks
-          command: |
-            curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz | tar xz
-            sudo mv gitleaks /usr/local/bin/
-      - run:
-          name: Run gitleaks
-          command: gitleaks detect --source . --verbose
-
-workflows:
-  security:
-    jobs:
-      - secret-scan
-```
-
-### 7.4 Jenkins
-
-```groovy
-// Jenkinsfile
-pipeline {
-    agent any
-
-    stages {
-        stage('Secret Scan') {
-            steps {
-                sh '''
-                    # Install gitleaks if not present
-                    if ! command -v gitleaks &> /dev/null; then
-                        curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz | tar xz
-                        mv gitleaks /usr/local/bin/
-                    fi
-
-                    # Run scan
-                    gitleaks detect --source . --verbose --report-format json --report-path gitleaks-report.json
-                '''
-            }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'gitleaks-report.json', allowEmptyArchive: true
-                }
-            }
-        }
-    }
-}
-```
-
----
-
-## 8. Checklist
-
-### Pre-Open Source Checklist
-
-```markdown
-## File System Scan
-- [ ] No .env files tracked in repository
-- [ ] No credential files (*.pem, *.key, *.p12) tracked
-- [ ] No service account JSON files tracked
-- [ ] No .npmrc with auth tokens tracked
-- [ ] .gitignore includes all sensitive patterns
-
-## Code Scan
-- [ ] No hardcoded API keys in source files
-- [ ] No hardcoded passwords in source files
-- [ ] No hardcoded connection strings with credentials
-- [ ] No private keys embedded in code
-- [ ] No personal information (emails, names) in comments
-
-## Git History Scan
-- [ ] Ran gitleaks on full history
-- [ ] No sensitive files ever committed (including deleted)
-- [ ] No secrets in any branch or tag
-- [ ] Checked merge commits for leaks
-- [ ] Checked stashes for sensitive data
-
-## Configuration
-- [ ] .env.example exists with placeholder values
-- [ ] README documents required environment variables
-- [ ] No default credentials in config files
-- [ ] Database seeds use fake data
-
-## Prevention Setup
-- [ ] Pre-commit hooks installed (gitleaks or git-secrets)
-- [ ] .gitleaks.toml configured for project
-- [ ] CI/CD secret scanning enabled
-- [ ] Team trained on secret hygiene
-
-## Credential Rotation
-- [ ] All previously leaked credentials rotated
-- [ ] New credentials generated for open source version
-- [ ] Access logs reviewed for unauthorized usage
-```
-
-### Emergency Response Checklist
-
-```markdown
-## Immediate Actions (within minutes)
-- [ ] Rotate compromised credential immediately
-- [ ] Revoke access tokens
-- [ ] Change affected passwords
-- [ ] Disable exposed API keys
-
-## Investigation (within hours)
-- [ ] Check access logs for unauthorized usage
-- [ ] Identify scope of exposure (which commits, branches)
-- [ ] Determine if credential was scraped by bots
-- [ ] Check for unusual account activity
-
-## Remediation (within day)
-- [ ] Clean git history using git-filter-repo or BFG
-- [ ] Force push cleaned history
-- [ ] Notify all collaborators to re-clone
-- [ ] Update .gitignore to prevent recurrence
-- [ ] Set up pre-commit hooks
-
-## Documentation
-- [ ] Document incident timeline
-- [ ] Document affected systems
-- [ ] Document remediation steps taken
-- [ ] Update security procedures
-```
-
----
-
-## 9. Output Format
-
-### Scan Report Template
-
-```markdown
-# Security Scan Report
-
-**Repository**: [repo-name]
-**Scan Date**: [YYYY-MM-DD HH:MM]
-**Scanned By**: [tool/person]
-
-## Summary
-
-| Category | Status | Count |
-|----------|--------|-------|
-| Sensitive Files (Current) | [PASS/FAIL] | [N] |
-| Sensitive Files (History) | [PASS/FAIL] | [N] |
-| Hardcoded Secrets | [PASS/FAIL] | [N] |
-| .gitignore Coverage | [PASS/FAIL] | [N] missing |
-
-## Findings
-
-### Critical (Immediate Action Required)
-
-| File/Location | Type | Details | Commit |
-|---------------|------|---------|--------|
-| .env | Environment File | Tracked in repo | abc1234 |
-| src/config.ts:42 | API Key | OpenAI key detected | def5678 |
-
-### Warning (Review Required)
-
-| File/Location | Type | Details | Commit |
-|---------------|------|---------|--------|
-| config/db.yml | Connection String | May contain password | - |
-
-### Info (False Positives / Reviewed)
-
-| File/Location | Type | Details | Status |
-|---------------|------|---------|--------|
-| .env.example | Example File | Contains placeholders | OK |
-
-## Recommendations
-
-1. **URGENT**: Rotate OpenAI API key immediately
-2. **HIGH**: Remove .env from git history using git-filter-repo
-3. **MEDIUM**: Add missing patterns to .gitignore
-4. **LOW**: Set up pre-commit hooks for ongoing protection
-
-## Commands to Execute
-
-```bash
-# Step 1: Create backup
-git clone --mirror . ../repo-backup-$(date +%Y%m%d)
-
-# Step 2: Remove sensitive files from history
-git filter-repo --path .env --invert-paths
-
-# Step 3: Update .gitignore
-echo ".env" >> .gitignore
-echo "*.pem" >> .gitignore
-
-# Step 4: Force push
-git push origin --force --all
-```
-
-```
-
----
-
-## 10. Best Practices
-
-### Development Workflow
-
-1. **Never commit secrets** - Use environment variables
-2. **Use .env.example** - Document required variables without values
-3. **Git hooks from day one** - Install pre-commit hooks immediately
-4. **Regular audits** - Run gitleaks weekly in CI/CD
-5. **Principle of least privilege** - Use separate keys for dev/staging/prod
-
-### Environment Variable Management
-
-```bash
-# .env.example (safe to commit)
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/MYDB
-OPENAI_API_KEY=your_openai_key_here
-STRIPE_SECRET_KEY=your_stripe_key_here
-
-# .env (NEVER commit)
-DATABASE_URL=postgresql://USER:PASSWORD@prod.example.com:5432/proddb
-OPENAI_API_KEY=sk-abc123...
-STRIPE_SECRET_KEY=sk_live_abc123...
-```
-
-### Secret Management Tools
-
-For production applications, use dedicated secret management:
-
-- **AWS Secrets Manager**
-- **HashiCorp Vault**
-- **Google Secret Manager**
-- **Azure Key Vault**
-- **Doppler**
-- **1Password Secrets Automation**
-
-### Team Training
-
-1. Educate team on risks of committed secrets
-2. Establish code review checklist for secrets
-3. Create incident response procedures
-4. Regular security awareness sessions
-5. Maintain up-to-date .gitignore templates
-
-### Gitignore Template
-
-```gitignore
-# Environment files
-.env
-.env.*
-*.env
-.envrc
-!.env.example
-!.env.template
-
-# Credentials
-credentials.json
-*-credentials.json
-service-account*.json
-secrets.yml
-secrets.json
-*.secret
-api_keys.*
-auth.json
-
-# Private keys
-*.pem
-*.key
-*.p12
-*.pfx
-id_rsa
-id_rsa.*
-id_ed25519
-id_ed25519.*
-id_ecdsa
-id_ecdsa.*
-*.keystore
-*.jks
-
-# Cloud provider
-.aws/
-.gcp/
-.azure/
-kubeconfig
-.kube/
-
-# Package manager auth
-.npmrc
-.yarnrc.yml
-.pypirc
-.gem/credentials
-.docker/config.json
-
-# IDE (may contain secrets)
-.idea/
-.vscode/settings.json
-*.sublime-workspace
-
-# Logs (may contain secrets)
-*.log
-logs/
-
-# Database
-*.sql
-!schema.sql
-!migrations/*.sql
-
-# OS files
-.DS_Store
-Thumbs.db
-```
-
----
-
-## Quick Reference Commands
-
-```bash
-# === SCANNING ===
-# Quick file scan
-find . -name ".env*" -o -name "*.pem" -o -name "*.key" | grep -v node_modules
-
-# Quick history scan
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -iE 'env|secret|credential|key'
-
-# Full gitleaks scan
+# === PASS 2: HISTORY SECRETS ===
 gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.env|\.pem'
 
-# === CLEANING ===
-# Remove file from history
-git filter-repo --path .env --invert-paths --force
+# === PASS 3: PRIVATE REFERENCES ===
+grep -rniE '\.(internal|corp|local)\b' . | grep -v node_modules
+git log --all --format='%an <%ae>' | sort -u
 
-# Force push after clean
-git push origin --force --all
+# === PASS 4: READINESS ===
+ls README* .env.example && cat .github/CODEOWNERS
 
-# === PREVENTION ===
-# Install git-secrets
-brew install git-secrets && git secrets --install && git secrets --register-aws
-
-# Install gitleaks pre-commit
-cat > .pre-commit-config.yaml << EOF
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.1
-    hooks:
-      - id: gitleaks
-EOF
-pre-commit install
+# === HANDOFF ===
+# Rotation, history rewrite, force-push, and the ongoing commit-time guard
+# are the git-safety skill's job — this audit produces the list only.
 ```
-
----
-
-**Remember**: Removing secrets from git history does NOT make them safe. Always rotate leaked credentials immediately. Cleaning history is for compliance and reducing exposure, not security.

--- a/bundles/workspace/skills/open-source-checker/SKILL.md
+++ b/bundles/workspace/skills/open-source-checker/SKILL.md
@@ -1,54 +1,253 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
+description: >-
+  Audits a whole private repository once, at the decision to make it public.
+  Runs four passes — license and attribution, secrets across the entire git
+  history, private references (internal hostnames, employee emails, client and
+  customer names, staging URLs), and publication readiness — then returns a
+  publish or block verdict. Use when the user is preparing to open source a
+  repository, asks whether a codebase is safe to publish, wants a pre-release
+  audit before flipping a repo public, or needs to know what is still private in
+  code that is about to ship publicly.
 metadata:
-  version: "1.0.1"
-  tags: "open-source, security, secrets"
+  version: "1.1.0"
+  tags: "open-source, publishing, license, audit"
+when_to_use: "open source this repo, make this repository public, is this safe to publish, pre-release audit, what is private in this codebase, check licensing before publishing, going public with this code"
 ---
 
 # Open Source Checker
 
-## When to Use
+The publish gate. This runs **once**, on a repository that has lived its whole
+life private, at the moment someone proposes making it public. Everything in a
+private repo was written on the assumption nobody outside would read it —
+comments, hostnames, client names, and every commit ever made. This audit finds
+what that assumption left behind.
 
-Use when you're:
+Four passes, then a verdict. The recurring commit-time guard is a different
+skill — see [Related](#related).
 
-- Preparing to open source a repository
-- Reviewing code for exposed secrets
-- Auditing codebase for sensitive data
-- Performing security audits before public release
-- Setting up pre-commit hooks for secret detection
+## Contract
 
-## What to Check
+Inputs:
 
-### Critical Items
+- Repository root, with full history fetched (`git fetch --all --tags`)
+- Intended public license, if already chosen
+- Names to treat as private: company domains, client names, internal hostnames
 
-- API keys (OpenAI, Stripe, AWS, GitHub tokens)
-- Database credentials and connection strings
-- Private keys and certificates (`.pem`, `.key`)
-- Personal information (emails, phone numbers)
-- Environment files (`.env` should be gitignored)
+Outputs:
 
-### Git History (CRITICAL)
+- Per-pass findings with file, line or commit, and severity
+- A publish / block verdict with the blocking set enumerated
+- A rotation list and a history-rewrite list, handed to `git-safety`
 
-- Secrets remain in git history even after deletion
-- Must scan all branches, tags, and deleted files
-- Use `gitleaks`, `truffleHog`, or `git-secrets`
+Creates/Modifies:
 
-## Quick Workflow
+- Nothing. This audit is read-only.
 
-1. **File scan**: Check for secret files, patterns
-2. **Code analysis**: Search for hardcoded secrets
-3. **Git history**: Scan entire history with tools
-4. **Setup hooks**: Prevent future commits with secrets
-5. **Clean history**: Use `git-filter-repo` if needed
+External Side Effects:
 
-## Tools
+- None. Remediation is delegated, not performed here.
 
-- `gitleaks`: Best for git history scanning
-- `truffleHog`: Alternative history scanner
-- `git-secrets`: AWS-focused with pre-commit hooks
-- `detect-secrets`: Baseline-based detection
+Confirmation Required:
 
-## References
+- Before the repository is flipped public — the verdict is advice, the flip is
+  the owner's action
 
-- [Full guide: Patterns, scanning workflow, git hooks, cleanup](references/full-guide.md)
+Delegates To:
+
+- `git-safety` to rotate credentials, rewrite history, and install the ongoing
+  commit-time guard
+- `security-audit` for application-level vulnerability review
+
+## Preflight
+
+The audit is only as complete as the refs present locally.
+
+```bash
+git fetch --all --tags --prune
+git log --all --oneline | wc -l    # commits in scope
+git branch -a && git tag -l        # refs in scope
+git stash list                     # stashes are not in --all
+```
+
+Ends when every remote branch and tag is present locally.
+
+---
+
+## Pass 1 — License and attribution
+
+A private repo needs no license. A public one that ships without a clear one is
+legally unusable by anyone who finds it, and code borrowed under one license
+cannot always be re-published under another.
+
+Check:
+
+- **`LICENSE` file present** at the root, matching what the owner intends
+- **Dependency licenses compatible** with the intended outgoing license —
+  copyleft (GPL, AGPL) dependencies constrain a permissive release
+- **Vendored and copy-pasted code attributed** — snippets lifted from Stack
+  Overflow, blog posts, or another repo carry their origin's terms
+- **Copyright headers** consistent, and naming the right entity
+- **Employer ownership** settled if the code was written on company time
+
+```bash
+ls LICENSE* COPYING* 2>/dev/null
+bunx license-checker --summary                      # JS dependency licenses
+grep -rniE 'copyright|\(c\) [0-9]{4}|SPDX-License' --include='*.*' -l . | head -30
+grep -rniE 'adapted from|based on|taken from|source: http' --include='*.*' . | head -30
+```
+
+Ends when the outgoing license is named, every dependency license is compatible
+with it, and every borrowed block is attributed or removed.
+
+---
+
+## Pass 2 — Secrets in history
+
+Deleting a secret from the working tree leaves it in every commit that ever held
+it. Publishing the repo publishes those commits.
+
+Scan every ref, not just `HEAD`:
+
+```bash
+# Automated sweep across all history — start here
+gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+
+# Every file that ever existed
+git log --all --pretty=format: --name-only --diff-filter=A | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.|id_rsa'
+
+# Files deleted from the tree but alive in history
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials'
+
+# Content search across every commit
+git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock'
+git log -p --all -G 'AKIA[0-9A-Z]{16}' --source
+```
+
+Also sweep the places `--all` misses: stashes, merge commits, and every tag.
+Commands in `references/full-guide.md` §3.
+
+Every hit is a **rotation item first** and a history-rewrite item second.
+Cleaning history does not un-leak a credential that was ever pushed.
+
+Ends when gitleaks and truffleHog both return clean across full history, and
+every earlier hit has a confirmed rotation.
+
+---
+
+## Pass 3 — Private references
+
+The pass with no tooling, and the one that leaks the most. These are not
+credentials; they are facts about the company that only made sense inside it.
+
+| Category | What to look for |
+|----------|------------------|
+| Internal hosts | `*.internal`, `*.corp`, `*.local`, VPN hostnames, RFC1918 IPs |
+| Internal services | Jira/Linear ticket URLs, internal wikis, admin dashboards |
+| People | Employee emails, personal emails, names in TODO and FIXME comments |
+| Customers | Client names, logos, contract terms, customer data in fixtures |
+| Infrastructure | Account IDs, bucket names, cluster names, staging URLs |
+| Commercial | Pricing logic, unreleased product names, internal roadmap notes |
+| Commit metadata | Author emails on every commit — these become public too |
+
+```bash
+# Internal domains and hosts (substitute your own)
+grep -rniE '@(yourcompany|internal|corp)\.(com|net|local)' . | grep -v node_modules
+grep -rniE '\b(10|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]+\.[0-9]+\b' . | grep -v node_modules
+
+# People and intent left in comments
+grep -rniE '(TODO|FIXME|HACK|XXX|NOTE)[:( ].*(ask|per|@[a-z]+)' --include='*.*' . | head -40
+
+# Author identities that ship with the history
+git log --all --format='%ae' | sort -u
+git log --all --format='%an <%ae>' | sort -u | head -30
+```
+
+Judge each hit by one question: **would a stranger reading this learn something
+the company would not say publicly?** A staging URL is a finding. A public docs
+link is not.
+
+Ends when every category has been searched and each hit is redacted, replaced
+with a neutral placeholder, or explicitly accepted by the owner.
+
+---
+
+## Pass 4 — Publication readiness
+
+What a stranger finds in the first thirty seconds:
+
+- **README** written for an outsider — what it is, how to run it, no "ask the
+  team in #eng" instructions
+- **`.env.example`** present and complete, so setup is possible without internal
+  access
+- **Docs** free of links to internal wikis, dashboards, and runbooks
+- **Issue and PR templates** that do not route to internal processes
+- **CI config** referencing only secrets a fork could plausibly supply, and no
+  internal registry or runner
+- **Test fixtures** carrying synthetic data, not production exports
+- **Repository settings** — an existing `.github/` config may expose internal
+  team names in `CODEOWNERS`
+
+```bash
+ls README* .env.example .github/ 2>/dev/null
+grep -rniE 'internal|confidential|do not distribute|proprietary' README* docs/ 2>/dev/null
+cat .github/CODEOWNERS 2>/dev/null
+```
+
+Ends when a reader with no internal access can install, run, and contribute from
+what is in the repository.
+
+---
+
+## Verdict
+
+Report one of two outcomes. No middle state — "mostly clean" publishes secrets.
+
+**BLOCK** — enumerate every blocking finding:
+
+```
+BLOCK — 3 blockers
+
+License   No LICENSE file; two AGPL dependencies conflict with intended MIT
+History   AWS key in commit a1b2c3d (deleted in e4f5g6h, still in history)
+Private   Client name "Acme Corp" in 14 files and 3 commit messages
+
+Rotate now:      AWS key AKIA…  (leak precedes any rewrite)
+Then hand to:    git-safety clean — strip .env from all refs, force-push
+Re-run this audit after the rewrite; commit hashes will have changed.
+```
+
+**PUBLISH** — state what was verified, so the verdict is auditable:
+
+```
+PUBLISH
+
+License   MIT at root; 214 deps all permissive; 2 adapted blocks attributed
+History   gitleaks + truffleHog clean across 1,847 commits, 12 branches, 40 tags
+Private   No internal hosts, customer names, or employee emails outside git authorship
+Ready     README, .env.example, CI runs on a fork without internal secrets
+
+Note: 4 distinct author emails remain in commit history and will be public.
+Next: install the ongoing commit-time guard — git-safety prevent
+```
+
+A rewrite invalidates every commit hash in the findings, so re-run passes 2 and
+3 after `git-safety` finishes.
+
+## Related
+
+- `git-safety` — the recurring guard for a repository already in daily use:
+  blocks secrets from entering the next commit, gates force-pushes and history
+  rewrites, and installs ignore rules and pre-commit hooks. It also performs the
+  rotation and history rewrite this audit hands off. Run it at every commit;
+  run this audit once, at the publish decision.
+- `security-audit` — application-level vulnerability review of the code itself.
+
+---
+
+**Full credential-pattern catalog, all-refs history commands (stashes, merges,
+tags, branches), license-compatibility matrix, private-reference search recipes,
+and the report template:** `references/full-guide.md`

--- a/bundles/workspace/skills/open-source-checker/plugin.json
+++ b/bundles/workspace/skills/open-source-checker/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.1",
-  "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
+  "version": "1.1.0",
+  "description": "Audit a private repo before publishing: license, history secrets, private references.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/workspace/skills/open-source-checker/references/full-guide.md
+++ b/bundles/workspace/skills/open-source-checker/references/full-guide.md
@@ -1,1446 +1,537 @@
-# Open Source Security Checker - Full Guide
+# Open Source Checker — Full Guide
 
-Comprehensive guide for detecting and removing sensitive information from codebases before open sourcing.
+Reference material for the publish gate: the one-time audit of a private
+repository at the moment it is proposed for public release.
 
----
-
-## 1. What to Check
-
-### 1.1 API Keys and Tokens
-
-API keys are the most common leaked secret. Check for:
-
-- **OpenAI**: `sk-...` (48 characters)
-- **Anthropic**: `sk-ant-...`
-- **Stripe**: `sk_live_...`, `sk_test_...`, `pk_live_...`, `pk_test_...`
-- **AWS**: Access Key ID (`AKIA...`), Secret Access Key
-- **GitHub**: `ghp_...`, `gho_...`, `ghu_...`, `ghs_...`, `ghr_...`
-- **Google**: `AIza...` (39 characters)
-- **Slack**: `xoxb-...`, `xoxp-...`, `xoxa-...`
-- **Twilio**: Account SID (`AC...`), Auth Token
-- **SendGrid**: `SG....`
-- **Firebase**: Various patterns in config objects
-- **Vercel**: `vercel_...`
-- **npm**: `npm_...`
-
-### 1.2 Database Credentials
-
-- Connection strings with embedded passwords
-- MongoDB URIs: `mongodb+srv://USER:PASSWORD@HOST`
-- PostgreSQL: `postgresql://USER:PASSWORD@HOST:PORT/DB`
-- MySQL: `mysql://USER:PASSWORD@HOST:PORT/DB`
-- Redis: `redis://:PASSWORD@HOST:PORT`
-
-### 1.3 Private Keys and Certificates
-
-```
-# File extensions to check
-*.pem
-*.key
-*.p12
-*.pfx
-*.cer
-*.crt
-id_rsa
-id_rsa.pub
-id_ed25519
-id_ecdsa
-*.keystore
-*.jks
-```
-
-### 1.4 Personal Information
-
-- Email addresses (especially internal/company emails)
-- Phone numbers
-- Physical addresses
-- Names in comments (developer names, client names)
-- IP addresses (especially internal network IPs)
-- License keys
-
-### 1.5 Environment Files
-
-```
-.env
-.env.local
-.env.development
-.env.production
-.env.staging
-.env.test
-.envrc
-*.env
-.env.*
-```
-
-### 1.6 Configuration Files
-
-```
-# Cloud provider configs
-.aws/credentials
-.aws/config
-.gcp/credentials.json
-.azure/credentials
-kubeconfig
-.kube/config
-
-# Package manager auth
-.npmrc (with auth tokens)
-.yarnrc.yml (with auth)
-.pypirc
-.gem/credentials
-.docker/config.json
-
-# Application configs
-config/secrets.yml
-config/credentials.yml.enc
-database.yml (check for passwords)
-secrets.json
-api_keys.json
-auth.json
-```
-
-### 1.7 Code Comments
-
-Developers often leave sensitive information in comments:
-
-```bash
-# Search for common patterns in comments
-grep -rn "TODO.*password" --include="*.ts" --include="*.js"
-grep -rn "FIXME.*key" --include="*.ts" --include="*.js"
-grep -rn "// .*secret" --include="*.ts" --include="*.js"
-grep -rn "password.*=" --include="*.ts" --include="*.js"
-```
-
-### 1.8 Git History
-
-**CRITICAL**: Deleted files and previous commits still contain secrets.
-
-```bash
-# Files deleted from repo but in history
-git log --all --full-history --diff-filter=D -- "*.env" ".env" "secrets.*"
-
-# Commits that modified sensitive files
-git log --all --oneline -- "*.env" "*.pem" "*.key" "credentials.*"
-```
+Scope note: this guide covers what changes **once**, when a repository crosses
+from private to public. Commit-time secret blocking, destructive-operation
+gating, ignore rules, pre-commit hooks, and the history rewrite itself belong to
+the `git-safety` skill and are not repeated here.
 
 ---
 
-## 2. Common Patterns to Detect
+## 1. Preflight — Establish the Audit Scope
 
-### 2.1 API Key Patterns
+An audit that misses a ref misses everything in it. Fetch first.
 
-```regex
-# Generic API key patterns
-[aA][pP][iI][_-]?[kK][eE][yY].*['\"][a-zA-Z0-9]{16,}['\"]
-[aA][pP][iI][_-]?[sS][eE][cC][rR][eE][tT].*['\"][a-zA-Z0-9]{16,}['\"]
+```bash
+git fetch --all --tags --prune
 
-# AWS Access Key ID
-AKIA[0-9A-Z]{16}
-
-# AWS Secret Access Key
-[a-zA-Z0-9+/]{40}
-
-# GitHub Token
-gh[pousr]_[A-Za-z0-9_]{36,}
-
-# Generic Secret Key
-[sS][eE][cC][rR][eE][tT][_-]?[kK][eE][yY].*['\"][a-zA-Z0-9]{16,}['\"]
-
-# Bearer Token
-[bB][eE][aA][rR][eE][rR][\s]+[a-zA-Z0-9\-_\.]{20,}
-
-# JWT Token
-eyJ[a-zA-Z0-9\-_]+\.eyJ[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+
-
-# OpenAI API Key
-sk-[a-zA-Z0-9]{48}
-
-# Anthropic API Key
-sk-ant-[a-zA-Z0-9\-_]{40,}
-
-# Stripe API Key
-sk_(live|test)_[a-zA-Z0-9]{24,}
-pk_(live|test)_[a-zA-Z0-9]{24,}
-
-# Slack Token
-xox[baprs]-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]{24}
-
-# Google API Key
-AIza[0-9A-Za-z\-_]{35}
-
-# SendGrid API Key
-SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
+# Scope of the audit
+git log --all --oneline | wc -l              # commits
+git branch -a | wc -l                        # branches, local + remote
+git tag -l | wc -l                           # tags
+git stash list                               # NOT covered by --all
+git count-objects -vH                        # repo size; large packs hide old blobs
 ```
 
-### 2.2 Password Patterns
+Record these numbers. The verdict cites them, and they are what makes a
+`PUBLISH` verdict auditable rather than a vibe.
 
-```regex
-# Password assignments
-[pP][aA][sS][sS][wW][oO][rR][dD].*[=:].*['\"][^'\"]{4,}['\"]
+Two refs that hide content from `--all`:
 
-# DB Password
-[dD][bB][_-]?[pP][aA][sS][sS][wW][oO][rR][dD].*[=:].*['\"][^'\"]+['\"]
+```bash
+# Dangling and unreachable objects — a deleted branch's commits may still exist
+git fsck --lost-found --unreachable 2>/dev/null | head -20
 
-# Admin Password
-[aA][dD][mM][iI][nN][_-]?[pP][aA][sS][sS].*[=:].*['\"][^'\"]+['\"]
-
-# Generic password in URL
-://[^:]+:[^@]+@
+# Notes, if the team used them
+git log --all --show-notes='*' --oneline | head
 ```
 
-### 2.3 Connection String Patterns
-
-```regex
-# NOTE: schemes are written with the colon inside brackets, followed by two
-# slashes, so this file itself never contains a URI-shaped literal that trips
-# secret scanners (secretlint, gitleaks) in consuming repositories.
-
-# MongoDB
-mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
-
-# PostgreSQL
-postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
-
-# MySQL
-mysql[:]//[^:]+:[^@]+@[^/]+
-
-# Redis
-redis[:]//:[^@]+@[^/]+
-
-# Generic database URL
-DATABASE_URL.*[=:].*['\"][^'\"]+['\"]
-```
-
-### 2.4 Email Patterns
-
-```regex
-# Email addresses
-[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
-
-# Specific internal domains (customize for your org)
-[a-zA-Z0-9._%+-]+@(company|internal)\.com
-```
-
-### 2.5 Private Key Patterns
-
-```regex
-# RSA Private Key
------BEGIN RSA PRIVATE KEY-----
-
-# EC Private Key
------BEGIN EC PRIVATE KEY-----
-
-# Generic Private Key
------BEGIN PRIVATE KEY-----
-
-# OpenSSH Private Key
------BEGIN OPENSSH PRIVATE KEY-----
-
-# PGP Private Key
------BEGIN PGP PRIVATE KEY BLOCK-----
-```
+If the repository will be published by pushing a fresh clone rather than
+flipping visibility, unreachable objects will not travel — note which path the
+owner intends, because it changes what is in scope.
 
 ---
 
-## 3. Scanning Workflow
+## 2. License and Attribution
 
-### 3.1 File System Scan
-
-**Step 1: Find sensitive file types**
+### 2.1 The outgoing license
 
 ```bash
-# Find all potentially sensitive files
-find . -type f \( \
-  -name ".env" -o \
-  -name ".env.*" -o \
-  -name "*.env" -o \
-  -name "credentials.json" -o \
-  -name "service-account*.json" -o \
-  -name "*.pem" -o \
-  -name "*.key" -o \
-  -name "*.p12" -o \
-  -name "*.pfx" -o \
-  -name "id_rsa*" -o \
-  -name "id_ed25519*" -o \
-  -name "id_ecdsa*" -o \
-  -name "secrets.*" -o \
-  -name "*.secret" -o \
-  -name ".npmrc" -o \
-  -name ".pypirc" -o \
-  -name "kubeconfig" -o \
-  -name ".htpasswd" -o \
-  -name ".netrc" \
-\) 2>/dev/null | grep -v node_modules | grep -v .git | grep -v vendor
+ls -1 LICENSE* COPYING* NOTICE* 2>/dev/null
+head -5 LICENSE 2>/dev/null
+grep -i '"license"' package.json 2>/dev/null
 ```
 
-**Step 2: Check if sensitive files are tracked**
+A public repository with no license grants no rights. Readers may look but
+legally may not use, fork, or contribute. Confirm the owner has picked one
+before the audit passes.
+
+### 2.2 Dependency license compatibility
+
+The outgoing license cannot be more permissive than what the strongest incoming
+dependency license allows.
 
 ```bash
-# Check git status of each found file
-for file in $(find . -name ".env*" -o -name "*.pem" -o -name "*.key" 2>/dev/null | grep -v node_modules); do
-  if git ls-files --error-unmatch "$file" 2>/dev/null; then
-    echo "TRACKED (DANGER): $file"
-  else
-    echo "Untracked (safe): $file"
-  fi
-done
+# JavaScript / TypeScript
+bunx license-checker --summary
+bunx license-checker --failOn 'GPL-3.0;AGPL-3.0;SSPL-1.0'
+
+# Python
+pip-licenses --summary
+
+# Rust
+cargo license --tsv | cut -f6 | sort | uniq -c
+
+# Go
+go-licenses report ./... 2>/dev/null
 ```
 
-### 3.2 Code Pattern Analysis
+| Dependency license | Publishing under MIT / Apache-2.0 |
+|--------------------|-----------------------------------|
+| MIT, ISC, BSD-2/3 | Compatible. Keep the notice files. |
+| Apache-2.0 | Compatible. Preserve `NOTICE` and patent terms. |
+| MPL-2.0 | Compatible at file granularity; modified MPL files stay MPL. |
+| LGPL | Compatible when dynamically linked; static linking pulls obligations in. |
+| GPL-2.0 / GPL-3.0 | **Incompatible.** Distributing the combined work requires GPL. |
+| AGPL-3.0 | **Incompatible**, and network use counts as distribution. |
+| SSPL, BUSL, Elastic | **Not open source.** Source-available; check the terms directly. |
+| "UNLICENSED" / none | **Blocker.** No grant exists — remove or get written permission. |
 
-**Step 1: Search for hardcoded secrets**
+Devtime-only dependencies (test runners, linters, build tools) do not ship in
+the artifact and rarely constrain the outgoing license. Runtime dependencies do.
+Check which bucket each copyleft hit falls in before calling it a blocker.
+
+### 2.3 Borrowed and vendored code
+
+Snippets pasted from elsewhere carry their origin's terms whether or not anyone
+recorded that.
 
 ```bash
-# Search for API key patterns
-git grep -E "(api[_-]?key|apikey|api[_-]?secret).*[=:].*['\"][a-zA-Z0-9]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb'
+grep -rniE 'adapted from|based on|copied from|taken from|source: https?:' \
+  --include='*.*' . | grep -v node_modules | head -40
 
-# Search for password patterns
-git grep -E "(password|passwd|pwd).*[=:].*['\"][^'\"]+['\"]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb' ':!*.lock' ':!package-lock.json'
+# Vendored trees that are not dependency-managed
+find . -type d \( -name vendor -o -name third_party -o -name external \) \
+  -not -path '*/node_modules/*'
 
-# Search for secret patterns
-git grep -E "(secret|token|auth).*[=:].*['\"][a-zA-Z0-9]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb'
-
-# Search for private keys
-git grep -E "-----BEGIN.*PRIVATE KEY-----" -- '*'
+# License headers already present
+grep -rl 'SPDX-License-Identifier' --include='*.*' . | grep -v node_modules | head -20
 ```
 
-**Step 2: Search for specific provider patterns**
+For each hit: attribute it in a `NOTICE` or header, replace it with original
+code, or remove it.
+
+### 2.4 Copyright ownership
 
 ```bash
-# AWS
-git grep -E "AKIA[0-9A-Z]{16}" -- '*'
-
-# GitHub
-git grep -E "gh[pousr]_[A-Za-z0-9_]{36,}" -- '*'
-
-# OpenAI
-git grep -E "sk-[a-zA-Z0-9]{48}" -- '*'
-
-# Stripe
-git grep -E "sk_(live|test)_[a-zA-Z0-9]{24,}" -- '*'
+grep -rniE 'copyright.*[0-9]{4}' --include='*.*' . | grep -v node_modules \
+  | sed -E 's/.*[Cc]opyright[^A-Za-z]*//' | sort -u | head -20
 ```
 
-### 3.3 Content Analysis
+Confirm the named entity is the one publishing, that the year range is current,
+and that headers are consistent. Code written under an employment agreement may
+not be the author's to release — settle that before the flip, not after.
 
-**Automated scanning with gitleaks**
+Ends when: license chosen and present, no incompatible runtime dependency, every
+borrowed block attributed, copyright naming the publishing entity.
+
+---
+
+## 3. Secrets Across Full History
+
+### 3.1 Tooling does the pattern matching
+
+Hand-written regexes work for a staged diff of five files. They do not work
+across thousands of commits — the false-negative rate is what gets repositories
+burned. Run scanners over full history and triage their output.
+
+**gitleaks**
 
 ```bash
-# Install gitleaks
-brew install gitleaks
-
-# Scan current directory
+# Full history, every ref
 gitleaks detect --source . --verbose
 
-# Scan with report
-gitleaks detect --source . --report-format json --report-path ./gitleaks-report.json
+# Machine-readable, for triage
+gitleaks detect --source . --report-format json --report-path gitleaks.json
+
+# Bound the scan to a range when re-auditing after a rewrite
+gitleaks detect --source . --log-opts="HEAD~200..HEAD"
+
+# Custom allowlist for known-fake fixture values
+gitleaks detect --source . --config .gitleaks.toml
 ```
 
-**Automated scanning with truffleHog**
+```toml
+# .gitleaks.toml — allowlist fixtures, never real values
+[extend]
+useDefault = true
 
-```bash
-# Install truffleHog
-pip install trufflehog
+[[rules]]
+id = "internal-domain"
+description = "Internal hostname"
+regex = '''[a-z0-9-]+\.(internal|corp|local)\b'''
 
-# Scan filesystem
-trufflehog filesystem . --only-verified
-
-# Scan with JSON output
-trufflehog filesystem . --json > trufflehog-report.json
+[allowlist]
+paths = [
+  '''tests/fixtures/.*''',
+  '''.*\.example$''',
+]
 ```
 
-### 3.4 Git History Check
-
-See dedicated section below.
-
----
-
-## 4. Git History Scanning (CRITICAL)
-
-This is the most commonly overlooked step. Secrets removed from current files remain in git history indefinitely.
-
-### 4.1 Essential Commands
-
-**Find all files ever committed**
+**truffleHog** — verifies candidates against the live provider, so a hit means
+the credential still works.
 
 ```bash
-# List all files that have ever existed in the repo
+trufflehog git file://. --only-verified
+trufflehog git file://. --include-detectors all      # widen, more noise
+trufflehog git https://github.com/org/repo.git       # after publication, as a check
+```
+
+Run both. gitleaks has better entropy coverage; truffleHog tells you which hits
+are live. A verified truffleHog hit is a rotate-now item.
+
+### 3.2 All-refs commands the scanners complement
+
+```bash
+# Every file that ever existed in the repository
 git log --all --pretty=format: --name-only --diff-filter=A | sort -u
-```
 
-**Search for sensitive filenames in history**
-
-```bash
-# Find when sensitive files were added
-git log --all --full-history --diff-filter=A -- \
-  "*.env" ".env" ".env.*" \
-  "credentials.json" "service-account*.json" \
-  "*.pem" "*.key" "id_rsa*" \
-  "secrets.*" ".npmrc" "*.secret" \
-  --name-only --oneline
-
-# More detailed with dates
+# Sensitive filenames, with when they were added
 git log --all --full-history --diff-filter=A \
   --pretty=format:"%h %ad %s" --date=short -- \
-  "*.env" "credentials.json" "*.pem" "*.key"
-```
+  "*.env" ".env" ".env.*" "credentials.json" "service-account*.json" \
+  "*.pem" "*.key" "id_rsa*" "secrets.*" ".npmrc" "*.secret"
 
-**Search for secret patterns in git history**
-
-```bash
-# Search commits that added/removed content matching pattern
+# Content added or removed anywhere in history
 git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock'
-
-# Search for specific secret value (if known)
-git log -p --all -S 'sk-ant-abc123...' --source
-
-# Search using regex
 git log -p --all -G 'AKIA[0-9A-Z]{16}' --source
 ```
 
-**View content of deleted files**
+### 3.3 Files deleted from the tree
+
+The most common miss: someone removed `.env` in a later commit and assumed that
+handled it.
 
 ```bash
-# Find when a file was deleted
-git log --all --full-history -- path/to/deleted/file.env
+# Everything ever deleted
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.'
 
-# View the file content at a specific commit
-git show <commit-hash>:path/to/deleted/file.env
-
-# View the last version before deletion
+# Recover the content of a deleted file to judge severity
 git log --all --full-history --diff-filter=D -- path/to/file.env
 git show <commit-before-deletion>:path/to/file.env
 ```
 
-### 4.2 Automated Tools for History Scanning
+### 3.4 Stashes
 
-**gitleaks (Recommended)**
-
-```bash
-# Full history scan
-gitleaks detect --source . --verbose
-
-# Scan specific commit range
-gitleaks detect --source . --log-opts="HEAD~50..HEAD"
-
-# Generate baseline (for existing repos)
-gitleaks detect --source . --baseline-path .gitleaks-baseline.json
-
-# Custom config
-gitleaks detect --source . --config .gitleaks.toml
-```
-
-**truffleHog**
+`--all` does not cover the stash reflog. Stashes are local, so they do not
+travel on publication — but they reveal what was being handled carelessly, and
+the same values usually landed in a commit somewhere.
 
 ```bash
-# Scan git history
-trufflehog git file://. --only-verified
-
-# Scan remote repository
-trufflehog git https://github.com/org/repo.git
-
-# Include unverified findings
-trufflehog git file://. --include-detectors all
-```
-
-**git-secrets (AWS-focused)**
-
-```bash
-# Install
-brew install git-secrets
-
-# Register AWS patterns
-git secrets --register-aws
-
-# Scan history
-git secrets --scan-history
-
-# Scan specific file
-git secrets --scan path/to/file
-```
-
-### 4.3 Checking Deleted Files
-
-```bash
-# List all deleted files in history
-git log --all --pretty=format: --name-only --diff-filter=D | sort -u
-
-# Filter for sensitive patterns
-git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.'
-
-# For each deleted sensitive file, check its content
-for file in $(git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.env$'); do
-  echo "=== $file ==="
-  git log --all --full-history -1 --format="%H" -- "$file" | xargs -I {} git show {}^:"$file" 2>/dev/null || echo "Could not retrieve"
+git stash list
+for i in $(seq 0 $(($(git stash list | wc -l) - 1))); do
+  echo "=== stash@{$i} ==="
+  git stash show -p "stash@{$i}" 2>/dev/null | grep -iE '(api.?key|password|secret|token)' || true
 done
 ```
 
-### 4.4 Checking Merge Commits
+### 3.5 Merge commits
 
-Merge commits can contain secrets that weren't in either branch:
+A merge commit can introduce content present in neither parent — a conflict
+resolved by hand-typing a value.
 
 ```bash
-# List all merge commits
-git log --all --merges --oneline
-
-# Check a specific merge for changes
-git show --stat <merge-commit-hash>
-
-# Diff merge against its parents
+git log --all --merges --oneline | head -30
 git diff <merge-commit>^1..<merge-commit>
 git diff <merge-commit>^2..<merge-commit>
 ```
 
-### 4.5 Checking Stashes
-
-Stashes are often forgotten and may contain secrets:
+### 3.6 Every branch and tag
 
 ```bash
-# List all stashes
-git stash list
-
-# Show stash content
-git stash show -p stash@{0}
-
-# Check all stashes for sensitive patterns
-for i in $(seq 0 $(git stash list | wc -l)); do
-  echo "=== Stash $i ==="
-  git stash show -p stash@{$i} 2>/dev/null | grep -iE "(api.?key|password|secret|token)" || true
+for branch in $(git branch -a | sed 's/^[* ]*//' | grep -v HEAD); do
+  hits=$(git ls-tree -r --name-only "$branch" 2>/dev/null | grep -iE '\.(env|pem|key)$')
+  [ -n "$hits" ] && printf '=== %s ===\n%s\n' "$branch" "$hits"
 done
-```
 
-### 4.6 Checking All Branches
-
-```bash
-# List all branches (local and remote)
-git branch -a
-
-# Scan each branch for sensitive files
-for branch in $(git branch -a | sed 's/^[\* ]*//' | grep -v HEAD); do
-  echo "=== Branch: $branch ==="
-  git ls-tree -r --name-only "$branch" 2>/dev/null | grep -iE '\.(env|pem|key)$' || true
-done
-```
-
-### 4.7 Checking Tags
-
-```bash
-# List all tags
-git tag -l
-
-# Check files in each tag
 for tag in $(git tag -l); do
-  echo "=== Tag: $tag ==="
-  git ls-tree -r --name-only "$tag" 2>/dev/null | grep -iE '\.(env|pem|key)$' || true
+  hits=$(git ls-tree -r --name-only "$tag" 2>/dev/null | grep -iE '\.(env|pem|key)$')
+  [ -n "$hits" ] && printf '=== tag %s ===\n%s\n' "$tag" "$hits"
 done
+```
+
+Stale release branches are frequently the only ref still holding a config file
+that `main` cleaned up years ago.
+
+### 3.7 Triage
+
+For each finding, record: the value's provider, the commit that introduced it,
+whether the repository was ever public or shared, and whether truffleHog
+verified it as live.
+
+| Finding | Action |
+|---------|--------|
+| Live credential, any ref | Rotate immediately, then rewrite. Blocker. |
+| Dead or already-rotated credential | Rewrite for hygiene. Blocker until confirmed dead. |
+| Fixture or documented placeholder | Allowlist it in `.gitleaks.toml`. Not a blocker. |
+| Internal-only value with no external auth (a dev seed password) | Judgment call; usually rewrite. |
+
+Rotation and history rewriting are performed by the `git-safety` skill. This
+audit produces the list; it does not run the rewrite.
+
+Ends when: both scanners return clean across full history, every earlier hit has
+a confirmed rotation, and stashes, merges, branches, and tags are each swept.
+
+---
+
+## 4. Private References
+
+No scanner finds these. They are not credentials — they are internal facts that
+were never meant to leave, and they are the pass that most often produces
+findings in an otherwise clean repository.
+
+### 4.1 Internal hosts and networks
+
+```bash
+# Internal TLDs
+grep -rniE '\.(internal|corp|intranet|local|lan)\b' . | grep -v node_modules | head -40
+
+# RFC1918 addresses
+grep -rniE '\b(10\.[0-9]+|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]+\.[0-9]+\b' . \
+  | grep -v node_modules | head -40
+
+# Staging and internal environments
+grep -rniE '(staging|preprod|internal|admin|vpn)[.-][a-z0-9-]+\.(com|net|io|dev)' . \
+  | grep -v node_modules | head -40
+```
+
+`127.0.0.1` and `localhost` are fine. A hostname that only resolves inside the
+company is a finding.
+
+### 4.2 People
+
+```bash
+# Company and personal email addresses in source
+grep -rniE '[a-z0-9._%+-]+@(yourcompany|gmail|outlook)\.[a-z]{2,}' . \
+  | grep -v node_modules | head -40
+
+# Intent and blame left in comments
+grep -rniE '(TODO|FIXME|HACK|XXX|NOTE)[:( ].*(ask|per|check with|@[a-z]+)' \
+  --include='*.*' . | grep -v node_modules | head -40
+
+# Slack and ticket references
+grep -rniE '(slack\.com/archives|#[a-z-]+-team|JIRA-[0-9]+|[A-Z]{2,}-[0-9]{2,})' . \
+  | grep -v node_modules | head -40
+```
+
+### 4.3 Commit metadata
+
+Every author name and email in history becomes public with the repository. This
+is frequently overlooked because it is not in any file.
+
+```bash
+git log --all --format='%an <%ae>' | sort -u
+git log --all --format='%cn <%ce>' | sort -u
+```
+
+Options: accept it (most open-source projects do), or normalize identities with
+a `.mailmap` — which changes the display name, not the underlying commit object.
+Genuinely removing an email from history requires a rewrite via `git-safety`.
+
+```
+# .mailmap — display name and address remapping
+Real Name <public@example.com> <internal@yourcompany.local>
+```
+
+Get consent from each contributor before publishing their address.
+
+### 4.4 Customers and commercial detail
+
+```bash
+# Client names — supply the list; no generic pattern finds these
+for name in "Acme Corp" "BigClient" "ProjectCodename"; do
+  echo "=== $name ==="
+  grep -rniF "$name" . --exclude-dir=node_modules --exclude-dir=.git | head -10
+  git log --all --oneline --grep="$name" | head -10
+done
+
+# Production data leaked into fixtures
+grep -rniE '(ssn|social.security|credit.?card|passport|date.?of.?birth)' \
+  --include='*.json' --include='*.csv' --include='*.sql' . | head -20
+```
+
+Also check: pricing and discount logic, unreleased product names, feature flags
+naming unannounced work, and comments describing internal roadmap or headcount.
+
+### 4.5 Infrastructure identifiers
+
+```bash
+grep -rniE '\b[0-9]{12}\b' --include='*.tf' --include='*.yml' --include='*.yaml' . | head -20   # AWS account IDs
+grep -rniE '(s3://|arn:aws:|projects/[a-z0-9-]+/)' . | grep -v node_modules | head -30
+grep -rniE '(cluster|namespace|bucket)[-_ ]?(name)?[=: ]+["\x27][a-z0-9-]+' . | head -20
+```
+
+Account IDs and bucket names are not secrets, but they narrow an attacker's
+target list. Decide deliberately rather than by omission.
+
+### 4.6 The judgment rule
+
+For each hit, ask: **would a stranger reading this learn something the company
+would not say publicly?**
+
+- A link to public documentation — not a finding.
+- A link to the internal runbook wiki — finding.
+- `localhost:3000` — not a finding.
+- `deploy-01.eng.corp` — finding.
+- A generic `TODO: refactor` — not a finding.
+- `TODO: ask Priya why the Acme contract needs this` — finding, twice over.
+
+Ends when: every category above has been searched and each hit is redacted,
+replaced with a neutral placeholder, or explicitly accepted by the owner.
+
+---
+
+## 5. Publication Readiness
+
+### 5.1 The first thirty seconds
+
+```bash
+ls -1 README* CONTRIBUTING* CODE_OF_CONDUCT* SECURITY* .env.example 2>/dev/null
+grep -rniE 'internal|confidential|do not distribute|proprietary|ask the team|#eng' \
+  README* docs/ 2>/dev/null | head -20
+```
+
+A README written for colleagues assumes access a stranger does not have. Rewrite
+onboarding steps that route through internal Slack, wikis, or VPN.
+
+### 5.2 Can an outsider actually run it?
+
+- `.env.example` lists every variable the app reads, with safe placeholders
+- Setup instructions reference public package registries only
+- No step requires an internal service, VPN, or SSO tenant
+- Seed and fixture data is synthetic
+
+```bash
+# Variables the code reads, versus what the example documents
+grep -rhoE 'process\.env\.[A-Z_]+|os\.environ\[.[A-Z_]+' src/ 2>/dev/null \
+  | grep -oE '[A-Z_]{3,}' | sort -u > /tmp/used-vars
+grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > /tmp/documented-vars
+comm -23 /tmp/used-vars /tmp/documented-vars     # read but undocumented
+```
+
+### 5.3 CI and repository configuration
+
+```bash
+cat .github/CODEOWNERS 2>/dev/null                 # internal team handles
+grep -rniE 'secrets\.[A-Z_]+' .github/workflows/ | sort -u
+grep -rniE '(registry|repository|runs-on).*(internal|corp|self-hosted)' .github/ 2>/dev/null
+cat .github/ISSUE_TEMPLATE/* 2>/dev/null | grep -iE 'internal|jira|slack'
+```
+
+Workflows referencing self-hosted runners or an internal registry will fail on
+every fork. Either make them fork-safe or gate them behind a condition.
+
+### 5.4 Repository-level settings
+
+Not visible in the tree, and worth checking before the flip:
+
+- Wiki content and its history
+- Existing issues and pull-request discussions — these become public too
+- Release artifacts and their notes
+- Repository description, topics, and homepage URL
+- Branch protection and required-check names that reference internal systems
+
+Ends when: a reader with no internal access can install, run, and contribute
+from what is in the repository.
+
+---
+
+## 6. Verdict Report Template
+
+```markdown
+# Open Source Readiness — <repo>
+
+Audited: <date> · Scope: <n> commits, <n> branches, <n> tags, <n> stashes
+
+## Verdict: BLOCK | PUBLISH
+
+## Pass 1 — License and attribution
+- Outgoing license: <MIT | none — BLOCKER>
+- Dependency conflicts: <n> (<list AGPL/GPL runtime deps>)
+- Unattributed borrowed code: <n> locations
+
+## Pass 2 — Secrets in history
+- gitleaks: <n> findings · truffleHog verified: <n>
+- Introduced in: <commits> · Deleted-but-present: <files>
+- Rotation required: <list>
+
+## Pass 3 — Private references
+- Internal hosts: <n> · Employee references: <n>
+- Customer names: <n> files, <n> commit messages
+- Distinct author emails in history: <n>
+
+## Pass 4 — Publication readiness
+- README outsider-ready: <yes/no> · .env.example complete: <yes/no>
+- CI fork-safe: <yes/no> · CODEOWNERS internal handles: <n>
+
+## Blockers
+1. <finding> → <action> → <owner>
+
+## Handoff
+- Rotate now: <credentials>
+- Then run: git-safety clean — <paths to strip>
+- Re-run passes 2 and 3 after the rewrite (commit hashes change)
 ```
 
 ---
 
-## 5. Cleaning Git History
+## 7. Re-Audit After a Rewrite
 
-**WARNING**: Before cleaning history:
-
-1. **Rotate all leaked credentials immediately** - cleaning history does NOT make secrets safe
-2. Create a backup of the repository
-3. Notify all collaborators
-4. Understand that this rewrites history and requires force push
-
-### 5.1 Using git-filter-repo (Recommended)
-
-**Installation**
+A history rewrite changes every commit hash downstream of the earliest rewritten
+commit. Findings referencing old hashes are stale, and the rewrite itself can
+introduce new problems.
 
 ```bash
-# pip
-pip install git-filter-repo
+# Confirm the value is gone from every ref
+git log --all --full-history -- .env             # expect empty
+git log -p --all -S '<rotated-value>' --source   # expect empty
 
-# Homebrew
-brew install git-filter-repo
-
-# Verify installation
-git filter-repo --version
-```
-
-**Remove specific files**
-
-```bash
-# Create backup first
-git clone --mirror . ../repo-backup-$(date +%Y%m%d)
-
-# Remove a single file
-git filter-repo --path .env --invert-paths
-
-# Remove multiple files
-git filter-repo --path .env --path .env.local --path credentials.json --invert-paths
-
-# Remove by pattern (glob)
-git filter-repo --path-glob '*.env' --invert-paths
-git filter-repo --path-glob '*.pem' --invert-paths
-
-# Remove by regex
-git filter-repo --path-regex '.*\.env(\..*)?' --invert-paths
-```
-
-**Remove content by pattern**
-
-```bash
-# Replace text in all files (useful for removing specific secrets)
-git filter-repo --replace-text expressions.txt
-
-# Where expressions.txt contains:
-# literal:sk-ant-api123abc==>[REDACTED]
-# regex:AKIA[0-9A-Z]{16}==>[REDACTED_AWS_KEY]
-```
-
-**Remove entire directories**
-
-```bash
-git filter-repo --path secrets/ --invert-paths
-git filter-repo --path config/credentials/ --invert-paths
-```
-
-### 5.2 Using BFG Repo-Cleaner
-
-**Installation**
-
-```bash
-# Homebrew
-brew install bfg
-
-# Or download JAR
-curl -L -o bfg.jar https://repo1.maven.org/maven2/com/madgag/bfg/1.14.0/bfg-1.14.0.jar
-```
-
-**Remove files by name**
-
-```bash
-# Clone a fresh mirror
-git clone --mirror git@github.com:org/repo.git
-
-cd repo.git
-
-# Remove files by name
-bfg --delete-files .env
-bfg --delete-files "*.pem"
-bfg --delete-files credentials.json
-
-# Clean up
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-```
-
-**Remove content by pattern**
-
-```bash
-# Create a file with patterns to remove
-echo "sk-ant-api123abc" > passwords.txt
-echo "AKIAIOSFODNN7EXAMPLE" >> passwords.txt
-
-# Replace matching content
-bfg --replace-text passwords.txt
-
-# Clean up
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-```
-
-**Remove files by size**
-
-```bash
-# Remove files larger than 100M
-bfg --strip-blobs-bigger-than 100M
-```
-
-### 5.3 Fresh Repository Approach
-
-When history is too compromised, start fresh:
-
-```bash
-# Create new repo with clean history
-mkdir new-repo
-cd new-repo
-git init
-
-# Copy current files (excluding secrets)
-rsync -av --exclude='.git' --exclude='.env*' --exclude='*.pem' --exclude='*.key' ../old-repo/ .
-
-# Create initial commit
-git add .
-git commit -m "Initial commit (clean history)"
-
-# Push to new remote (or rename old one)
-git remote add origin git@github.com:org/new-repo.git
-git push -u origin main
-```
-
-### 5.4 Force Push After Cleaning
-
-```bash
-# After cleaning with git-filter-repo or BFG
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-
-# Force push ALL branches
-git push origin --force --all
-
-# Force push ALL tags
-git push origin --force --tags
-```
-
-### 5.5 Notify Collaborators
-
-All collaborators must re-clone or rebase:
-
-```bash
-# Option 1: Re-clone (safest)
-rm -rf local-repo
-git clone git@github.com:org/repo.git
-
-# Option 2: Fetch and reset (advanced)
-git fetch origin
-git reset --hard origin/main
-git clean -fd
-```
-
-### 5.6 Verify Cleanup
-
-```bash
-# Verify file is gone from all history
-git log --all --full-history -- .env
-# Should return empty
-
-# Verify content pattern is gone
-git log -p --all -S 'your-secret-value' --source
-# Should return empty
-
-# Run gitleaks again
+# Re-run the scanners against the new history
 gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+
+# Confirm the ref counts match pre-rewrite expectations
+git log --all --oneline | wc -l
+git tag -l | wc -l
+```
+
+Verify against a fresh clone of the rewritten remote, not the local working
+copy — the local repository keeps the old objects in its reflog and packs until
+they are pruned, which can mask an incomplete rewrite.
+
+```bash
+git clone --mirror <remote-url> /tmp/verify-clone
+gitleaks detect --source /tmp/verify-clone --verbose
 ```
 
 ---
 
-## 6. Git Hooks and Pre-Commit Hooks
-
-### 6.1 git-secrets
-
-**Installation and setup**
+## 8. Quick Reference
 
 ```bash
-# Install
-brew install git-secrets
+# === PREFLIGHT ===
+git fetch --all --tags --prune
+git log --all --oneline | wc -l
 
-# Install hooks in repository
-git secrets --install
+# === PASS 1: LICENSE ===
+ls LICENSE* && bunx license-checker --failOn 'GPL-3.0;AGPL-3.0'
 
-# Register AWS patterns
-git secrets --register-aws
-
-# Add custom patterns
-git secrets --add 'sk-ant-[a-zA-Z0-9\-_]{40,}'
-git secrets --add 'sk-[a-zA-Z0-9]{48}'
-git secrets --add 'ghp_[A-Za-z0-9_]{36,}'
-git secrets --add 'ANTHROPIC_API_KEY.*=.*sk-ant-'
-git secrets --add 'OPENAI_API_KEY.*=.*sk-'
-
-# Add allowed patterns (false positives)
-git secrets --add --allowed 'sk-ant-example-key-not-real'
-```
-
-**Configuration file** (`.git/config` or global):
-
-```gitconfig
-[secrets]
-    providers = git secrets --aws-provider
-    patterns = sk-ant-[a-zA-Z0-9\\-_]{40,}
-    patterns = sk-[a-zA-Z0-9]{48}
-    patterns = ghp_[A-Za-z0-9_]{36,}
-    allowed = example-api-key
-```
-
-### 6.2 gitleaks Pre-Commit Hook
-
-**Using pre-commit framework**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.1
-    hooks:
-      - id: gitleaks
-```
-
-```bash
-# Install pre-commit
-pip install pre-commit
-
-# Install hooks
-pre-commit install
-```
-
-**Custom gitleaks configuration**
-
-```toml
-# .gitleaks.toml
-title = "Gitleaks Custom Config"
-
-[allowlist]
-description = "Global allowlist"
-paths = [
-    '''\.env\.example$''',
-    '''\.env\.template$''',
-]
-
-[[rules]]
-id = "anthropic-api-key"
-description = "Anthropic API Key"
-regex = '''sk-ant-[a-zA-Z0-9\-_]{40,}'''
-tags = ["key", "anthropic"]
-
-[[rules]]
-id = "openai-api-key"
-description = "OpenAI API Key"
-regex = '''sk-[a-zA-Z0-9]{48}'''
-tags = ["key", "openai"]
-
-[[rules]]
-id = "generic-api-key"
-description = "Generic API Key"
-regex = '''(?i)(api[_-]?key|apikey)['":\s]*[=:]\s*['"][a-zA-Z0-9]{16,}['"]'''
-tags = ["key", "generic"]
-
-[[rules]]
-id = "generic-password"
-description = "Generic Password"
-regex = '''(?i)(password|passwd|pwd)['":\s]*[=:]\s*['"][^'"]{4,}['"]'''
-tags = ["password"]
-```
-
-### 6.3 detect-secrets
-
-**Installation and baseline**
-
-```bash
-# Install
-pip install detect-secrets
-
-# Generate baseline
-detect-secrets scan > .secrets.baseline
-
-# Audit baseline (mark false positives)
-detect-secrets audit .secrets.baseline
-
-# Update baseline after adding new secrets
-detect-secrets scan --baseline .secrets.baseline
-```
-
-**Pre-commit hook**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
-    hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
-```
-
-### 6.4 Husky (Node.js Projects)
-
-**Installation**
-
-```bash
-# Install husky
-npm install --save-dev husky
-
-# Initialize husky
-npx husky init
-```
-
-**Pre-commit hook for secrets**
-
-```bash
-# Create pre-commit hook
-cat > .husky/pre-commit << 'EOF'
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-# Check for secrets with gitleaks
-if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose
-  if [ $? -ne 0 ]; then
-    echo "Secrets detected! Commit blocked."
-    exit 1
-  fi
-fi
-
-# Check for forbidden files
-FORBIDDEN_PATTERNS=".env .env.* *.pem *.key credentials.json secrets.*"
-for pattern in $FORBIDDEN_PATTERNS; do
-  if git diff --cached --name-only | grep -E "$pattern"; then
-    echo "ERROR: Attempting to commit forbidden file: $pattern"
-    exit 1
-  fi
-done
-
-exit 0
-EOF
-
-chmod +x .husky/pre-commit
-```
-
-### 6.5 Custom Pre-Commit Hook Script
-
-```bash
-#!/bin/bash
-# .git/hooks/pre-commit
-
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-NC='\033[0m'
-
-echo "Running secret detection..."
-
-# Forbidden file patterns
-FORBIDDEN_FILES=(
-  ".env"
-  ".env.*"
-  "*.env"
-  "credentials.json"
-  "*-credentials.json"
-  "service-account*.json"
-  "secrets.yml"
-  "secrets.json"
-  "*.pem"
-  "*.key"
-  "*.p12"
-  "*.pfx"
-  "id_rsa"
-  "id_rsa.*"
-  "id_ed25519"
-  "id_ecdsa"
-  ".npmrc"
-  ".pypirc"
-)
-
-# Secret patterns to detect in content
-SECRET_PATTERNS=(
-  "-----BEGIN.*PRIVATE KEY-----"
-  "api[_-]?key.*[=:].*['\"][a-zA-Z0-9]{16,}['\"]"
-  "password.*[=:].*['\"][^'\"]{4,}['\"]"
-  "secret.*[=:].*['\"][a-zA-Z0-9]{16,}['\"]"
-  "sk-ant-[a-zA-Z0-9\-_]{40,}"
-  "sk-[a-zA-Z0-9]{48}"
-  "AKIA[0-9A-Z]{16}"
-  "ghp_[A-Za-z0-9_]{36,}"
-  "xox[baprs]-[0-9]{10,}"
-)
-
-ERRORS=0
-
-# Check for forbidden files
-for pattern in "${FORBIDDEN_FILES[@]}"; do
-  files=$(git diff --cached --name-only | grep -E "^$pattern$|/$pattern$" || true)
-  if [ -n "$files" ]; then
-    echo -e "${RED}ERROR: Forbidden file pattern '$pattern' detected:${NC}"
-    echo "$files"
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-# Check for secret patterns in staged content
-for pattern in "${SECRET_PATTERNS[@]}"; do
-  matches=$(git diff --cached -U0 | grep -E "^\+" | grep -E "$pattern" || true)
-  if [ -n "$matches" ]; then
-    echo -e "${YELLOW}WARNING: Possible secret detected (pattern: $pattern):${NC}"
-    echo "$matches" | head -3
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-# Run gitleaks if available
-if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose --redact
-  if [ $? -ne 0 ]; then
-    ERRORS=$((ERRORS + 1))
-  fi
-fi
-
-if [ $ERRORS -gt 0 ]; then
-  echo ""
-  echo -e "${RED}===============================================${NC}"
-  echo -e "${RED}COMMIT BLOCKED: $ERRORS potential secret(s) found${NC}"
-  echo -e "${RED}===============================================${NC}"
-  echo ""
-  echo "If these are false positives, you can:"
-  echo "  1. Add to .gitleaks.toml allowlist"
-  echo "  2. Use: git commit --no-verify (NOT RECOMMENDED)"
-  echo ""
-  exit 1
-fi
-
-echo -e "${GREEN}No secrets detected. Proceeding with commit.${NC}"
-exit 0
-```
-
-```bash
-# Make executable
-chmod +x .git/hooks/pre-commit
-```
-
----
-
-## 7. CI/CD Integration
-
-### 7.1 GitHub Actions
-
-```yaml
-# .github/workflows/secrets-scan.yml
-name: Secret Scanning
-
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-
-jobs:
-  gitleaks:
-    name: Gitleaks Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # Optional for enterprise
-
-  trufflehog:
-    name: TruffleHog Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --only-verified
-
-  detect-secrets:
-    name: Detect Secrets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install detect-secrets
-        run: pip install detect-secrets
-
-      - name: Run detect-secrets
-        run: |
-          detect-secrets scan --baseline .secrets.baseline
-          detect-secrets audit --report --baseline .secrets.baseline
-```
-
-### 7.2 GitLab CI
-
-```yaml
-# .gitlab-ci.yml
-stages:
-  - security
-
-gitleaks:
-  stage: security
-  image: zricethezav/gitleaks:latest
-  script:
-    - gitleaks detect --source . --verbose --report-format json --report-path gitleaks-report.json
-  artifacts:
-    reports:
-      secret_detection: gitleaks-report.json
-    when: always
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
-
-secret_detection:
-  stage: security
-  image: registry.gitlab.com/gitlab-org/security-products/analyzers/secrets:latest
-  script:
-    - /analyzer run
-  artifacts:
-    reports:
-      secret_detection: gl-secret-detection-report.json
-```
-
-### 7.3 CircleCI
-
-```yaml
-# .circleci/config.yml
-version: 2.1
-
-orbs:
-  gitleaks: upsidr/gitleaks@2.0.0
-
-jobs:
-  secret-scan:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Install gitleaks
-          command: |
-            curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz | tar xz
-            sudo mv gitleaks /usr/local/bin/
-      - run:
-          name: Run gitleaks
-          command: gitleaks detect --source . --verbose
-
-workflows:
-  security:
-    jobs:
-      - secret-scan
-```
-
-### 7.4 Jenkins
-
-```groovy
-// Jenkinsfile
-pipeline {
-    agent any
-
-    stages {
-        stage('Secret Scan') {
-            steps {
-                sh '''
-                    # Install gitleaks if not present
-                    if ! command -v gitleaks &> /dev/null; then
-                        curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz | tar xz
-                        mv gitleaks /usr/local/bin/
-                    fi
-
-                    # Run scan
-                    gitleaks detect --source . --verbose --report-format json --report-path gitleaks-report.json
-                '''
-            }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'gitleaks-report.json', allowEmptyArchive: true
-                }
-            }
-        }
-    }
-}
-```
-
----
-
-## 8. Checklist
-
-### Pre-Open Source Checklist
-
-```markdown
-## File System Scan
-- [ ] No .env files tracked in repository
-- [ ] No credential files (*.pem, *.key, *.p12) tracked
-- [ ] No service account JSON files tracked
-- [ ] No .npmrc with auth tokens tracked
-- [ ] .gitignore includes all sensitive patterns
-
-## Code Scan
-- [ ] No hardcoded API keys in source files
-- [ ] No hardcoded passwords in source files
-- [ ] No hardcoded connection strings with credentials
-- [ ] No private keys embedded in code
-- [ ] No personal information (emails, names) in comments
-
-## Git History Scan
-- [ ] Ran gitleaks on full history
-- [ ] No sensitive files ever committed (including deleted)
-- [ ] No secrets in any branch or tag
-- [ ] Checked merge commits for leaks
-- [ ] Checked stashes for sensitive data
-
-## Configuration
-- [ ] .env.example exists with placeholder values
-- [ ] README documents required environment variables
-- [ ] No default credentials in config files
-- [ ] Database seeds use fake data
-
-## Prevention Setup
-- [ ] Pre-commit hooks installed (gitleaks or git-secrets)
-- [ ] .gitleaks.toml configured for project
-- [ ] CI/CD secret scanning enabled
-- [ ] Team trained on secret hygiene
-
-## Credential Rotation
-- [ ] All previously leaked credentials rotated
-- [ ] New credentials generated for open source version
-- [ ] Access logs reviewed for unauthorized usage
-```
-
-### Emergency Response Checklist
-
-```markdown
-## Immediate Actions (within minutes)
-- [ ] Rotate compromised credential immediately
-- [ ] Revoke access tokens
-- [ ] Change affected passwords
-- [ ] Disable exposed API keys
-
-## Investigation (within hours)
-- [ ] Check access logs for unauthorized usage
-- [ ] Identify scope of exposure (which commits, branches)
-- [ ] Determine if credential was scraped by bots
-- [ ] Check for unusual account activity
-
-## Remediation (within day)
-- [ ] Clean git history using git-filter-repo or BFG
-- [ ] Force push cleaned history
-- [ ] Notify all collaborators to re-clone
-- [ ] Update .gitignore to prevent recurrence
-- [ ] Set up pre-commit hooks
-
-## Documentation
-- [ ] Document incident timeline
-- [ ] Document affected systems
-- [ ] Document remediation steps taken
-- [ ] Update security procedures
-```
-
----
-
-## 9. Output Format
-
-### Scan Report Template
-
-```markdown
-# Security Scan Report
-
-**Repository**: [repo-name]
-**Scan Date**: [YYYY-MM-DD HH:MM]
-**Scanned By**: [tool/person]
-
-## Summary
-
-| Category | Status | Count |
-|----------|--------|-------|
-| Sensitive Files (Current) | [PASS/FAIL] | [N] |
-| Sensitive Files (History) | [PASS/FAIL] | [N] |
-| Hardcoded Secrets | [PASS/FAIL] | [N] |
-| .gitignore Coverage | [PASS/FAIL] | [N] missing |
-
-## Findings
-
-### Critical (Immediate Action Required)
-
-| File/Location | Type | Details | Commit |
-|---------------|------|---------|--------|
-| .env | Environment File | Tracked in repo | abc1234 |
-| src/config.ts:42 | API Key | OpenAI key detected | def5678 |
-
-### Warning (Review Required)
-
-| File/Location | Type | Details | Commit |
-|---------------|------|---------|--------|
-| config/db.yml | Connection String | May contain password | - |
-
-### Info (False Positives / Reviewed)
-
-| File/Location | Type | Details | Status |
-|---------------|------|---------|--------|
-| .env.example | Example File | Contains placeholders | OK |
-
-## Recommendations
-
-1. **URGENT**: Rotate OpenAI API key immediately
-2. **HIGH**: Remove .env from git history using git-filter-repo
-3. **MEDIUM**: Add missing patterns to .gitignore
-4. **LOW**: Set up pre-commit hooks for ongoing protection
-
-## Commands to Execute
-
-```bash
-# Step 1: Create backup
-git clone --mirror . ../repo-backup-$(date +%Y%m%d)
-
-# Step 2: Remove sensitive files from history
-git filter-repo --path .env --invert-paths
-
-# Step 3: Update .gitignore
-echo ".env" >> .gitignore
-echo "*.pem" >> .gitignore
-
-# Step 4: Force push
-git push origin --force --all
-```
-
-```
-
----
-
-## 10. Best Practices
-
-### Development Workflow
-
-1. **Never commit secrets** - Use environment variables
-2. **Use .env.example** - Document required variables without values
-3. **Git hooks from day one** - Install pre-commit hooks immediately
-4. **Regular audits** - Run gitleaks weekly in CI/CD
-5. **Principle of least privilege** - Use separate keys for dev/staging/prod
-
-### Environment Variable Management
-
-```bash
-# .env.example (safe to commit)
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/MYDB
-OPENAI_API_KEY=your_openai_key_here
-STRIPE_SECRET_KEY=your_stripe_key_here
-
-# .env (NEVER commit)
-DATABASE_URL=postgresql://USER:PASSWORD@prod.example.com:5432/proddb
-OPENAI_API_KEY=sk-abc123...
-STRIPE_SECRET_KEY=sk_live_abc123...
-```
-
-### Secret Management Tools
-
-For production applications, use dedicated secret management:
-
-- **AWS Secrets Manager**
-- **HashiCorp Vault**
-- **Google Secret Manager**
-- **Azure Key Vault**
-- **Doppler**
-- **1Password Secrets Automation**
-
-### Team Training
-
-1. Educate team on risks of committed secrets
-2. Establish code review checklist for secrets
-3. Create incident response procedures
-4. Regular security awareness sessions
-5. Maintain up-to-date .gitignore templates
-
-### Gitignore Template
-
-```gitignore
-# Environment files
-.env
-.env.*
-*.env
-.envrc
-!.env.example
-!.env.template
-
-# Credentials
-credentials.json
-*-credentials.json
-service-account*.json
-secrets.yml
-secrets.json
-*.secret
-api_keys.*
-auth.json
-
-# Private keys
-*.pem
-*.key
-*.p12
-*.pfx
-id_rsa
-id_rsa.*
-id_ed25519
-id_ed25519.*
-id_ecdsa
-id_ecdsa.*
-*.keystore
-*.jks
-
-# Cloud provider
-.aws/
-.gcp/
-.azure/
-kubeconfig
-.kube/
-
-# Package manager auth
-.npmrc
-.yarnrc.yml
-.pypirc
-.gem/credentials
-.docker/config.json
-
-# IDE (may contain secrets)
-.idea/
-.vscode/settings.json
-*.sublime-workspace
-
-# Logs (may contain secrets)
-*.log
-logs/
-
-# Database
-*.sql
-!schema.sql
-!migrations/*.sql
-
-# OS files
-.DS_Store
-Thumbs.db
-```
-
----
-
-## Quick Reference Commands
-
-```bash
-# === SCANNING ===
-# Quick file scan
-find . -name ".env*" -o -name "*.pem" -o -name "*.key" | grep -v node_modules
-
-# Quick history scan
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -iE 'env|secret|credential|key'
-
-# Full gitleaks scan
+# === PASS 2: HISTORY SECRETS ===
 gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.env|\.pem'
 
-# === CLEANING ===
-# Remove file from history
-git filter-repo --path .env --invert-paths --force
+# === PASS 3: PRIVATE REFERENCES ===
+grep -rniE '\.(internal|corp|local)\b' . | grep -v node_modules
+git log --all --format='%an <%ae>' | sort -u
 
-# Force push after clean
-git push origin --force --all
+# === PASS 4: READINESS ===
+ls README* .env.example && cat .github/CODEOWNERS
 
-# === PREVENTION ===
-# Install git-secrets
-brew install git-secrets && git secrets --install && git secrets --register-aws
-
-# Install gitleaks pre-commit
-cat > .pre-commit-config.yaml << EOF
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.1
-    hooks:
-      - id: gitleaks
-EOF
-pre-commit install
+# === HANDOFF ===
+# Rotation, history rewrite, force-push, and the ongoing commit-time guard
+# are the git-safety skill's job — this audit produces the list only.
 ```
-
----
-
-**Remember**: Removing secrets from git history does NOT make them safe. Always rotate leaked credentials immediately. Cleaning history is for compliance and reducing exposure, not security.

--- a/skills/git-safety/SKILL.md
+++ b/skills/git-safety/SKILL.md
@@ -1,128 +1,189 @@
 ---
 name: git-safety
 description: >-
-  Scans, cleans, and prevents secrets in git history across four modes: scan
-  (detect sensitive files in the current state and history), clean (rewrite
-  history to remove secrets using git-filter-repo or BFG), prevent (add
-  .gitignore and pre-commit hooks), and full (all three in sequence). Use when
-  the user asks to check for leaked credentials, scrub a secret from git
-  history, force-push a cleaned repo, set up pre-commit secret prevention, or
-  run a full git security audit.
+  Guards day-to-day git work in an existing repository: blocks secrets from
+  entering a commit, gates destructive git operations before they run, installs
+  ignore rules and pre-commit hooks, and drives the rotate-first response when a
+  credential has already leaked.
 metadata:
-  version: "1.0.0"
-  tags: "git, security, secrets"
+  version: "1.1.0"
+  tags: "git, security, secrets, pre-commit"
+when_to_use: "about to commit, check what is staged, staged secret, pre-commit hook, pre-push check, force push, push --force, reset --hard, clean -fdx, rewrite git history, filter-repo, BFG, scrub a leaked credential, rotate a leaked key, git safety check"
 disable-model-invocation: true
 ---
 
-# Git Safety Skill
+# Git Safety
+
+Two guards, one repository you already work in every day:
+
+- **Staged guard** — nothing sensitive enters the next commit.
+- **Operation guard** — no destructive git command runs unconfirmed and unbacked.
+
+Both are recurring. They run at commit time and at push time, on every branch,
+forever. A one-time audit of a whole repository before it goes public is a
+different moment — see [Related](#related).
 
 ## Contract
 
 Inputs:
 
 - Repository root
-- Mode: scan, prevent, clean, or full
-- Optional leaked path, secret pattern, or affected ref range
+- Mode: `scan`, `guard`, `prevent`, `clean`, or `full`
+- For `clean`: the leaked path or secret string, and the refs it touches
 
 Outputs:
 
-- Sensitive file/history findings
-- Rotation and remediation checklist
-- Commands required for prevention or history cleanup
+- Staged findings with a block/allow verdict per file
+- Destructive-operation risk assessment and backup command
+- Rotation checklist for anything already pushed
 
 Creates/Modifies:
 
-- Scan mode: no file changes
-- Prevent mode: `.gitignore` and optional hook updates
-- Clean mode: rewritten git history only after explicit confirmation
+- `scan` and `guard`: no file changes
+- `prevent`: `.gitignore`, `.env.example`, and hook files
+- `clean`: rewritten git history, only after explicit confirmation
 
 External Side Effects:
 
-- May force-push rewritten history in clean mode
-- May require credential rotation outside the repository
+- May force-push rewritten history in `clean` mode
+- Requires credential rotation on systems outside the repository
 
 Confirmation Required:
 
-- Before history rewriting
-- Before force-pushing
-- Before changing hooks or ignore rules in shared repos
+- Before rewriting history
+- Before force-pushing or any push that discards remote commits
+- Before `reset --hard`, `clean -fdx`, or branch/tag deletion
+- Before changing hooks or ignore rules in a shared repository
 
 Delegates To:
 
+- `open-source-checker` before publishing a private repository
 - `security-audit` for broader application-security review
-- `open-source-checker` before publishing a private repo
 
-## CRITICAL WARNING
+## Rotate first
 
-**Removing secrets from git history does NOT make them safe!**
+Removing a secret from git history does **not** make it safe. Once pushed:
 
-Even after cleaning git history:
+- Bots scrape new pushes within seconds
+- Archive and mirror services may hold snapshots
+- Forks keep the original history
+- CI/CD logs may hold the value
 
-- GitHub is scraped by bots within seconds of a push
-- Archive services may have captured snapshots
-- Forks retain the original history
-- CI/CD logs may contain the values
+Rotate the credential at its source before touching history. History rewriting
+is cleanup, never containment. The bound: the old value is rejected by the
+issuing system.
 
-**ALWAYS rotate leaked credentials immediately.** Cleaning history is NOT enough.
+## Modes
 
-## Modes of Operation
+| Mode | Moment | Ends when |
+|------|--------|-----------|
+| `scan` | Before committing | Every staged file and added line is cleared or flagged |
+| `guard` | Before a destructive command | Blast radius stated, backup made, operator confirmed |
+| `prevent` | Once per repo, then on drift | Ignore rules and hook block a known-bad test commit |
+| `clean` | After a confirmed leak, post-rotation | Secret absent from every ref, collaborators notified |
+| `full` | New repo onboarding | `scan` → `prevent` complete |
 
-### 1. `/git-safety scan` - Detect Sensitive Files
+### `scan` — staged guard
 
-Scan repository for sensitive files in current state and git history.
-
-### 2. `/git-safety clean` - Remove from History
-
-Remove sensitive files using git-filter-repo or BFG.
-
-### 3. `/git-safety prevent` - Set Up Prevention
-
-Configure .gitignore and pre-commit hooks.
-
-### 4. `/git-safety full` - Complete Audit
-
-Run all three operations in sequence.
-
-## Sensitive File Patterns
-
-```
-.env, .env.*, credentials.json, service-account*.json
-*.pem, *.key, id_rsa*, secrets.*, .npmrc, *.secret
-```
-
-## Quick Commands
-
-**Scan for sensitive files in history:**
+Scope is the working tree and the staged diff, not history.
 
 ```bash
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -iE 'env|secret|credential|key'
+# Files about to be committed
+git diff --cached --name-only
+
+# Sensitive filenames among them
+git diff --cached --name-only | grep -iE '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|secret)$|credentials|service-account|id_rsa|id_ed25519|\.npmrc$|kubeconfig'
+
+# Secret-shaped values in added lines only
+git diff --cached -U0 | grep -E '^\+' | grep -iE '(api[_-]?key|secret[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|password)[^a-z]{0,4}[=:][^=:]{8,}'
+
+# Untracked files sitting in the tree that must never be added
+git status --porcelain --untracked-files=all | grep -E '^\?\?' | grep -iE '\.env|\.pem$|\.key$|credentials|secrets\.'
 ```
 
-**Remove .env from all history:**
+Verdict per finding: **block** (real credential), **allow** (placeholder,
+fixture, or example), or **ask** when the value cannot be classified from the
+diff alone. Report the file and line for each block. Ends when every staged path
+carries a verdict.
+
+### `guard` — destructive operation gate
+
+Any of these rewrites or discards work that git cannot recover for a
+collaborator:
+
+| Command | Discards |
+|---------|----------|
+| `git push --force` / `--force-with-lease` | Remote commits others may hold |
+| `git filter-repo`, `bfg` | Every commit hash in the repository |
+| `git reset --hard` | Uncommitted work in the tree and index |
+| `git clean -fdx` | Untracked files, including local `.env` |
+| `git checkout -- <path>` | Uncommitted edits to that path |
+| `git branch -D`, `git push origin --delete` | Unmerged commits on that ref |
+| `git rebase` on a pushed branch | Published commits under collaborators |
+
+Before running one:
+
+1. **State the blast radius** — which refs change, whose clones break, what is
+   unrecoverable.
+2. **Back up** — `git clone --mirror . ../repo-backup-$(date +%Y%m%d)` for any
+   history rewrite; `git stash -u` before a `reset --hard` or `clean -fdx`.
+3. **Prefer the reversible form** — `--force-with-lease` over `--force`,
+   `git revert` over `reset --hard` on a pushed branch, `git stash` over
+   `checkout --`.
+4. **Confirm with the operator**, quoting the exact command.
+
+Ends when the operator confirms against a stated blast radius, or the reversible
+alternative is used instead.
+
+### `prevent` — make the guard automatic
+
+Add the ignore rules, write the pre-commit hook, and create `.env.example`.
+Patterns, the full hook script, and `git secrets` setup are in
+`references/full-guide.md`.
+
+Ends when a deliberate test commit of a dummy `.env` is rejected by the hook.
+
+### `clean` — rewrite history after a leak
+
+Runs only after rotation is confirmed, and only inside the `guard` gate above.
 
 ```bash
-git filter-repo --path .env --invert-paths --force
-git push origin --force --all
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+git filter-repo --path .env --invert-paths
+git push origin --force --all && git push origin --force --tags
 ```
 
-**Add to .gitignore:**
+Verify:
 
 ```bash
-echo -e "\n.env\n.env.*\n*.pem\n*.key\ncredentials.json" >> .gitignore
+git log --all --full-history -- .env     # empty
+git log -p --all -S '<rotated-value>'    # empty
 ```
 
-## Emergency Response
+Ends when both verifications return empty and every collaborator has re-cloned.
 
-If you've leaked credentials:
+## Emergency response
 
-1. **IMMEDIATELY rotate the credential**
-2. Check access logs
-3. Run `/git-safety clean`
-4. Force push cleaned history
-5. Notify team to re-clone
-6. Update .gitignore
-7. Set up pre-commit hooks
+A credential is in a pushed commit:
+
+1. Rotate the credential. Nothing else counts until this is done.
+2. Check the provider's access logs for use of the old value.
+3. Run `clean` to strip it from history.
+4. Force-push through the `guard` gate.
+5. Tell collaborators to re-clone; forks and open PRs keep the old history.
+6. Run `prevent` so the same file cannot be staged again.
+7. Write down what leaked, when, and what was rotated.
+
+## Related
+
+- `open-source-checker` — the one-time audit before a private repository is
+  published: license and attribution, secrets across the entire history,
+  internal hostnames and employee references. Run it once, at the publish
+  decision; run `git-safety` at every commit thereafter.
+- `security-audit` — application-level vulnerability review, not git state.
 
 ---
 
-**For complete scan commands, cleaning process with git-filter-repo/BFG, pre-commit hook setup, .gitignore templates, platform-specific guidance, and detailed emergency checklist, see:** `references/full-guide.md`
+**Full sensitive-file patterns, the complete pre-commit hook script, `.gitignore`
+template, `git secrets` setup, BFG alternative, and platform notes:**
+`references/full-guide.md`

--- a/skills/git-safety/plugin.json
+++ b/skills/git-safety/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "git-safety",
-  "version": "1.0.0",
-  "description": "Scan, clean, and prevent secrets in git history and repository state.",
+  "version": "1.1.0",
+  "description": "Block secrets from entering a commit and gate destructive git operations.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/git-safety/references/full-guide.md
+++ b/skills/git-safety/references/full-guide.md
@@ -1,10 +1,20 @@
-# Git Safety - Full Guide
+# Git Safety — Full Guide
 
-## 1. SCAN - Detect Sensitive Files
+Reference material for the two recurring guards: what must never enter a commit,
+and what must never run without confirmation.
 
-### Sensitive File Patterns
+Scope note: this guide covers the **ongoing** moment — commit time, push time,
+and leak response in a repository you already work in. The one-time audit of a
+whole repository before publication (license, attribution, full-history sweep,
+internal references) belongs to the `open-source-checker` skill.
 
-```bash
+---
+
+## 1. Sensitive File Patterns
+
+Filenames that should never be staged:
+
+```
 # Environment files
 .env
 .env.*
@@ -28,12 +38,10 @@ id_ecdsa*
 .aws/config
 .gcp/credentials.json
 .azure/credentials
+kubeconfig
+.kube/config
 
-# Database
-*.sql (check for passwords)
-database.yml (check for passwords)
-
-# API/Secret files
+# API/secret files
 secrets.yml
 secrets.json
 *.secret
@@ -41,217 +49,156 @@ api_keys.*
 auth.json
 
 # Package manager tokens
-.npmrc (with auth tokens)
+.npmrc
 .pypirc
 .gem/credentials
+.docker/config.json
 
 # Other
-*.log (may contain secrets)
 .htpasswd
 .netrc
-.docker/config.json
-kubeconfig
+*.log          # may contain secrets
+*.sql          # may contain passwords or production data
+database.yml   # may contain passwords
 ```
 
-### Scan Commands
+Allowlist the safe siblings explicitly: `.env.example`, `.env.template`,
+`schema.sql`, `migrations/*.sql`.
 
-**Step 1: Check current working directory**
+---
+
+## 2. Staged Guard Commands
+
+### 2.1 What is about to be committed
 
 ```bash
-# List potentially sensitive files in current state
-find . -type f \( \
-  -name ".env" -o \
-  -name ".env.*" -o \
-  -name "*.env" -o \
-  -name "credentials.json" -o \
-  -name "service-account*.json" -o \
-  -name "*.pem" -o \
-  -name "*.key" -o \
-  -name "id_rsa*" -o \
-  -name "secrets.*" -o \
-  -name ".npmrc" -o \
-  -name "*.secret" \
-\) 2>/dev/null | grep -v node_modules | grep -v .git
+# Names only
+git diff --cached --name-only
+
+# With status letters (A/M/D)
+git diff --cached --name-status
+
+# Full added content, no context lines
+git diff --cached -U0
 ```
 
-**Step 2: Check git history for sensitive files**
+### 2.2 Sensitive filenames in the staged set
 
 ```bash
-# Search all commits for sensitive filenames
-git log --all --full-history --diff-filter=A -- \
-  "*.env" ".env" ".env.*" \
-  "credentials.json" "service-account*.json" \
-  "*.pem" "*.key" "id_rsa*" \
-  "secrets.*" ".npmrc" "*.secret" \
-  --name-only --pretty=format:"%h %s" 2>/dev/null
-
-# Alternative: List all files ever committed
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -E '\.(env|pem|key|secret)$|credentials|secrets\.|id_rsa'
+git diff --cached --name-only | grep -iE \
+  '(^|/)\.env($|\.)|\.(pem|key|p12|pfx|secret)$|credentials|service-account|id_rsa|id_ed25519|\.npmrc$|kubeconfig'
 ```
 
-**Step 3: Search for secrets in file contents**
+### 2.3 Secret-shaped values in added lines
+
+Scan only lines the commit adds — existing lines are history's problem, not this
+commit's.
 
 ```bash
-# Search for common secret patterns in tracked files
-git grep -E "(api[_-]?key|apikey|secret[_-]?key|password|passwd|pwd|token|auth[_-]?token|access[_-]?token|private[_-]?key|client[_-]?secret)" --cached -- ':!*.lock' ':!package-lock.json' ':!yarn.lock' 2>/dev/null | head -50
+# Generic assignment shapes
+git diff --cached -U0 | grep -E '^\+' | grep -iE \
+  '(api[_-]?key|apikey|secret[_-]?key|client[_-]?secret|access[_-]?token|auth[_-]?token|password|passwd)[^a-z]{0,4}[=:][^=:]{8,}'
 
-# Search git history for secret patterns (expensive but thorough)
-git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock' 2>/dev/null | head -100
+# Private key material
+git diff --cached -U0 | grep -E '^\+' | grep -E 'BEGIN (RSA|EC|OPENSSH|PGP)? ?PRIVATE KEY'
+
+# Vendor key prefixes (extend for the providers you use)
+git diff --cached -U0 | grep -E '^\+' | grep -E \
+  'AKIA[0-9A-Z]{16}|gh[pousr]_[A-Za-z0-9]{36}|xox[baprs]-[0-9A-Za-z-]{10,}|AIza[0-9A-Za-z_-]{35}'
+
+# Credentials embedded in a connection URI (scheme split so this file does not
+# itself contain a URI-shaped literal that trips downstream secret scanners)
+git diff --cached -U0 | grep -E '^\+' | grep -E '[a-z]+:'"//"'[^:@/]+:[^:@/]+@'
 ```
 
-**Step 4: Check .gitignore coverage**
+### 2.4 Untracked files sitting in the tree
+
+Not staged today, easy to `git add -A` tomorrow:
 
 ```bash
-# Verify sensitive patterns are in .gitignore
+git status --porcelain --untracked-files=all \
+  | grep -E '^\?\?' \
+  | grep -iE '\.env|\.pem$|\.key$|credentials|secrets\.'
+```
+
+### 2.5 Ignore-rule coverage
+
+```bash
 for pattern in ".env" ".env.*" "*.pem" "*.key" "credentials.json" "secrets.*"; do
-  if ! grep -q "$pattern" .gitignore 2>/dev/null; then
-    echo "Missing from .gitignore: $pattern"
-  fi
+  grep -q -- "$pattern" .gitignore 2>/dev/null || echo "Missing from .gitignore: $pattern"
 done
 ```
 
-### Scan Report Format
+### 2.6 Verdict format
 
 ```
-## Git Safety Scan Results
+## Staged Guard — <branch>, <n> files staged
 
-### Current Directory
-- [ ] No sensitive files found
-- [X] Found: .env.local (not tracked - OK)
-- [!] Found: credentials.json (TRACKED - DANGER)
+BLOCK  src/config.ts:42        live-looking API key in an added line
+BLOCK  credentials.json        forbidden filename, newly added
+ASK    tests/fixtures/key.pem  private key — confirm it is a throwaway test key
+ALLOW  .env.example            placeholder values only
 
-### Git History
-- [ ] No sensitive files in history
-- [!] Found in history: .env (commit abc1234, 2024-01-15)
-- [!] Found in history: api-keys.json (commit def5678, 2024-02-20)
+Untracked but present: .env.local (ignored — OK)
+.gitignore gaps: *.pem, credentials.json
 
-### Secret Patterns in Code
-- [ ] No hardcoded secrets detected
-- [!] Possible API key in: src/config.ts:42
-
-### .gitignore Coverage
-- [X] .env patterns covered
-- [ ] Missing: *.pem
-- [ ] Missing: credentials.json
-
-### Recommendations
-1. [URGENT] Rotate any exposed credentials immediately
-2. Run `/git-safety clean` to remove files from history
-3. Run `/git-safety prevent` to update .gitignore
+Next: unstage the two BLOCK paths, then rerun.
 ```
 
 ---
 
-## 2. CLEAN - Remove from Git History
+## 3. Destructive Operation Gate
 
-### Prerequisites Check
+### 3.1 Blast radius by command
 
-```bash
-# Check if git-filter-repo is installed (preferred)
-which git-filter-repo
+| Command | Rewrites | Discards | Recoverable via |
+|---------|----------|----------|-----------------|
+| `git push --force` | Remote refs | Remote commits others hold | Their local reflog only |
+| `git push --force-with-lease` | Remote refs | Same, but aborts on unseen updates | Preferred form |
+| `git filter-repo` / `bfg` | All commit hashes | Nothing, if mirrored first | Mirror backup |
+| `git reset --hard` | Index and tree | Uncommitted work | `git stash` beforehand |
+| `git clean -fdx` | Tree | Untracked files, local `.env` | Nothing |
+| `git checkout -- <path>` | Tree | Uncommitted edits to that path | Nothing |
+| `git branch -D` | Local ref | Unmerged commits | Local reflog, ~90 days |
+| `git push origin --delete` | Remote ref | Unmerged commits on the remote | Nothing reliable |
+| `git rebase` on a pushed branch | Local history | Published commit identity | Force-push follows |
 
-# Check if BFG is available (alternative)
-which bfg
-```
-
-### Installation (if needed)
-
-```bash
-# Install git-filter-repo (recommended)
-pip install git-filter-repo
-
-# Or via Homebrew on macOS
-brew install git-filter-repo
-
-# BFG alternative (Java required)
-brew install bfg
-```
-
-### Cleaning Process
-
-**IMPORTANT: Before cleaning, ensure:**
-
-1. All team members have pushed their changes
-2. You have a backup of the repository
-3. You understand this rewrites history (force push required)
-
-**Step 1: Create backup**
+### 3.2 Backup commands
 
 ```bash
-# Clone a backup
+# Before any history rewrite
 git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# Before reset --hard or clean -fdx
+git stash push --include-untracked -m "pre-destructive-op $(date +%FT%T)"
+
+# Before deleting a branch, keep a pointer
+git tag archive/<branch-name> <branch-name>
 ```
 
-**Step 2: Remove specific files with git-filter-repo**
+### 3.3 Reversible alternatives
+
+| Instead of | Use | Why |
+|-----------|-----|-----|
+| `push --force` | `push --force-with-lease` | Aborts if the remote moved since your last fetch |
+| `reset --hard` on a pushed branch | `git revert <sha>` | Adds a commit; collaborators keep their history |
+| `checkout -- <path>` | `git stash push <path>` | Recoverable from the stash list |
+| `clean -fdx` | `git clean -nd` first | Dry run lists what would be deleted |
+| `branch -D` | `git branch -d` | Refuses when the branch has unmerged commits |
+
+### 3.4 Dry runs
 
 ```bash
-# Remove a single file from all history
-git filter-repo --path .env --invert-paths
-
-# Remove multiple files
-git filter-repo --path .env --path credentials.json --path secrets.yml --invert-paths
-
-# Remove by pattern
-git filter-repo --path-glob '*.env' --invert-paths
-git filter-repo --path-glob '*.pem' --invert-paths
-```
-
-**Step 3: Alternative - BFG Repo Cleaner**
-
-```bash
-# Remove specific file
-bfg --delete-files .env
-
-# Remove files matching pattern
-bfg --delete-files '*.pem'
-
-# Remove files containing secrets (by content)
-bfg --replace-text passwords.txt  # File containing patterns to remove
-```
-
-**Step 4: Clean up and force push**
-
-```bash
-# Expire old references
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-
-# Force push to remote (DESTRUCTIVE - requires --force)
-# WARNING: This rewrites history for ALL collaborators
-git push origin --force --all
-git push origin --force --tags
-```
-
-**Step 5: Notify team**
-All collaborators must:
-
-```bash
-# Delete local repo and re-clone
-rm -rf local-repo
-git clone <remote-url>
-
-# OR rebase on new history (advanced)
-git fetch origin
-git rebase origin/main
-```
-
-### Post-Clean Verification
-
-```bash
-# Verify file is gone from all history
-git log --all --full-history -- .env
-# Should return empty
-
-# Verify content is gone
-git log -p --all -S 'YOUR_SECRET_VALUE' --source
-# Should return empty
+git clean -nd                          # list what clean would remove
+git push --force-with-lease --dry-run  # show refs that would move
+git filter-repo --path .env --invert-paths --dry-run
 ```
 
 ---
 
-## 3. PREVENT - Set Up Protection
+## 4. Prevention Setup
 
-### Update .gitignore
+### 4.1 `.gitignore` template
 
 ```gitignore
 # Environment files
@@ -315,59 +262,52 @@ Thumbs.db
 .vscode/settings.json
 ```
 
-### Set Up Pre-commit Hook
+### 4.2 Pre-commit hook
 
 Create `.git/hooks/pre-commit`:
 
 ```bash
 #!/bin/bash
-# Pre-commit hook to prevent committing sensitive files
+# Block sensitive files and secret-shaped values from entering a commit.
 
 RED='\033[0;31m'
 YELLOW='\033[1;33m'
 NC='\033[0m'
 
-# Files that should never be committed
 FORBIDDEN_FILES=(
-  ".env"
-  "credentials.json"
-  "secrets.yml"
-  "secrets.json"
-  "*.pem"
-  "*.key"
+  "(^|/)\.env($|\.)"
+  "credentials\.json"
+  "service-account.*\.json"
+  "secrets\.(yml|json)"
+  "\.(pem|key|p12|pfx)$"
   "id_rsa"
-  ".npmrc"
+  "^\.npmrc$"
 )
 
-# Patterns that indicate secrets in file content
 SECRET_PATTERNS=(
-  "PRIVATE KEY"
-  "api_key.*=.*['\"][a-zA-Z0-9]"
-  "apiKey.*:.*['\"][a-zA-Z0-9]"
-  "password.*=.*['\"][^'\"]+['\"]"
-  "secret.*=.*['\"][a-zA-Z0-9]"
-  "AWS_SECRET"
-  "ANTHROPIC_API_KEY"
-  "OPENAI_API_KEY"
+  "BEGIN (RSA|EC|OPENSSH|PGP)? ?PRIVATE KEY"
+  "(api[_-]?key|apikey)[^a-z]{0,4}[=:][^=:]{8,}"
+  "(secret[_-]?key|client[_-]?secret)[^a-z]{0,4}[=:][^=:]{8,}"
+  "password[^a-z]{0,4}[=:]['\"][^'\"]{6,}['\"]"
+  "AKIA[0-9A-Z]{16}"
+  "gh[pousr]_[A-Za-z0-9]{36}"
 )
 
 ERRORS=0
 
-# Check for forbidden files
 for pattern in "${FORBIDDEN_FILES[@]}"; do
   files=$(git diff --cached --name-only | grep -E "$pattern" || true)
   if [ -n "$files" ]; then
-    echo -e "${RED}ERROR: Attempting to commit forbidden file matching '$pattern':${NC}"
+    echo -e "${RED}BLOCKED: forbidden file matching '$pattern':${NC}"
     echo "$files"
     ERRORS=$((ERRORS + 1))
   fi
 done
 
-# Check for secret patterns in staged content
 for pattern in "${SECRET_PATTERNS[@]}"; do
   matches=$(git diff --cached -U0 | grep -E "^\+" | grep -iE "$pattern" || true)
   if [ -n "$matches" ]; then
-    echo -e "${YELLOW}WARNING: Possible secret detected matching '$pattern':${NC}"
+    echo -e "${YELLOW}BLOCKED: possible secret matching '$pattern':${NC}"
     echo "$matches" | head -5
     ERRORS=$((ERRORS + 1))
   fi
@@ -375,86 +315,229 @@ done
 
 if [ $ERRORS -gt 0 ]; then
   echo ""
-  echo -e "${RED}Commit blocked due to potential secrets.${NC}"
-  echo "If this is a false positive, use: git commit --no-verify"
-  echo "But first, verify these files don't contain real secrets!"
+  echo -e "${RED}Commit blocked. Rotate anything real before retrying.${NC}"
+  echo "False positive? Confirm the value is fake, then: git commit --no-verify"
   exit 1
 fi
 
 exit 0
 ```
 
-Make executable:
+Make it executable and prove it bites:
 
 ```bash
 chmod +x .git/hooks/pre-commit
+
+# Verification: this must be rejected
+printf 'API_KEY=abcd1234efgh5678\n' > .env.hooktest
+git add -f .env.hooktest && git commit -m "hook test"   # expect: BLOCKED
+git reset && rm .env.hooktest
 ```
 
-### Set Up git-secrets (Optional - AWS)
+### 4.3 Shared hooks via pre-commit framework
+
+`.git/hooks/` is not committed, so teammates get nothing. Use a tracked config:
+
+```yaml
+# .pre-commit-config.yaml
+repos:
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.18.0
+    hooks:
+      - id: gitleaks
+```
 
 ```bash
-# Install git-secrets
-brew install git-secrets
+pip install pre-commit
+pre-commit install
+```
 
-# Set up for AWS patterns
+### 4.4 `git secrets`
+
+```bash
+brew install git-secrets
 git secrets --install
 git secrets --register-aws
-
-# Add custom patterns
 git secrets --add 'ANTHROPIC_API_KEY.*=.*sk-ant-'
 git secrets --add 'OPENAI_API_KEY.*=.*sk-'
 ```
 
-### Create .env.example Template
+### 4.5 `.env.example` template
 
 ```bash
-# .env.example - Safe template for environment variables
-# Copy to .env and fill in your values
-# NEVER commit .env files!
+# .env.example — safe template. Copy to .env and fill in real values.
+# .env itself is ignored and must never be staged.
 
-# API Keys
 ANTHROPIC_API_KEY=your_key_here
 OPENAI_API_KEY=your_key_here
-
-# Database
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/DBNAME
-
-# Auth
+DATABASE_URL=postgresql:"//"USER:PASSWORD@HOST:5432/DBNAME
 JWT_SECRET=generate_a_secure_random_string
 SESSION_SECRET=generate_another_secure_string
 ```
 
+### 4.6 Server-side backstops
+
+- **GitHub** — enable secret scanning and push protection in repository
+  settings; store CI values in Actions secrets.
+- **GitLab** — enable the Secret Detection CI/CD component; use CI/CD variables.
+- **Vercel / Netlify** — set environment variables in the dashboard, never in
+  the repository.
+
+Push protection rejects the push before the value reaches the remote, which is
+the only control that prevents exposure rather than reacting to it.
+
+### 4.7 CI secret scanning
+
+A hook only runs on machines that installed it. CI catches what slipped past —
+including commits pushed with `--no-verify`.
+
+```yaml
+# .github/workflows/secret-scan.yml
+name: Secret Scan
+on: [push, pull_request]
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0        # full history, or the scan sees one commit
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+```
+
+```yaml
+# .gitlab-ci.yml
+include:
+  - template: Jobs/Secret-Detection.gitlab-ci.yml
+
+secret_detection:
+  variables:
+    SECRET_DETECTION_HISTORIC_SCAN: "true"
+```
+
+`fetch-depth: 0` is the line that matters. A shallow checkout scans only the tip
+commit and reports clean on a repository full of leaked keys.
+
 ---
 
-## Handling Specific Platforms
+## 5. History Rewrite (post-rotation only)
 
-### GitHub
+Rewriting is cleanup. The credential must already be rotated.
 
-- Enable secret scanning in repository settings
-- Use GitHub Actions secrets for CI/CD
-- Consider using GitHub's push protection
+### 5.1 Prerequisites
 
-### GitLab
+```bash
+which git-filter-repo || pip install git-filter-repo   # or: brew install git-filter-repo
+which bfg            || brew install bfg               # Java alternative
+```
 
-- Enable Secret Detection CI/CD component
-- Use CI/CD variables for secrets
+Before starting: every collaborator has pushed, a mirror backup exists, and the
+operator has confirmed the force-push.
 
-### Vercel/Netlify
+### 5.2 git-filter-repo
 
-- Use environment variables in dashboard
-- Never commit production secrets
+```bash
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# Remove one path from every commit
+git filter-repo --path .env --invert-paths
+
+# Several paths
+git filter-repo --path .env --path credentials.json --path secrets.yml --invert-paths
+
+# By glob
+git filter-repo --path-glob '*.pem' --invert-paths
+
+# Redact a value while keeping the file
+git filter-repo --replace-text expressions.txt
+# expressions.txt:
+#   literal:<the-rotated-value>==>[REDACTED]
+#   regex:AKIA[0-9A-Z]{16}==>[REDACTED_AWS_KEY]
+```
+
+### 5.3 BFG alternative
+
+```bash
+bfg --delete-files .env
+bfg --delete-files '*.pem'
+bfg --replace-text passwords.txt
+git reflog expire --expire=now --all && git gc --prune=now --aggressive
+```
+
+### 5.4 Force-push and verify
+
+```bash
+git push origin --force --all
+git push origin --force --tags
+
+git log --all --full-history -- .env       # expect empty
+git log -p --all -S '<rotated-value>'      # expect empty
+```
+
+### 5.5 Collaborator recovery
+
+```bash
+# Safest
+rm -rf <clone> && git clone <remote-url>
+
+# Advanced, for a clean local branch only
+git fetch origin && git rebase origin/main
+```
+
+Open pull requests and forks keep the old history. Close and reopen PRs from
+re-cloned branches; ask fork owners to delete or re-fork.
 
 ---
 
-## Emergency Response Checklist
+## 6. Emergency Response Checklist
 
-If you've leaked credentials:
+Within minutes:
 
-1. **IMMEDIATELY rotate the credential** (this is the only real fix)
-2. Check access logs for unauthorized usage
-3. Run `/git-safety clean` to remove from history
-4. Force push the cleaned history
-5. Notify affected team members to re-clone
-6. Update .gitignore to prevent recurrence
-7. Set up pre-commit hooks
-8. Document the incident
+- [ ] Rotate the credential at the issuing provider
+- [ ] Confirm the old value is rejected
+- [ ] Revoke active sessions or tokens derived from it
+
+Within hours:
+
+- [ ] Read provider access logs for use of the old value
+- [ ] Identify every ref, fork, and CI log holding the value
+- [ ] Check whether the repository is public or was ever public
+
+Within a day:
+
+- [ ] Rewrite history (section 5)
+- [ ] Force-push through the operation gate
+- [ ] Notify collaborators to re-clone
+- [ ] Install ignore rules and hooks (section 4)
+- [ ] Record what leaked, when, how, and what was rotated
+
+---
+
+## 7. Quick Reference
+
+```bash
+# === STAGED GUARD ===
+git diff --cached --name-only
+git diff --cached -U0 | grep -E '^\+' | grep -iE '(api[_-]?key|password|secret|token)[^a-z]{0,4}[=:]'
+
+# === OPERATION GUARD ===
+git clean -nd                                    # dry run
+git stash push --include-untracked               # before reset --hard
+git clone --mirror . ../repo-backup-$(date +%Y%m%d)
+
+# === PREVENTION ===
+chmod +x .git/hooks/pre-commit
+pre-commit install
+git secrets --install && git secrets --register-aws
+
+# === REWRITE (post-rotation) ===
+git filter-repo --path .env --invert-paths
+git push origin --force --all
+```
+
+For the pre-publication audit of a whole repository — license, attribution,
+full-history secret sweep, internal hostnames and employee references — use the
+`open-source-checker` skill instead.

--- a/skills/open-source-checker/SKILL.md
+++ b/skills/open-source-checker/SKILL.md
@@ -1,54 +1,253 @@
 ---
 name: open-source-checker
-description: Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codebases before open sourcing. Use when preparing to open source a repository, reviewing code for exposed secrets, or auditing a codebase for sensitive data before public release.
+description: >-
+  Audits a whole private repository once, at the decision to make it public.
+  Runs four passes — license and attribution, secrets across the entire git
+  history, private references (internal hostnames, employee emails, client and
+  customer names, staging URLs), and publication readiness — then returns a
+  publish or block verdict. Use when the user is preparing to open source a
+  repository, asks whether a codebase is safe to publish, wants a pre-release
+  audit before flipping a repo public, or needs to know what is still private in
+  code that is about to ship publicly.
 metadata:
-  version: "1.0.1"
-  tags: "open-source, security, secrets"
+  version: "1.1.0"
+  tags: "open-source, publishing, license, audit"
+when_to_use: "open source this repo, make this repository public, is this safe to publish, pre-release audit, what is private in this codebase, check licensing before publishing, going public with this code"
 ---
 
 # Open Source Checker
 
-## When to Use
+The publish gate. This runs **once**, on a repository that has lived its whole
+life private, at the moment someone proposes making it public. Everything in a
+private repo was written on the assumption nobody outside would read it —
+comments, hostnames, client names, and every commit ever made. This audit finds
+what that assumption left behind.
 
-Use when you're:
+Four passes, then a verdict. The recurring commit-time guard is a different
+skill — see [Related](#related).
 
-- Preparing to open source a repository
-- Reviewing code for exposed secrets
-- Auditing codebase for sensitive data
-- Performing security audits before public release
-- Setting up pre-commit hooks for secret detection
+## Contract
 
-## What to Check
+Inputs:
 
-### Critical Items
+- Repository root, with full history fetched (`git fetch --all --tags`)
+- Intended public license, if already chosen
+- Names to treat as private: company domains, client names, internal hostnames
 
-- API keys (OpenAI, Stripe, AWS, GitHub tokens)
-- Database credentials and connection strings
-- Private keys and certificates (`.pem`, `.key`)
-- Personal information (emails, phone numbers)
-- Environment files (`.env` should be gitignored)
+Outputs:
 
-### Git History (CRITICAL)
+- Per-pass findings with file, line or commit, and severity
+- A publish / block verdict with the blocking set enumerated
+- A rotation list and a history-rewrite list, handed to `git-safety`
 
-- Secrets remain in git history even after deletion
-- Must scan all branches, tags, and deleted files
-- Use `gitleaks`, `truffleHog`, or `git-secrets`
+Creates/Modifies:
 
-## Quick Workflow
+- Nothing. This audit is read-only.
 
-1. **File scan**: Check for secret files, patterns
-2. **Code analysis**: Search for hardcoded secrets
-3. **Git history**: Scan entire history with tools
-4. **Setup hooks**: Prevent future commits with secrets
-5. **Clean history**: Use `git-filter-repo` if needed
+External Side Effects:
 
-## Tools
+- None. Remediation is delegated, not performed here.
 
-- `gitleaks`: Best for git history scanning
-- `truffleHog`: Alternative history scanner
-- `git-secrets`: AWS-focused with pre-commit hooks
-- `detect-secrets`: Baseline-based detection
+Confirmation Required:
 
-## References
+- Before the repository is flipped public — the verdict is advice, the flip is
+  the owner's action
 
-- [Full guide: Patterns, scanning workflow, git hooks, cleanup](references/full-guide.md)
+Delegates To:
+
+- `git-safety` to rotate credentials, rewrite history, and install the ongoing
+  commit-time guard
+- `security-audit` for application-level vulnerability review
+
+## Preflight
+
+The audit is only as complete as the refs present locally.
+
+```bash
+git fetch --all --tags --prune
+git log --all --oneline | wc -l    # commits in scope
+git branch -a && git tag -l        # refs in scope
+git stash list                     # stashes are not in --all
+```
+
+Ends when every remote branch and tag is present locally.
+
+---
+
+## Pass 1 — License and attribution
+
+A private repo needs no license. A public one that ships without a clear one is
+legally unusable by anyone who finds it, and code borrowed under one license
+cannot always be re-published under another.
+
+Check:
+
+- **`LICENSE` file present** at the root, matching what the owner intends
+- **Dependency licenses compatible** with the intended outgoing license —
+  copyleft (GPL, AGPL) dependencies constrain a permissive release
+- **Vendored and copy-pasted code attributed** — snippets lifted from Stack
+  Overflow, blog posts, or another repo carry their origin's terms
+- **Copyright headers** consistent, and naming the right entity
+- **Employer ownership** settled if the code was written on company time
+
+```bash
+ls LICENSE* COPYING* 2>/dev/null
+bunx license-checker --summary                      # JS dependency licenses
+grep -rniE 'copyright|\(c\) [0-9]{4}|SPDX-License' --include='*.*' -l . | head -30
+grep -rniE 'adapted from|based on|taken from|source: http' --include='*.*' . | head -30
+```
+
+Ends when the outgoing license is named, every dependency license is compatible
+with it, and every borrowed block is attributed or removed.
+
+---
+
+## Pass 2 — Secrets in history
+
+Deleting a secret from the working tree leaves it in every commit that ever held
+it. Publishing the repo publishes those commits.
+
+Scan every ref, not just `HEAD`:
+
+```bash
+# Automated sweep across all history — start here
+gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+
+# Every file that ever existed
+git log --all --pretty=format: --name-only --diff-filter=A | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.|id_rsa'
+
+# Files deleted from the tree but alive in history
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials'
+
+# Content search across every commit
+git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock'
+git log -p --all -G 'AKIA[0-9A-Z]{16}' --source
+```
+
+Also sweep the places `--all` misses: stashes, merge commits, and every tag.
+Commands in `references/full-guide.md` §3.
+
+Every hit is a **rotation item first** and a history-rewrite item second.
+Cleaning history does not un-leak a credential that was ever pushed.
+
+Ends when gitleaks and truffleHog both return clean across full history, and
+every earlier hit has a confirmed rotation.
+
+---
+
+## Pass 3 — Private references
+
+The pass with no tooling, and the one that leaks the most. These are not
+credentials; they are facts about the company that only made sense inside it.
+
+| Category | What to look for |
+|----------|------------------|
+| Internal hosts | `*.internal`, `*.corp`, `*.local`, VPN hostnames, RFC1918 IPs |
+| Internal services | Jira/Linear ticket URLs, internal wikis, admin dashboards |
+| People | Employee emails, personal emails, names in TODO and FIXME comments |
+| Customers | Client names, logos, contract terms, customer data in fixtures |
+| Infrastructure | Account IDs, bucket names, cluster names, staging URLs |
+| Commercial | Pricing logic, unreleased product names, internal roadmap notes |
+| Commit metadata | Author emails on every commit — these become public too |
+
+```bash
+# Internal domains and hosts (substitute your own)
+grep -rniE '@(yourcompany|internal|corp)\.(com|net|local)' . | grep -v node_modules
+grep -rniE '\b(10|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]+\.[0-9]+\b' . | grep -v node_modules
+
+# People and intent left in comments
+grep -rniE '(TODO|FIXME|HACK|XXX|NOTE)[:( ].*(ask|per|@[a-z]+)' --include='*.*' . | head -40
+
+# Author identities that ship with the history
+git log --all --format='%ae' | sort -u
+git log --all --format='%an <%ae>' | sort -u | head -30
+```
+
+Judge each hit by one question: **would a stranger reading this learn something
+the company would not say publicly?** A staging URL is a finding. A public docs
+link is not.
+
+Ends when every category has been searched and each hit is redacted, replaced
+with a neutral placeholder, or explicitly accepted by the owner.
+
+---
+
+## Pass 4 — Publication readiness
+
+What a stranger finds in the first thirty seconds:
+
+- **README** written for an outsider — what it is, how to run it, no "ask the
+  team in #eng" instructions
+- **`.env.example`** present and complete, so setup is possible without internal
+  access
+- **Docs** free of links to internal wikis, dashboards, and runbooks
+- **Issue and PR templates** that do not route to internal processes
+- **CI config** referencing only secrets a fork could plausibly supply, and no
+  internal registry or runner
+- **Test fixtures** carrying synthetic data, not production exports
+- **Repository settings** — an existing `.github/` config may expose internal
+  team names in `CODEOWNERS`
+
+```bash
+ls README* .env.example .github/ 2>/dev/null
+grep -rniE 'internal|confidential|do not distribute|proprietary' README* docs/ 2>/dev/null
+cat .github/CODEOWNERS 2>/dev/null
+```
+
+Ends when a reader with no internal access can install, run, and contribute from
+what is in the repository.
+
+---
+
+## Verdict
+
+Report one of two outcomes. No middle state — "mostly clean" publishes secrets.
+
+**BLOCK** — enumerate every blocking finding:
+
+```
+BLOCK — 3 blockers
+
+License   No LICENSE file; two AGPL dependencies conflict with intended MIT
+History   AWS key in commit a1b2c3d (deleted in e4f5g6h, still in history)
+Private   Client name "Acme Corp" in 14 files and 3 commit messages
+
+Rotate now:      AWS key AKIA…  (leak precedes any rewrite)
+Then hand to:    git-safety clean — strip .env from all refs, force-push
+Re-run this audit after the rewrite; commit hashes will have changed.
+```
+
+**PUBLISH** — state what was verified, so the verdict is auditable:
+
+```
+PUBLISH
+
+License   MIT at root; 214 deps all permissive; 2 adapted blocks attributed
+History   gitleaks + truffleHog clean across 1,847 commits, 12 branches, 40 tags
+Private   No internal hosts, customer names, or employee emails outside git authorship
+Ready     README, .env.example, CI runs on a fork without internal secrets
+
+Note: 4 distinct author emails remain in commit history and will be public.
+Next: install the ongoing commit-time guard — git-safety prevent
+```
+
+A rewrite invalidates every commit hash in the findings, so re-run passes 2 and
+3 after `git-safety` finishes.
+
+## Related
+
+- `git-safety` — the recurring guard for a repository already in daily use:
+  blocks secrets from entering the next commit, gates force-pushes and history
+  rewrites, and installs ignore rules and pre-commit hooks. It also performs the
+  rotation and history rewrite this audit hands off. Run it at every commit;
+  run this audit once, at the publish decision.
+- `security-audit` — application-level vulnerability review of the code itself.
+
+---
+
+**Full credential-pattern catalog, all-refs history commands (stashes, merges,
+tags, branches), license-compatibility matrix, private-reference search recipes,
+and the report template:** `references/full-guide.md`

--- a/skills/open-source-checker/plugin.json
+++ b/skills/open-source-checker/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "open-source-checker",
-  "version": "1.0.1",
-  "description": "Expert in detecting private information, secrets, API keys, credentials, and sensitive data in codeb",
+  "version": "1.1.0",
+  "description": "Audit a private repo before publishing: license, history secrets, private references.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/open-source-checker/references/full-guide.md
+++ b/skills/open-source-checker/references/full-guide.md
@@ -1,1446 +1,537 @@
-# Open Source Security Checker - Full Guide
+# Open Source Checker — Full Guide
 
-Comprehensive guide for detecting and removing sensitive information from codebases before open sourcing.
+Reference material for the publish gate: the one-time audit of a private
+repository at the moment it is proposed for public release.
 
----
-
-## 1. What to Check
-
-### 1.1 API Keys and Tokens
-
-API keys are the most common leaked secret. Check for:
-
-- **OpenAI**: `sk-...` (48 characters)
-- **Anthropic**: `sk-ant-...`
-- **Stripe**: `sk_live_...`, `sk_test_...`, `pk_live_...`, `pk_test_...`
-- **AWS**: Access Key ID (`AKIA...`), Secret Access Key
-- **GitHub**: `ghp_...`, `gho_...`, `ghu_...`, `ghs_...`, `ghr_...`
-- **Google**: `AIza...` (39 characters)
-- **Slack**: `xoxb-...`, `xoxp-...`, `xoxa-...`
-- **Twilio**: Account SID (`AC...`), Auth Token
-- **SendGrid**: `SG....`
-- **Firebase**: Various patterns in config objects
-- **Vercel**: `vercel_...`
-- **npm**: `npm_...`
-
-### 1.2 Database Credentials
-
-- Connection strings with embedded passwords
-- MongoDB URIs: `mongodb+srv://USER:PASSWORD@HOST`
-- PostgreSQL: `postgresql://USER:PASSWORD@HOST:PORT/DB`
-- MySQL: `mysql://USER:PASSWORD@HOST:PORT/DB`
-- Redis: `redis://:PASSWORD@HOST:PORT`
-
-### 1.3 Private Keys and Certificates
-
-```
-# File extensions to check
-*.pem
-*.key
-*.p12
-*.pfx
-*.cer
-*.crt
-id_rsa
-id_rsa.pub
-id_ed25519
-id_ecdsa
-*.keystore
-*.jks
-```
-
-### 1.4 Personal Information
-
-- Email addresses (especially internal/company emails)
-- Phone numbers
-- Physical addresses
-- Names in comments (developer names, client names)
-- IP addresses (especially internal network IPs)
-- License keys
-
-### 1.5 Environment Files
-
-```
-.env
-.env.local
-.env.development
-.env.production
-.env.staging
-.env.test
-.envrc
-*.env
-.env.*
-```
-
-### 1.6 Configuration Files
-
-```
-# Cloud provider configs
-.aws/credentials
-.aws/config
-.gcp/credentials.json
-.azure/credentials
-kubeconfig
-.kube/config
-
-# Package manager auth
-.npmrc (with auth tokens)
-.yarnrc.yml (with auth)
-.pypirc
-.gem/credentials
-.docker/config.json
-
-# Application configs
-config/secrets.yml
-config/credentials.yml.enc
-database.yml (check for passwords)
-secrets.json
-api_keys.json
-auth.json
-```
-
-### 1.7 Code Comments
-
-Developers often leave sensitive information in comments:
-
-```bash
-# Search for common patterns in comments
-grep -rn "TODO.*password" --include="*.ts" --include="*.js"
-grep -rn "FIXME.*key" --include="*.ts" --include="*.js"
-grep -rn "// .*secret" --include="*.ts" --include="*.js"
-grep -rn "password.*=" --include="*.ts" --include="*.js"
-```
-
-### 1.8 Git History
-
-**CRITICAL**: Deleted files and previous commits still contain secrets.
-
-```bash
-# Files deleted from repo but in history
-git log --all --full-history --diff-filter=D -- "*.env" ".env" "secrets.*"
-
-# Commits that modified sensitive files
-git log --all --oneline -- "*.env" "*.pem" "*.key" "credentials.*"
-```
+Scope note: this guide covers what changes **once**, when a repository crosses
+from private to public. Commit-time secret blocking, destructive-operation
+gating, ignore rules, pre-commit hooks, and the history rewrite itself belong to
+the `git-safety` skill and are not repeated here.
 
 ---
 
-## 2. Common Patterns to Detect
+## 1. Preflight — Establish the Audit Scope
 
-### 2.1 API Key Patterns
+An audit that misses a ref misses everything in it. Fetch first.
 
-```regex
-# Generic API key patterns
-[aA][pP][iI][_-]?[kK][eE][yY].*['\"][a-zA-Z0-9]{16,}['\"]
-[aA][pP][iI][_-]?[sS][eE][cC][rR][eE][tT].*['\"][a-zA-Z0-9]{16,}['\"]
+```bash
+git fetch --all --tags --prune
 
-# AWS Access Key ID
-AKIA[0-9A-Z]{16}
-
-# AWS Secret Access Key
-[a-zA-Z0-9+/]{40}
-
-# GitHub Token
-gh[pousr]_[A-Za-z0-9_]{36,}
-
-# Generic Secret Key
-[sS][eE][cC][rR][eE][tT][_-]?[kK][eE][yY].*['\"][a-zA-Z0-9]{16,}['\"]
-
-# Bearer Token
-[bB][eE][aA][rR][eE][rR][\s]+[a-zA-Z0-9\-_\.]{20,}
-
-# JWT Token
-eyJ[a-zA-Z0-9\-_]+\.eyJ[a-zA-Z0-9\-_]+\.[a-zA-Z0-9\-_]+
-
-# OpenAI API Key
-sk-[a-zA-Z0-9]{48}
-
-# Anthropic API Key
-sk-ant-[a-zA-Z0-9\-_]{40,}
-
-# Stripe API Key
-sk_(live|test)_[a-zA-Z0-9]{24,}
-pk_(live|test)_[a-zA-Z0-9]{24,}
-
-# Slack Token
-xox[baprs]-[0-9]{10,}-[0-9]{10,}-[a-zA-Z0-9]{24}
-
-# Google API Key
-AIza[0-9A-Za-z\-_]{35}
-
-# SendGrid API Key
-SG\.[a-zA-Z0-9]{22}\.[a-zA-Z0-9\-_]{43}
+# Scope of the audit
+git log --all --oneline | wc -l              # commits
+git branch -a | wc -l                        # branches, local + remote
+git tag -l | wc -l                           # tags
+git stash list                               # NOT covered by --all
+git count-objects -vH                        # repo size; large packs hide old blobs
 ```
 
-### 2.2 Password Patterns
+Record these numbers. The verdict cites them, and they are what makes a
+`PUBLISH` verdict auditable rather than a vibe.
 
-```regex
-# Password assignments
-[pP][aA][sS][sS][wW][oO][rR][dD].*[=:].*['\"][^'\"]{4,}['\"]
+Two refs that hide content from `--all`:
 
-# DB Password
-[dD][bB][_-]?[pP][aA][sS][sS][wW][oO][rR][dD].*[=:].*['\"][^'\"]+['\"]
+```bash
+# Dangling and unreachable objects — a deleted branch's commits may still exist
+git fsck --lost-found --unreachable 2>/dev/null | head -20
 
-# Admin Password
-[aA][dD][mM][iI][nN][_-]?[pP][aA][sS][sS].*[=:].*['\"][^'\"]+['\"]
-
-# Generic password in URL
-://[^:]+:[^@]+@
+# Notes, if the team used them
+git log --all --show-notes='*' --oneline | head
 ```
 
-### 2.3 Connection String Patterns
-
-```regex
-# NOTE: schemes are written with the colon inside brackets, followed by two
-# slashes, so this file itself never contains a URI-shaped literal that trips
-# secret scanners (secretlint, gitleaks) in consuming repositories.
-
-# MongoDB
-mongodb(\+srv)?[:]//[^:]+:[^@]+@[^/]+
-
-# PostgreSQL
-postgres(ql)?[:]//[^:]+:[^@]+@[^/]+
-
-# MySQL
-mysql[:]//[^:]+:[^@]+@[^/]+
-
-# Redis
-redis[:]//:[^@]+@[^/]+
-
-# Generic database URL
-DATABASE_URL.*[=:].*['\"][^'\"]+['\"]
-```
-
-### 2.4 Email Patterns
-
-```regex
-# Email addresses
-[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}
-
-# Specific internal domains (customize for your org)
-[a-zA-Z0-9._%+-]+@(company|internal)\.com
-```
-
-### 2.5 Private Key Patterns
-
-```regex
-# RSA Private Key
------BEGIN RSA PRIVATE KEY-----
-
-# EC Private Key
------BEGIN EC PRIVATE KEY-----
-
-# Generic Private Key
------BEGIN PRIVATE KEY-----
-
-# OpenSSH Private Key
------BEGIN OPENSSH PRIVATE KEY-----
-
-# PGP Private Key
------BEGIN PGP PRIVATE KEY BLOCK-----
-```
+If the repository will be published by pushing a fresh clone rather than
+flipping visibility, unreachable objects will not travel — note which path the
+owner intends, because it changes what is in scope.
 
 ---
 
-## 3. Scanning Workflow
+## 2. License and Attribution
 
-### 3.1 File System Scan
-
-**Step 1: Find sensitive file types**
+### 2.1 The outgoing license
 
 ```bash
-# Find all potentially sensitive files
-find . -type f \( \
-  -name ".env" -o \
-  -name ".env.*" -o \
-  -name "*.env" -o \
-  -name "credentials.json" -o \
-  -name "service-account*.json" -o \
-  -name "*.pem" -o \
-  -name "*.key" -o \
-  -name "*.p12" -o \
-  -name "*.pfx" -o \
-  -name "id_rsa*" -o \
-  -name "id_ed25519*" -o \
-  -name "id_ecdsa*" -o \
-  -name "secrets.*" -o \
-  -name "*.secret" -o \
-  -name ".npmrc" -o \
-  -name ".pypirc" -o \
-  -name "kubeconfig" -o \
-  -name ".htpasswd" -o \
-  -name ".netrc" \
-\) 2>/dev/null | grep -v node_modules | grep -v .git | grep -v vendor
+ls -1 LICENSE* COPYING* NOTICE* 2>/dev/null
+head -5 LICENSE 2>/dev/null
+grep -i '"license"' package.json 2>/dev/null
 ```
 
-**Step 2: Check if sensitive files are tracked**
+A public repository with no license grants no rights. Readers may look but
+legally may not use, fork, or contribute. Confirm the owner has picked one
+before the audit passes.
+
+### 2.2 Dependency license compatibility
+
+The outgoing license cannot be more permissive than what the strongest incoming
+dependency license allows.
 
 ```bash
-# Check git status of each found file
-for file in $(find . -name ".env*" -o -name "*.pem" -o -name "*.key" 2>/dev/null | grep -v node_modules); do
-  if git ls-files --error-unmatch "$file" 2>/dev/null; then
-    echo "TRACKED (DANGER): $file"
-  else
-    echo "Untracked (safe): $file"
-  fi
-done
+# JavaScript / TypeScript
+bunx license-checker --summary
+bunx license-checker --failOn 'GPL-3.0;AGPL-3.0;SSPL-1.0'
+
+# Python
+pip-licenses --summary
+
+# Rust
+cargo license --tsv | cut -f6 | sort | uniq -c
+
+# Go
+go-licenses report ./... 2>/dev/null
 ```
 
-### 3.2 Code Pattern Analysis
+| Dependency license | Publishing under MIT / Apache-2.0 |
+|--------------------|-----------------------------------|
+| MIT, ISC, BSD-2/3 | Compatible. Keep the notice files. |
+| Apache-2.0 | Compatible. Preserve `NOTICE` and patent terms. |
+| MPL-2.0 | Compatible at file granularity; modified MPL files stay MPL. |
+| LGPL | Compatible when dynamically linked; static linking pulls obligations in. |
+| GPL-2.0 / GPL-3.0 | **Incompatible.** Distributing the combined work requires GPL. |
+| AGPL-3.0 | **Incompatible**, and network use counts as distribution. |
+| SSPL, BUSL, Elastic | **Not open source.** Source-available; check the terms directly. |
+| "UNLICENSED" / none | **Blocker.** No grant exists — remove or get written permission. |
 
-**Step 1: Search for hardcoded secrets**
+Devtime-only dependencies (test runners, linters, build tools) do not ship in
+the artifact and rarely constrain the outgoing license. Runtime dependencies do.
+Check which bucket each copyleft hit falls in before calling it a blocker.
+
+### 2.3 Borrowed and vendored code
+
+Snippets pasted from elsewhere carry their origin's terms whether or not anyone
+recorded that.
 
 ```bash
-# Search for API key patterns
-git grep -E "(api[_-]?key|apikey|api[_-]?secret).*[=:].*['\"][a-zA-Z0-9]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb'
+grep -rniE 'adapted from|based on|copied from|taken from|source: https?:' \
+  --include='*.*' . | grep -v node_modules | head -40
 
-# Search for password patterns
-git grep -E "(password|passwd|pwd).*[=:].*['\"][^'\"]+['\"]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb' ':!*.lock' ':!package-lock.json'
+# Vendored trees that are not dependency-managed
+find . -type d \( -name vendor -o -name third_party -o -name external \) \
+  -not -path '*/node_modules/*'
 
-# Search for secret patterns
-git grep -E "(secret|token|auth).*[=:].*['\"][a-zA-Z0-9]" -- '*.ts' '*.js' '*.py' '*.go' '*.java' '*.rb'
-
-# Search for private keys
-git grep -E "-----BEGIN.*PRIVATE KEY-----" -- '*'
+# License headers already present
+grep -rl 'SPDX-License-Identifier' --include='*.*' . | grep -v node_modules | head -20
 ```
 
-**Step 2: Search for specific provider patterns**
+For each hit: attribute it in a `NOTICE` or header, replace it with original
+code, or remove it.
+
+### 2.4 Copyright ownership
 
 ```bash
-# AWS
-git grep -E "AKIA[0-9A-Z]{16}" -- '*'
-
-# GitHub
-git grep -E "gh[pousr]_[A-Za-z0-9_]{36,}" -- '*'
-
-# OpenAI
-git grep -E "sk-[a-zA-Z0-9]{48}" -- '*'
-
-# Stripe
-git grep -E "sk_(live|test)_[a-zA-Z0-9]{24,}" -- '*'
+grep -rniE 'copyright.*[0-9]{4}' --include='*.*' . | grep -v node_modules \
+  | sed -E 's/.*[Cc]opyright[^A-Za-z]*//' | sort -u | head -20
 ```
 
-### 3.3 Content Analysis
+Confirm the named entity is the one publishing, that the year range is current,
+and that headers are consistent. Code written under an employment agreement may
+not be the author's to release — settle that before the flip, not after.
 
-**Automated scanning with gitleaks**
+Ends when: license chosen and present, no incompatible runtime dependency, every
+borrowed block attributed, copyright naming the publishing entity.
+
+---
+
+## 3. Secrets Across Full History
+
+### 3.1 Tooling does the pattern matching
+
+Hand-written regexes work for a staged diff of five files. They do not work
+across thousands of commits — the false-negative rate is what gets repositories
+burned. Run scanners over full history and triage their output.
+
+**gitleaks**
 
 ```bash
-# Install gitleaks
-brew install gitleaks
-
-# Scan current directory
+# Full history, every ref
 gitleaks detect --source . --verbose
 
-# Scan with report
-gitleaks detect --source . --report-format json --report-path ./gitleaks-report.json
+# Machine-readable, for triage
+gitleaks detect --source . --report-format json --report-path gitleaks.json
+
+# Bound the scan to a range when re-auditing after a rewrite
+gitleaks detect --source . --log-opts="HEAD~200..HEAD"
+
+# Custom allowlist for known-fake fixture values
+gitleaks detect --source . --config .gitleaks.toml
 ```
 
-**Automated scanning with truffleHog**
+```toml
+# .gitleaks.toml — allowlist fixtures, never real values
+[extend]
+useDefault = true
 
-```bash
-# Install truffleHog
-pip install trufflehog
+[[rules]]
+id = "internal-domain"
+description = "Internal hostname"
+regex = '''[a-z0-9-]+\.(internal|corp|local)\b'''
 
-# Scan filesystem
-trufflehog filesystem . --only-verified
-
-# Scan with JSON output
-trufflehog filesystem . --json > trufflehog-report.json
+[allowlist]
+paths = [
+  '''tests/fixtures/.*''',
+  '''.*\.example$''',
+]
 ```
 
-### 3.4 Git History Check
-
-See dedicated section below.
-
----
-
-## 4. Git History Scanning (CRITICAL)
-
-This is the most commonly overlooked step. Secrets removed from current files remain in git history indefinitely.
-
-### 4.1 Essential Commands
-
-**Find all files ever committed**
+**truffleHog** — verifies candidates against the live provider, so a hit means
+the credential still works.
 
 ```bash
-# List all files that have ever existed in the repo
+trufflehog git file://. --only-verified
+trufflehog git file://. --include-detectors all      # widen, more noise
+trufflehog git https://github.com/org/repo.git       # after publication, as a check
+```
+
+Run both. gitleaks has better entropy coverage; truffleHog tells you which hits
+are live. A verified truffleHog hit is a rotate-now item.
+
+### 3.2 All-refs commands the scanners complement
+
+```bash
+# Every file that ever existed in the repository
 git log --all --pretty=format: --name-only --diff-filter=A | sort -u
-```
 
-**Search for sensitive filenames in history**
-
-```bash
-# Find when sensitive files were added
-git log --all --full-history --diff-filter=A -- \
-  "*.env" ".env" ".env.*" \
-  "credentials.json" "service-account*.json" \
-  "*.pem" "*.key" "id_rsa*" \
-  "secrets.*" ".npmrc" "*.secret" \
-  --name-only --oneline
-
-# More detailed with dates
+# Sensitive filenames, with when they were added
 git log --all --full-history --diff-filter=A \
   --pretty=format:"%h %ad %s" --date=short -- \
-  "*.env" "credentials.json" "*.pem" "*.key"
-```
+  "*.env" ".env" ".env.*" "credentials.json" "service-account*.json" \
+  "*.pem" "*.key" "id_rsa*" "secrets.*" ".npmrc" "*.secret"
 
-**Search for secret patterns in git history**
-
-```bash
-# Search commits that added/removed content matching pattern
+# Content added or removed anywhere in history
 git log -p --all -S 'API_KEY' --source -- ':(exclude)*.lock'
-
-# Search for specific secret value (if known)
-git log -p --all -S 'sk-ant-abc123...' --source
-
-# Search using regex
 git log -p --all -G 'AKIA[0-9A-Z]{16}' --source
 ```
 
-**View content of deleted files**
+### 3.3 Files deleted from the tree
+
+The most common miss: someone removed `.env` in a later commit and assumed that
+handled it.
 
 ```bash
-# Find when a file was deleted
-git log --all --full-history -- path/to/deleted/file.env
+# Everything ever deleted
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u \
+  | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.'
 
-# View the file content at a specific commit
-git show <commit-hash>:path/to/deleted/file.env
-
-# View the last version before deletion
+# Recover the content of a deleted file to judge severity
 git log --all --full-history --diff-filter=D -- path/to/file.env
 git show <commit-before-deletion>:path/to/file.env
 ```
 
-### 4.2 Automated Tools for History Scanning
+### 3.4 Stashes
 
-**gitleaks (Recommended)**
-
-```bash
-# Full history scan
-gitleaks detect --source . --verbose
-
-# Scan specific commit range
-gitleaks detect --source . --log-opts="HEAD~50..HEAD"
-
-# Generate baseline (for existing repos)
-gitleaks detect --source . --baseline-path .gitleaks-baseline.json
-
-# Custom config
-gitleaks detect --source . --config .gitleaks.toml
-```
-
-**truffleHog**
+`--all` does not cover the stash reflog. Stashes are local, so they do not
+travel on publication — but they reveal what was being handled carelessly, and
+the same values usually landed in a commit somewhere.
 
 ```bash
-# Scan git history
-trufflehog git file://. --only-verified
-
-# Scan remote repository
-trufflehog git https://github.com/org/repo.git
-
-# Include unverified findings
-trufflehog git file://. --include-detectors all
-```
-
-**git-secrets (AWS-focused)**
-
-```bash
-# Install
-brew install git-secrets
-
-# Register AWS patterns
-git secrets --register-aws
-
-# Scan history
-git secrets --scan-history
-
-# Scan specific file
-git secrets --scan path/to/file
-```
-
-### 4.3 Checking Deleted Files
-
-```bash
-# List all deleted files in history
-git log --all --pretty=format: --name-only --diff-filter=D | sort -u
-
-# Filter for sensitive patterns
-git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.(env|pem|key|secret)$|credentials|secrets\.'
-
-# For each deleted sensitive file, check its content
-for file in $(git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.env$'); do
-  echo "=== $file ==="
-  git log --all --full-history -1 --format="%H" -- "$file" | xargs -I {} git show {}^:"$file" 2>/dev/null || echo "Could not retrieve"
+git stash list
+for i in $(seq 0 $(($(git stash list | wc -l) - 1))); do
+  echo "=== stash@{$i} ==="
+  git stash show -p "stash@{$i}" 2>/dev/null | grep -iE '(api.?key|password|secret|token)' || true
 done
 ```
 
-### 4.4 Checking Merge Commits
+### 3.5 Merge commits
 
-Merge commits can contain secrets that weren't in either branch:
+A merge commit can introduce content present in neither parent — a conflict
+resolved by hand-typing a value.
 
 ```bash
-# List all merge commits
-git log --all --merges --oneline
-
-# Check a specific merge for changes
-git show --stat <merge-commit-hash>
-
-# Diff merge against its parents
+git log --all --merges --oneline | head -30
 git diff <merge-commit>^1..<merge-commit>
 git diff <merge-commit>^2..<merge-commit>
 ```
 
-### 4.5 Checking Stashes
-
-Stashes are often forgotten and may contain secrets:
+### 3.6 Every branch and tag
 
 ```bash
-# List all stashes
-git stash list
-
-# Show stash content
-git stash show -p stash@{0}
-
-# Check all stashes for sensitive patterns
-for i in $(seq 0 $(git stash list | wc -l)); do
-  echo "=== Stash $i ==="
-  git stash show -p stash@{$i} 2>/dev/null | grep -iE "(api.?key|password|secret|token)" || true
+for branch in $(git branch -a | sed 's/^[* ]*//' | grep -v HEAD); do
+  hits=$(git ls-tree -r --name-only "$branch" 2>/dev/null | grep -iE '\.(env|pem|key)$')
+  [ -n "$hits" ] && printf '=== %s ===\n%s\n' "$branch" "$hits"
 done
-```
 
-### 4.6 Checking All Branches
-
-```bash
-# List all branches (local and remote)
-git branch -a
-
-# Scan each branch for sensitive files
-for branch in $(git branch -a | sed 's/^[\* ]*//' | grep -v HEAD); do
-  echo "=== Branch: $branch ==="
-  git ls-tree -r --name-only "$branch" 2>/dev/null | grep -iE '\.(env|pem|key)$' || true
-done
-```
-
-### 4.7 Checking Tags
-
-```bash
-# List all tags
-git tag -l
-
-# Check files in each tag
 for tag in $(git tag -l); do
-  echo "=== Tag: $tag ==="
-  git ls-tree -r --name-only "$tag" 2>/dev/null | grep -iE '\.(env|pem|key)$' || true
+  hits=$(git ls-tree -r --name-only "$tag" 2>/dev/null | grep -iE '\.(env|pem|key)$')
+  [ -n "$hits" ] && printf '=== tag %s ===\n%s\n' "$tag" "$hits"
 done
+```
+
+Stale release branches are frequently the only ref still holding a config file
+that `main` cleaned up years ago.
+
+### 3.7 Triage
+
+For each finding, record: the value's provider, the commit that introduced it,
+whether the repository was ever public or shared, and whether truffleHog
+verified it as live.
+
+| Finding | Action |
+|---------|--------|
+| Live credential, any ref | Rotate immediately, then rewrite. Blocker. |
+| Dead or already-rotated credential | Rewrite for hygiene. Blocker until confirmed dead. |
+| Fixture or documented placeholder | Allowlist it in `.gitleaks.toml`. Not a blocker. |
+| Internal-only value with no external auth (a dev seed password) | Judgment call; usually rewrite. |
+
+Rotation and history rewriting are performed by the `git-safety` skill. This
+audit produces the list; it does not run the rewrite.
+
+Ends when: both scanners return clean across full history, every earlier hit has
+a confirmed rotation, and stashes, merges, branches, and tags are each swept.
+
+---
+
+## 4. Private References
+
+No scanner finds these. They are not credentials — they are internal facts that
+were never meant to leave, and they are the pass that most often produces
+findings in an otherwise clean repository.
+
+### 4.1 Internal hosts and networks
+
+```bash
+# Internal TLDs
+grep -rniE '\.(internal|corp|intranet|local|lan)\b' . | grep -v node_modules | head -40
+
+# RFC1918 addresses
+grep -rniE '\b(10\.[0-9]+|192\.168|172\.(1[6-9]|2[0-9]|3[01]))\.[0-9]+\.[0-9]+\b' . \
+  | grep -v node_modules | head -40
+
+# Staging and internal environments
+grep -rniE '(staging|preprod|internal|admin|vpn)[.-][a-z0-9-]+\.(com|net|io|dev)' . \
+  | grep -v node_modules | head -40
+```
+
+`127.0.0.1` and `localhost` are fine. A hostname that only resolves inside the
+company is a finding.
+
+### 4.2 People
+
+```bash
+# Company and personal email addresses in source
+grep -rniE '[a-z0-9._%+-]+@(yourcompany|gmail|outlook)\.[a-z]{2,}' . \
+  | grep -v node_modules | head -40
+
+# Intent and blame left in comments
+grep -rniE '(TODO|FIXME|HACK|XXX|NOTE)[:( ].*(ask|per|check with|@[a-z]+)' \
+  --include='*.*' . | grep -v node_modules | head -40
+
+# Slack and ticket references
+grep -rniE '(slack\.com/archives|#[a-z-]+-team|JIRA-[0-9]+|[A-Z]{2,}-[0-9]{2,})' . \
+  | grep -v node_modules | head -40
+```
+
+### 4.3 Commit metadata
+
+Every author name and email in history becomes public with the repository. This
+is frequently overlooked because it is not in any file.
+
+```bash
+git log --all --format='%an <%ae>' | sort -u
+git log --all --format='%cn <%ce>' | sort -u
+```
+
+Options: accept it (most open-source projects do), or normalize identities with
+a `.mailmap` — which changes the display name, not the underlying commit object.
+Genuinely removing an email from history requires a rewrite via `git-safety`.
+
+```
+# .mailmap — display name and address remapping
+Real Name <public@example.com> <internal@yourcompany.local>
+```
+
+Get consent from each contributor before publishing their address.
+
+### 4.4 Customers and commercial detail
+
+```bash
+# Client names — supply the list; no generic pattern finds these
+for name in "Acme Corp" "BigClient" "ProjectCodename"; do
+  echo "=== $name ==="
+  grep -rniF "$name" . --exclude-dir=node_modules --exclude-dir=.git | head -10
+  git log --all --oneline --grep="$name" | head -10
+done
+
+# Production data leaked into fixtures
+grep -rniE '(ssn|social.security|credit.?card|passport|date.?of.?birth)' \
+  --include='*.json' --include='*.csv' --include='*.sql' . | head -20
+```
+
+Also check: pricing and discount logic, unreleased product names, feature flags
+naming unannounced work, and comments describing internal roadmap or headcount.
+
+### 4.5 Infrastructure identifiers
+
+```bash
+grep -rniE '\b[0-9]{12}\b' --include='*.tf' --include='*.yml' --include='*.yaml' . | head -20   # AWS account IDs
+grep -rniE '(s3://|arn:aws:|projects/[a-z0-9-]+/)' . | grep -v node_modules | head -30
+grep -rniE '(cluster|namespace|bucket)[-_ ]?(name)?[=: ]+["\x27][a-z0-9-]+' . | head -20
+```
+
+Account IDs and bucket names are not secrets, but they narrow an attacker's
+target list. Decide deliberately rather than by omission.
+
+### 4.6 The judgment rule
+
+For each hit, ask: **would a stranger reading this learn something the company
+would not say publicly?**
+
+- A link to public documentation — not a finding.
+- A link to the internal runbook wiki — finding.
+- `localhost:3000` — not a finding.
+- `deploy-01.eng.corp` — finding.
+- A generic `TODO: refactor` — not a finding.
+- `TODO: ask Priya why the Acme contract needs this` — finding, twice over.
+
+Ends when: every category above has been searched and each hit is redacted,
+replaced with a neutral placeholder, or explicitly accepted by the owner.
+
+---
+
+## 5. Publication Readiness
+
+### 5.1 The first thirty seconds
+
+```bash
+ls -1 README* CONTRIBUTING* CODE_OF_CONDUCT* SECURITY* .env.example 2>/dev/null
+grep -rniE 'internal|confidential|do not distribute|proprietary|ask the team|#eng' \
+  README* docs/ 2>/dev/null | head -20
+```
+
+A README written for colleagues assumes access a stranger does not have. Rewrite
+onboarding steps that route through internal Slack, wikis, or VPN.
+
+### 5.2 Can an outsider actually run it?
+
+- `.env.example` lists every variable the app reads, with safe placeholders
+- Setup instructions reference public package registries only
+- No step requires an internal service, VPN, or SSO tenant
+- Seed and fixture data is synthetic
+
+```bash
+# Variables the code reads, versus what the example documents
+grep -rhoE 'process\.env\.[A-Z_]+|os\.environ\[.[A-Z_]+' src/ 2>/dev/null \
+  | grep -oE '[A-Z_]{3,}' | sort -u > /tmp/used-vars
+grep -oE '^[A-Z_]+' .env.example 2>/dev/null | sort -u > /tmp/documented-vars
+comm -23 /tmp/used-vars /tmp/documented-vars     # read but undocumented
+```
+
+### 5.3 CI and repository configuration
+
+```bash
+cat .github/CODEOWNERS 2>/dev/null                 # internal team handles
+grep -rniE 'secrets\.[A-Z_]+' .github/workflows/ | sort -u
+grep -rniE '(registry|repository|runs-on).*(internal|corp|self-hosted)' .github/ 2>/dev/null
+cat .github/ISSUE_TEMPLATE/* 2>/dev/null | grep -iE 'internal|jira|slack'
+```
+
+Workflows referencing self-hosted runners or an internal registry will fail on
+every fork. Either make them fork-safe or gate them behind a condition.
+
+### 5.4 Repository-level settings
+
+Not visible in the tree, and worth checking before the flip:
+
+- Wiki content and its history
+- Existing issues and pull-request discussions — these become public too
+- Release artifacts and their notes
+- Repository description, topics, and homepage URL
+- Branch protection and required-check names that reference internal systems
+
+Ends when: a reader with no internal access can install, run, and contribute
+from what is in the repository.
+
+---
+
+## 6. Verdict Report Template
+
+```markdown
+# Open Source Readiness — <repo>
+
+Audited: <date> · Scope: <n> commits, <n> branches, <n> tags, <n> stashes
+
+## Verdict: BLOCK | PUBLISH
+
+## Pass 1 — License and attribution
+- Outgoing license: <MIT | none — BLOCKER>
+- Dependency conflicts: <n> (<list AGPL/GPL runtime deps>)
+- Unattributed borrowed code: <n> locations
+
+## Pass 2 — Secrets in history
+- gitleaks: <n> findings · truffleHog verified: <n>
+- Introduced in: <commits> · Deleted-but-present: <files>
+- Rotation required: <list>
+
+## Pass 3 — Private references
+- Internal hosts: <n> · Employee references: <n>
+- Customer names: <n> files, <n> commit messages
+- Distinct author emails in history: <n>
+
+## Pass 4 — Publication readiness
+- README outsider-ready: <yes/no> · .env.example complete: <yes/no>
+- CI fork-safe: <yes/no> · CODEOWNERS internal handles: <n>
+
+## Blockers
+1. <finding> → <action> → <owner>
+
+## Handoff
+- Rotate now: <credentials>
+- Then run: git-safety clean — <paths to strip>
+- Re-run passes 2 and 3 after the rewrite (commit hashes change)
 ```
 
 ---
 
-## 5. Cleaning Git History
+## 7. Re-Audit After a Rewrite
 
-**WARNING**: Before cleaning history:
-
-1. **Rotate all leaked credentials immediately** - cleaning history does NOT make secrets safe
-2. Create a backup of the repository
-3. Notify all collaborators
-4. Understand that this rewrites history and requires force push
-
-### 5.1 Using git-filter-repo (Recommended)
-
-**Installation**
+A history rewrite changes every commit hash downstream of the earliest rewritten
+commit. Findings referencing old hashes are stale, and the rewrite itself can
+introduce new problems.
 
 ```bash
-# pip
-pip install git-filter-repo
+# Confirm the value is gone from every ref
+git log --all --full-history -- .env             # expect empty
+git log -p --all -S '<rotated-value>' --source   # expect empty
 
-# Homebrew
-brew install git-filter-repo
-
-# Verify installation
-git filter-repo --version
-```
-
-**Remove specific files**
-
-```bash
-# Create backup first
-git clone --mirror . ../repo-backup-$(date +%Y%m%d)
-
-# Remove a single file
-git filter-repo --path .env --invert-paths
-
-# Remove multiple files
-git filter-repo --path .env --path .env.local --path credentials.json --invert-paths
-
-# Remove by pattern (glob)
-git filter-repo --path-glob '*.env' --invert-paths
-git filter-repo --path-glob '*.pem' --invert-paths
-
-# Remove by regex
-git filter-repo --path-regex '.*\.env(\..*)?' --invert-paths
-```
-
-**Remove content by pattern**
-
-```bash
-# Replace text in all files (useful for removing specific secrets)
-git filter-repo --replace-text expressions.txt
-
-# Where expressions.txt contains:
-# literal:sk-ant-api123abc==>[REDACTED]
-# regex:AKIA[0-9A-Z]{16}==>[REDACTED_AWS_KEY]
-```
-
-**Remove entire directories**
-
-```bash
-git filter-repo --path secrets/ --invert-paths
-git filter-repo --path config/credentials/ --invert-paths
-```
-
-### 5.2 Using BFG Repo-Cleaner
-
-**Installation**
-
-```bash
-# Homebrew
-brew install bfg
-
-# Or download JAR
-curl -L -o bfg.jar https://repo1.maven.org/maven2/com/madgag/bfg/1.14.0/bfg-1.14.0.jar
-```
-
-**Remove files by name**
-
-```bash
-# Clone a fresh mirror
-git clone --mirror git@github.com:org/repo.git
-
-cd repo.git
-
-# Remove files by name
-bfg --delete-files .env
-bfg --delete-files "*.pem"
-bfg --delete-files credentials.json
-
-# Clean up
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-```
-
-**Remove content by pattern**
-
-```bash
-# Create a file with patterns to remove
-echo "sk-ant-api123abc" > passwords.txt
-echo "AKIAIOSFODNN7EXAMPLE" >> passwords.txt
-
-# Replace matching content
-bfg --replace-text passwords.txt
-
-# Clean up
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-```
-
-**Remove files by size**
-
-```bash
-# Remove files larger than 100M
-bfg --strip-blobs-bigger-than 100M
-```
-
-### 5.3 Fresh Repository Approach
-
-When history is too compromised, start fresh:
-
-```bash
-# Create new repo with clean history
-mkdir new-repo
-cd new-repo
-git init
-
-# Copy current files (excluding secrets)
-rsync -av --exclude='.git' --exclude='.env*' --exclude='*.pem' --exclude='*.key' ../old-repo/ .
-
-# Create initial commit
-git add .
-git commit -m "Initial commit (clean history)"
-
-# Push to new remote (or rename old one)
-git remote add origin git@github.com:org/new-repo.git
-git push -u origin main
-```
-
-### 5.4 Force Push After Cleaning
-
-```bash
-# After cleaning with git-filter-repo or BFG
-git reflog expire --expire=now --all
-git gc --prune=now --aggressive
-
-# Force push ALL branches
-git push origin --force --all
-
-# Force push ALL tags
-git push origin --force --tags
-```
-
-### 5.5 Notify Collaborators
-
-All collaborators must re-clone or rebase:
-
-```bash
-# Option 1: Re-clone (safest)
-rm -rf local-repo
-git clone git@github.com:org/repo.git
-
-# Option 2: Fetch and reset (advanced)
-git fetch origin
-git reset --hard origin/main
-git clean -fd
-```
-
-### 5.6 Verify Cleanup
-
-```bash
-# Verify file is gone from all history
-git log --all --full-history -- .env
-# Should return empty
-
-# Verify content pattern is gone
-git log -p --all -S 'your-secret-value' --source
-# Should return empty
-
-# Run gitleaks again
+# Re-run the scanners against the new history
 gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+
+# Confirm the ref counts match pre-rewrite expectations
+git log --all --oneline | wc -l
+git tag -l | wc -l
+```
+
+Verify against a fresh clone of the rewritten remote, not the local working
+copy — the local repository keeps the old objects in its reflog and packs until
+they are pruned, which can mask an incomplete rewrite.
+
+```bash
+git clone --mirror <remote-url> /tmp/verify-clone
+gitleaks detect --source /tmp/verify-clone --verbose
 ```
 
 ---
 
-## 6. Git Hooks and Pre-Commit Hooks
-
-### 6.1 git-secrets
-
-**Installation and setup**
+## 8. Quick Reference
 
 ```bash
-# Install
-brew install git-secrets
+# === PREFLIGHT ===
+git fetch --all --tags --prune
+git log --all --oneline | wc -l
 
-# Install hooks in repository
-git secrets --install
+# === PASS 1: LICENSE ===
+ls LICENSE* && bunx license-checker --failOn 'GPL-3.0;AGPL-3.0'
 
-# Register AWS patterns
-git secrets --register-aws
-
-# Add custom patterns
-git secrets --add 'sk-ant-[a-zA-Z0-9\-_]{40,}'
-git secrets --add 'sk-[a-zA-Z0-9]{48}'
-git secrets --add 'ghp_[A-Za-z0-9_]{36,}'
-git secrets --add 'ANTHROPIC_API_KEY.*=.*sk-ant-'
-git secrets --add 'OPENAI_API_KEY.*=.*sk-'
-
-# Add allowed patterns (false positives)
-git secrets --add --allowed 'sk-ant-example-key-not-real'
-```
-
-**Configuration file** (`.git/config` or global):
-
-```gitconfig
-[secrets]
-    providers = git secrets --aws-provider
-    patterns = sk-ant-[a-zA-Z0-9\\-_]{40,}
-    patterns = sk-[a-zA-Z0-9]{48}
-    patterns = ghp_[A-Za-z0-9_]{36,}
-    allowed = example-api-key
-```
-
-### 6.2 gitleaks Pre-Commit Hook
-
-**Using pre-commit framework**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.1
-    hooks:
-      - id: gitleaks
-```
-
-```bash
-# Install pre-commit
-pip install pre-commit
-
-# Install hooks
-pre-commit install
-```
-
-**Custom gitleaks configuration**
-
-```toml
-# .gitleaks.toml
-title = "Gitleaks Custom Config"
-
-[allowlist]
-description = "Global allowlist"
-paths = [
-    '''\.env\.example$''',
-    '''\.env\.template$''',
-]
-
-[[rules]]
-id = "anthropic-api-key"
-description = "Anthropic API Key"
-regex = '''sk-ant-[a-zA-Z0-9\-_]{40,}'''
-tags = ["key", "anthropic"]
-
-[[rules]]
-id = "openai-api-key"
-description = "OpenAI API Key"
-regex = '''sk-[a-zA-Z0-9]{48}'''
-tags = ["key", "openai"]
-
-[[rules]]
-id = "generic-api-key"
-description = "Generic API Key"
-regex = '''(?i)(api[_-]?key|apikey)['":\s]*[=:]\s*['"][a-zA-Z0-9]{16,}['"]'''
-tags = ["key", "generic"]
-
-[[rules]]
-id = "generic-password"
-description = "Generic Password"
-regex = '''(?i)(password|passwd|pwd)['":\s]*[=:]\s*['"][^'"]{4,}['"]'''
-tags = ["password"]
-```
-
-### 6.3 detect-secrets
-
-**Installation and baseline**
-
-```bash
-# Install
-pip install detect-secrets
-
-# Generate baseline
-detect-secrets scan > .secrets.baseline
-
-# Audit baseline (mark false positives)
-detect-secrets audit .secrets.baseline
-
-# Update baseline after adding new secrets
-detect-secrets scan --baseline .secrets.baseline
-```
-
-**Pre-commit hook**
-
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/Yelp/detect-secrets
-    rev: v1.4.0
-    hooks:
-      - id: detect-secrets
-        args: ['--baseline', '.secrets.baseline']
-```
-
-### 6.4 Husky (Node.js Projects)
-
-**Installation**
-
-```bash
-# Install husky
-npm install --save-dev husky
-
-# Initialize husky
-npx husky init
-```
-
-**Pre-commit hook for secrets**
-
-```bash
-# Create pre-commit hook
-cat > .husky/pre-commit << 'EOF'
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-
-# Check for secrets with gitleaks
-if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose
-  if [ $? -ne 0 ]; then
-    echo "Secrets detected! Commit blocked."
-    exit 1
-  fi
-fi
-
-# Check for forbidden files
-FORBIDDEN_PATTERNS=".env .env.* *.pem *.key credentials.json secrets.*"
-for pattern in $FORBIDDEN_PATTERNS; do
-  if git diff --cached --name-only | grep -E "$pattern"; then
-    echo "ERROR: Attempting to commit forbidden file: $pattern"
-    exit 1
-  fi
-done
-
-exit 0
-EOF
-
-chmod +x .husky/pre-commit
-```
-
-### 6.5 Custom Pre-Commit Hook Script
-
-```bash
-#!/bin/bash
-# .git/hooks/pre-commit
-
-RED='\033[0;31m'
-YELLOW='\033[1;33m'
-GREEN='\033[0;32m'
-NC='\033[0m'
-
-echo "Running secret detection..."
-
-# Forbidden file patterns
-FORBIDDEN_FILES=(
-  ".env"
-  ".env.*"
-  "*.env"
-  "credentials.json"
-  "*-credentials.json"
-  "service-account*.json"
-  "secrets.yml"
-  "secrets.json"
-  "*.pem"
-  "*.key"
-  "*.p12"
-  "*.pfx"
-  "id_rsa"
-  "id_rsa.*"
-  "id_ed25519"
-  "id_ecdsa"
-  ".npmrc"
-  ".pypirc"
-)
-
-# Secret patterns to detect in content
-SECRET_PATTERNS=(
-  "-----BEGIN.*PRIVATE KEY-----"
-  "api[_-]?key.*[=:].*['\"][a-zA-Z0-9]{16,}['\"]"
-  "password.*[=:].*['\"][^'\"]{4,}['\"]"
-  "secret.*[=:].*['\"][a-zA-Z0-9]{16,}['\"]"
-  "sk-ant-[a-zA-Z0-9\-_]{40,}"
-  "sk-[a-zA-Z0-9]{48}"
-  "AKIA[0-9A-Z]{16}"
-  "ghp_[A-Za-z0-9_]{36,}"
-  "xox[baprs]-[0-9]{10,}"
-)
-
-ERRORS=0
-
-# Check for forbidden files
-for pattern in "${FORBIDDEN_FILES[@]}"; do
-  files=$(git diff --cached --name-only | grep -E "^$pattern$|/$pattern$" || true)
-  if [ -n "$files" ]; then
-    echo -e "${RED}ERROR: Forbidden file pattern '$pattern' detected:${NC}"
-    echo "$files"
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-# Check for secret patterns in staged content
-for pattern in "${SECRET_PATTERNS[@]}"; do
-  matches=$(git diff --cached -U0 | grep -E "^\+" | grep -E "$pattern" || true)
-  if [ -n "$matches" ]; then
-    echo -e "${YELLOW}WARNING: Possible secret detected (pattern: $pattern):${NC}"
-    echo "$matches" | head -3
-    ERRORS=$((ERRORS + 1))
-  fi
-done
-
-# Run gitleaks if available
-if command -v gitleaks &> /dev/null; then
-  gitleaks protect --staged --verbose --redact
-  if [ $? -ne 0 ]; then
-    ERRORS=$((ERRORS + 1))
-  fi
-fi
-
-if [ $ERRORS -gt 0 ]; then
-  echo ""
-  echo -e "${RED}===============================================${NC}"
-  echo -e "${RED}COMMIT BLOCKED: $ERRORS potential secret(s) found${NC}"
-  echo -e "${RED}===============================================${NC}"
-  echo ""
-  echo "If these are false positives, you can:"
-  echo "  1. Add to .gitleaks.toml allowlist"
-  echo "  2. Use: git commit --no-verify (NOT RECOMMENDED)"
-  echo ""
-  exit 1
-fi
-
-echo -e "${GREEN}No secrets detected. Proceeding with commit.${NC}"
-exit 0
-```
-
-```bash
-# Make executable
-chmod +x .git/hooks/pre-commit
-```
-
----
-
-## 7. CI/CD Integration
-
-### 7.1 GitHub Actions
-
-```yaml
-# .github/workflows/secrets-scan.yml
-name: Secret Scanning
-
-on:
-  push:
-    branches: [main, master]
-  pull_request:
-    branches: [main, master]
-
-jobs:
-  gitleaks:
-    name: Gitleaks Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run Gitleaks
-        uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }} # Optional for enterprise
-
-  trufflehog:
-    name: TruffleHog Scan
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Run TruffleHog
-        uses: trufflesecurity/trufflehog@main
-        with:
-          path: ./
-          base: ${{ github.event.repository.default_branch }}
-          head: HEAD
-          extra_args: --only-verified
-
-  detect-secrets:
-    name: Detect Secrets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.x'
-
-      - name: Install detect-secrets
-        run: pip install detect-secrets
-
-      - name: Run detect-secrets
-        run: |
-          detect-secrets scan --baseline .secrets.baseline
-          detect-secrets audit --report --baseline .secrets.baseline
-```
-
-### 7.2 GitLab CI
-
-```yaml
-# .gitlab-ci.yml
-stages:
-  - security
-
-gitleaks:
-  stage: security
-  image: zricethezav/gitleaks:latest
-  script:
-    - gitleaks detect --source . --verbose --report-format json --report-path gitleaks-report.json
-  artifacts:
-    reports:
-      secret_detection: gitleaks-report.json
-    when: always
-  rules:
-    - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
-    - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
-
-secret_detection:
-  stage: security
-  image: registry.gitlab.com/gitlab-org/security-products/analyzers/secrets:latest
-  script:
-    - /analyzer run
-  artifacts:
-    reports:
-      secret_detection: gl-secret-detection-report.json
-```
-
-### 7.3 CircleCI
-
-```yaml
-# .circleci/config.yml
-version: 2.1
-
-orbs:
-  gitleaks: upsidr/gitleaks@2.0.0
-
-jobs:
-  secret-scan:
-    docker:
-      - image: cimg/base:stable
-    steps:
-      - checkout
-      - run:
-          name: Install gitleaks
-          command: |
-            curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz | tar xz
-            sudo mv gitleaks /usr/local/bin/
-      - run:
-          name: Run gitleaks
-          command: gitleaks detect --source . --verbose
-
-workflows:
-  security:
-    jobs:
-      - secret-scan
-```
-
-### 7.4 Jenkins
-
-```groovy
-// Jenkinsfile
-pipeline {
-    agent any
-
-    stages {
-        stage('Secret Scan') {
-            steps {
-                sh '''
-                    # Install gitleaks if not present
-                    if ! command -v gitleaks &> /dev/null; then
-                        curl -sSfL https://github.com/gitleaks/gitleaks/releases/download/v8.18.1/gitleaks_8.18.1_linux_x64.tar.gz | tar xz
-                        mv gitleaks /usr/local/bin/
-                    fi
-
-                    # Run scan
-                    gitleaks detect --source . --verbose --report-format json --report-path gitleaks-report.json
-                '''
-            }
-            post {
-                always {
-                    archiveArtifacts artifacts: 'gitleaks-report.json', allowEmptyArchive: true
-                }
-            }
-        }
-    }
-}
-```
-
----
-
-## 8. Checklist
-
-### Pre-Open Source Checklist
-
-```markdown
-## File System Scan
-- [ ] No .env files tracked in repository
-- [ ] No credential files (*.pem, *.key, *.p12) tracked
-- [ ] No service account JSON files tracked
-- [ ] No .npmrc with auth tokens tracked
-- [ ] .gitignore includes all sensitive patterns
-
-## Code Scan
-- [ ] No hardcoded API keys in source files
-- [ ] No hardcoded passwords in source files
-- [ ] No hardcoded connection strings with credentials
-- [ ] No private keys embedded in code
-- [ ] No personal information (emails, names) in comments
-
-## Git History Scan
-- [ ] Ran gitleaks on full history
-- [ ] No sensitive files ever committed (including deleted)
-- [ ] No secrets in any branch or tag
-- [ ] Checked merge commits for leaks
-- [ ] Checked stashes for sensitive data
-
-## Configuration
-- [ ] .env.example exists with placeholder values
-- [ ] README documents required environment variables
-- [ ] No default credentials in config files
-- [ ] Database seeds use fake data
-
-## Prevention Setup
-- [ ] Pre-commit hooks installed (gitleaks or git-secrets)
-- [ ] .gitleaks.toml configured for project
-- [ ] CI/CD secret scanning enabled
-- [ ] Team trained on secret hygiene
-
-## Credential Rotation
-- [ ] All previously leaked credentials rotated
-- [ ] New credentials generated for open source version
-- [ ] Access logs reviewed for unauthorized usage
-```
-
-### Emergency Response Checklist
-
-```markdown
-## Immediate Actions (within minutes)
-- [ ] Rotate compromised credential immediately
-- [ ] Revoke access tokens
-- [ ] Change affected passwords
-- [ ] Disable exposed API keys
-
-## Investigation (within hours)
-- [ ] Check access logs for unauthorized usage
-- [ ] Identify scope of exposure (which commits, branches)
-- [ ] Determine if credential was scraped by bots
-- [ ] Check for unusual account activity
-
-## Remediation (within day)
-- [ ] Clean git history using git-filter-repo or BFG
-- [ ] Force push cleaned history
-- [ ] Notify all collaborators to re-clone
-- [ ] Update .gitignore to prevent recurrence
-- [ ] Set up pre-commit hooks
-
-## Documentation
-- [ ] Document incident timeline
-- [ ] Document affected systems
-- [ ] Document remediation steps taken
-- [ ] Update security procedures
-```
-
----
-
-## 9. Output Format
-
-### Scan Report Template
-
-```markdown
-# Security Scan Report
-
-**Repository**: [repo-name]
-**Scan Date**: [YYYY-MM-DD HH:MM]
-**Scanned By**: [tool/person]
-
-## Summary
-
-| Category | Status | Count |
-|----------|--------|-------|
-| Sensitive Files (Current) | [PASS/FAIL] | [N] |
-| Sensitive Files (History) | [PASS/FAIL] | [N] |
-| Hardcoded Secrets | [PASS/FAIL] | [N] |
-| .gitignore Coverage | [PASS/FAIL] | [N] missing |
-
-## Findings
-
-### Critical (Immediate Action Required)
-
-| File/Location | Type | Details | Commit |
-|---------------|------|---------|--------|
-| .env | Environment File | Tracked in repo | abc1234 |
-| src/config.ts:42 | API Key | OpenAI key detected | def5678 |
-
-### Warning (Review Required)
-
-| File/Location | Type | Details | Commit |
-|---------------|------|---------|--------|
-| config/db.yml | Connection String | May contain password | - |
-
-### Info (False Positives / Reviewed)
-
-| File/Location | Type | Details | Status |
-|---------------|------|---------|--------|
-| .env.example | Example File | Contains placeholders | OK |
-
-## Recommendations
-
-1. **URGENT**: Rotate OpenAI API key immediately
-2. **HIGH**: Remove .env from git history using git-filter-repo
-3. **MEDIUM**: Add missing patterns to .gitignore
-4. **LOW**: Set up pre-commit hooks for ongoing protection
-
-## Commands to Execute
-
-```bash
-# Step 1: Create backup
-git clone --mirror . ../repo-backup-$(date +%Y%m%d)
-
-# Step 2: Remove sensitive files from history
-git filter-repo --path .env --invert-paths
-
-# Step 3: Update .gitignore
-echo ".env" >> .gitignore
-echo "*.pem" >> .gitignore
-
-# Step 4: Force push
-git push origin --force --all
-```
-
-```
-
----
-
-## 10. Best Practices
-
-### Development Workflow
-
-1. **Never commit secrets** - Use environment variables
-2. **Use .env.example** - Document required variables without values
-3. **Git hooks from day one** - Install pre-commit hooks immediately
-4. **Regular audits** - Run gitleaks weekly in CI/CD
-5. **Principle of least privilege** - Use separate keys for dev/staging/prod
-
-### Environment Variable Management
-
-```bash
-# .env.example (safe to commit)
-DATABASE_URL=postgresql://USER:PASSWORD@HOST:5432/MYDB
-OPENAI_API_KEY=your_openai_key_here
-STRIPE_SECRET_KEY=your_stripe_key_here
-
-# .env (NEVER commit)
-DATABASE_URL=postgresql://USER:PASSWORD@prod.example.com:5432/proddb
-OPENAI_API_KEY=sk-abc123...
-STRIPE_SECRET_KEY=sk_live_abc123...
-```
-
-### Secret Management Tools
-
-For production applications, use dedicated secret management:
-
-- **AWS Secrets Manager**
-- **HashiCorp Vault**
-- **Google Secret Manager**
-- **Azure Key Vault**
-- **Doppler**
-- **1Password Secrets Automation**
-
-### Team Training
-
-1. Educate team on risks of committed secrets
-2. Establish code review checklist for secrets
-3. Create incident response procedures
-4. Regular security awareness sessions
-5. Maintain up-to-date .gitignore templates
-
-### Gitignore Template
-
-```gitignore
-# Environment files
-.env
-.env.*
-*.env
-.envrc
-!.env.example
-!.env.template
-
-# Credentials
-credentials.json
-*-credentials.json
-service-account*.json
-secrets.yml
-secrets.json
-*.secret
-api_keys.*
-auth.json
-
-# Private keys
-*.pem
-*.key
-*.p12
-*.pfx
-id_rsa
-id_rsa.*
-id_ed25519
-id_ed25519.*
-id_ecdsa
-id_ecdsa.*
-*.keystore
-*.jks
-
-# Cloud provider
-.aws/
-.gcp/
-.azure/
-kubeconfig
-.kube/
-
-# Package manager auth
-.npmrc
-.yarnrc.yml
-.pypirc
-.gem/credentials
-.docker/config.json
-
-# IDE (may contain secrets)
-.idea/
-.vscode/settings.json
-*.sublime-workspace
-
-# Logs (may contain secrets)
-*.log
-logs/
-
-# Database
-*.sql
-!schema.sql
-!migrations/*.sql
-
-# OS files
-.DS_Store
-Thumbs.db
-```
-
----
-
-## Quick Reference Commands
-
-```bash
-# === SCANNING ===
-# Quick file scan
-find . -name ".env*" -o -name "*.pem" -o -name "*.key" | grep -v node_modules
-
-# Quick history scan
-git log --all --pretty=format: --name-only --diff-filter=A | sort -u | grep -iE 'env|secret|credential|key'
-
-# Full gitleaks scan
+# === PASS 2: HISTORY SECRETS ===
 gitleaks detect --source . --verbose
+trufflehog git file://. --only-verified
+git log --all --pretty=format: --name-only --diff-filter=D | sort -u | grep -iE '\.env|\.pem'
 
-# === CLEANING ===
-# Remove file from history
-git filter-repo --path .env --invert-paths --force
+# === PASS 3: PRIVATE REFERENCES ===
+grep -rniE '\.(internal|corp|local)\b' . | grep -v node_modules
+git log --all --format='%an <%ae>' | sort -u
 
-# Force push after clean
-git push origin --force --all
+# === PASS 4: READINESS ===
+ls README* .env.example && cat .github/CODEOWNERS
 
-# === PREVENTION ===
-# Install git-secrets
-brew install git-secrets && git secrets --install && git secrets --register-aws
-
-# Install gitleaks pre-commit
-cat > .pre-commit-config.yaml << EOF
-repos:
-  - repo: https://github.com/gitleaks/gitleaks
-    rev: v8.18.1
-    hooks:
-      - id: gitleaks
-EOF
-pre-commit install
+# === HANDOFF ===
+# Rotation, history rewrite, force-push, and the ongoing commit-time guard
+# are the git-safety skill's job — this audit produces the list only.
 ```
-
----
-
-**Remember**: Removing secrets from git history does NOT make them safe. Always rotate leaked credentials immediately. Cleaning history is for compliance and reducing exposure, not security.


### PR DESCRIPTION
Closes #100.

A duplicate-detection audit found `skills/open-source-checker/` and `skills/git-safety/` both scanning for secrets and unsafe commits, with heavily duplicated content: sensitive-file patterns, history sweep commands, git-filter-repo/BFG cleanup, `.gitignore` templates, pre-commit hook scripts, and emergency-response checklists all appeared in **both**. The overlap made triggers ambiguous and left two copies of every check to maintain.

Both skills are kept. They are split by **the moment each is reached for**.

## The split

| | `open-source-checker` | `git-safety` |
|---|---|---|
| **Moment** | Once, at the decision to make a private repo public | Every commit, every push, forever |
| **Scope** | The whole repository and its entire history | The staged diff and the command about to run |
| **Invocation** | Model-invoked (publish triggers) | User-invoked (`disable-model-invocation: true`) |
| **Side effects** | None — read-only audit | Rewrites history, force-pushes, writes hooks |

### `open-source-checker` — the publish gate

Four passes, then a binary publish/block verdict:

1. **License and attribution** — `LICENSE` presence, a dependency-compatibility matrix (runtime AGPL/GPL/SSPL vs. an intended MIT release), borrowed and vendored code attribution, copyright ownership.
2. **Secrets across full history** — scanner-driven (gitleaks + truffleHog over all refs), plus the places `--all` misses: stashes, merge commits, deleted-but-present files, every branch and tag. Findings triage into rotate-now vs. rewrite vs. allowlist.
3. **Private references** — the pass no scanner covers: internal hostnames and RFC1918 addresses, employee emails and names in TODOs, customer and client names, infrastructure identifiers, and commit author metadata (which becomes public with the repo).
4. **Publication readiness** — outsider-ready README, complete `.env.example`, fork-safe CI, `CODEOWNERS`, synthetic fixtures.

It produces the rotation list and the rewrite list; it does not perform either.

### `git-safety` — the recurring guard

Two guards on a repo already in daily use:

- **Staged guard** — sensitive filenames and secret-shaped values in the staged diff only. Per-file `BLOCK` / `ALLOW` / `ASK` verdicts.
- **Operation guard** (new) — gates destructive git commands behind stated blast radius, a backup command, and a reversible alternative: `push --force`, `filter-repo`/BFG, `reset --hard`, `clean -fdx`, `checkout --`, branch deletion, rebase on a pushed branch.

Plus prevention setup (ignore rules, hook script, pre-commit framework, `git secrets`, CI scanning with the `fetch-depth: 0` trap called out), the history-rewrite procedure, and leak emergency response.

## Why this line

The detection labour divides along the same seam: **hand-written regexes for the small staged set, scanner tooling for thousands of commits.** Manual patterns have an unacceptable false-negative rate across full history — so `open-source-checker` configures gitleaks and triages its output rather than carrying a regex catalog, and `git-safety` keeps the greps tuned for added lines in a diff. That is what makes the split hold rather than being an arbitrary partition.

History *rewriting* went to `git-safety` because it is a dangerous git operation and belongs behind the operation guard. History *auditing* stayed with `open-source-checker` because it is a one-time completeness sweep.

## Cross-references

Each skill has a `## Related` section naming the other for the out-of-scope moment, and each reference guide opens with a scope note. `open-source-checker` hands rotation and rewrite work to `git-safety` in its verdict template; `git-safety` points at `open-source-checker` before a private repo is published.

## Triggers, now disjoint

- **`open-source-checker`** — "open source this repo", "make this repository public", "is this safe to publish", "check licensing before publishing".
- **`git-safety`** — "about to commit", "staged secret", "force push", "reset --hard", "scrub a leaked credential".

`git-safety` also moves to the user-invoked convention from `skill-standards.md`: human-facing `description`, trigger list relocated to `when_to_use`. `open-source-checker` gains a `## Contract` block declaring the audit read-only.

## Verification

- `bun run catalog:generate` — no drift (169 skills / 32 commands / 13 bundles / 182 plugins).
- `bash scripts/validate-skill-sync.sh` — **0 errors**; both skills report `✓ Valid (Claude + Codex)` with 0 warnings each. The 28 repo-wide warnings are pre-existing on `master` and untouched here.
- `bun run lint` — exit 0.
- `metadata.version` bumped minor and synced to `plugin.json`: `open-source-checker` 1.0.1 → 1.1.0, `git-safety` 1.0.0 → 1.1.0. Existing mode names (`scan`/`clean`/`prevent`/`full`) are preserved, so the bump stays backwards compatible; `guard` is the added mode.
- Net −1,568 / +1,002 lines. Reference guides go from 1,906 lines combined to 1,080, with no check dropped — only relocated.

No local tests or builds were run (MacBook Pro rule); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent-skill metadata only; no runtime application or auth logic changes. Risk is limited to how assistants route and phrase git/security workflows.
> 
> **Overview**
> **Refactors `git-safety` and `open-source-checker` so they no longer duplicate secret-scanning and cleanup guidance.** Responsibility is split by when you reach for each skill: ongoing commit/push work vs. a one-time pre-publication audit.
> 
> **`git-safety` (v1.1.0)** is reframed as two recurring guards: a **staged guard** (`scan`) on the cached diff only, and a new **`guard`** mode that requires blast radius, backup, and confirmation before force-push, history rewrite, hard reset, clean, etc. Modes are documented as `scan` / `guard` / `prevent` / `clean` / `full`, with rotate-first leak response and hooks/CI detail moved into `references/full-guide.md`. Marketplace copy, `when_to_use`, and `disable-model-invocation` align it with day-to-day, user-invoked use.
> 
> **`open-source-checker` (v1.1.0)** becomes a read-only **publish gate**: preflight, four passes (license, full-history secrets via scanners, private references, publication readiness), and explicit **BLOCK** / **PUBLISH** verdicts that hand rotation/rewrite lists to `git-safety`. Its full guide is trimmed and focused on audit scope; it no longer owns pre-commit/history-rewrite playbooks.
> 
> Changes are mirrored under `skills/`, `bundles/github`, `bundles/security`, and `bundles/workspace`, with updated marketplace descriptions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3e49d41944da12dfa7200c9f803f3acc035c7b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->