### PR TITLE
fix: stop Issue Governance failing with a blank project item id

### DIFF
--- a/.github/workflows/issue-governance.yml
+++ b/.github/workflows/issue-governance.yml
@@ -90,6 +90,14 @@ jobs:
             if ADD_OUTPUT=$(gh project item-add "$PROJECT_NUMBER" \
               --owner "$PROJECT_OWNER" --url "$IURL" --format json 2>&1); then
               FLAGS="${FLAGS}added to board; "
+              # item-add already hands back the new item's id — keep it. The
+              # items query reads a replica that lags behind this write, so
+              # re-querying here can come back empty and leave --id blank,
+              # which is how this step died with gh's item-edit usage text.
+              # A freshly added item has no field values yet, hence the empty
+              # nodes list: both defaults below then apply, which is correct.
+              ITEM_JSON=$(printf '%s' "$ADD_OUTPUT" \
+                | jq -c 'select(.id) | {id: .id, fieldValues: {nodes: []}}' 2>/dev/null || true)
             else
               # A concurrent run or an item beyond a fixed list limit may have
               # added it already. Re-query every page before treating this as fatal.
@@ -103,7 +111,11 @@ jobs:
           if [ -z "$ITEM_JSON" ]; then
             ITEM_JSON=$(find_item_json)
           fi
-          ITEM=$(echo "$ITEM_JSON" | jq -r '.id')
+          ITEM=$(echo "$ITEM_JSON" | jq -r '.id // empty')
+          if [ -z "$ITEM" ]; then
+            printf '::error::Could not resolve a board item id for %s — refusing to edit fields blind.\n' "$IURL"
+            exit 1
+          fi
           CUR_STATUS=$(echo "$ITEM_JSON" | jq -r \
             '[.fieldValues.nodes[] | select(.field.name == "Status") | .name][0] // ""')
           CUR_PRI=$(echo "$ITEM_JSON" | jq -r \


### PR DESCRIPTION
## Problem

Every issue opened in the last batch (#97–#101) failed the **Issue Governance** workflow with `gh project item-edit`'s usage text:

```
specify the item to edit with `--id` or `--url`
```

## Root cause

The step adds the issue to the board, then **throws away the item id that `gh project item-add --format json` already returned** and re-runs the paginated items query to find it again. That query reads a replica that lags behind the write it just made, so it returned nothing. `ITEM` resolved to the empty string and `item-edit --id ""` died before any field was set.

Blast radius: issues #92 and #97–#101 sit on the board with **no Priority, no Type, and no `needs-triage` label** — governance never got past step 2.

## Fix

- Keep the id `item-add` hands back. A freshly added item has no field values, so both defaults correctly apply.
- Hard-fail with a readable `::error::` if the id still cannot be resolved, instead of calling `item-edit` with a blank `--id` and surfacing CLI usage text as the failure.

## Verification

- Workflow YAML parses.
- `shellcheck -S warning` on the extracted `run` block is clean.
- Behaviour on the already-on-board path is unchanged (that path never re-queried).

Note: this only fixes *future* issue events. The six already-non-compliant issues need a re-trigger once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only shell changes in one workflow; behavior is more defensive with no auth or production runtime impact.
> 
> **Overview**
> Fixes **Issue Governance** failing on new issues with `gh project item-edit` usage text because `--id` was empty.
> 
> After a successful **`gh project item-add`**, the workflow **builds `ITEM_JSON` from that command’s JSON output** (`id` plus an empty `fieldValues.nodes` list) instead of immediately re-running the paginated board items query. That query can miss a just-added row due to **read-after-write replica lag**, which left `ITEM` blank and broke field defaults.
> 
> **`ITEM` extraction** uses `jq`’s `.id // empty`, and the step **hard-fails with a `::error::`** if no board item id is available, rather than calling `item-edit` with an empty `--id`. The already-on-board path is unchanged aside from the safer id guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7b5e42004c82abaa96aa50716b8179454d8b600. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->