### PR TITLE
fix: enforce skill version sync and require bumps on content changes

### DIFF
--- a/.agents/memory/system/skill-standards.md
+++ b/.agents/memory/system/skill-standards.md
@@ -341,6 +341,11 @@ Versions live in `metadata.version`. Use semver:
 - `2.0.0` — breaking change to workflow or output format
 
 Bump version in both `SKILL.md` (`metadata.version`) and `plugin.json` (`version`) when publishing.
+`SKILL.md` is canonical; `plugin.json` mirrors it. Both are enforced, not advisory:
+
+- `bun run validate` hard-fails when `plugin.json.version ≠ metadata.version` or the plugin description is a YAML block marker.
+- CI `version:check` (`scripts/check-skill-version-bumps.sh`) hard-fails when any file under `skills/<name>/` other than `plugin.json` changes without a `metadata.version` bump vs `origin/master`.
+- Bundle and marketplace `version` fields come from `package.json.version`, which release-please bumps.
 
 ---
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -8,906 +8,1087 @@
     {
       "name": "shipshitdev-testing",
       "source": "./bundles/testing",
+      "version": "1.0.0",
       "description": "Testing, QA, and CI/CD automation skills"
     },
     {
       "name": "shipshitdev-payments",
       "source": "./bundles/payments",
+      "version": "1.0.0",
       "description": "Payment processing and financial integrations"
     },
     {
       "name": "shipshitdev-infrastructure",
       "source": "./bundles/infrastructure",
+      "version": "1.0.0",
       "description": "DevOps, cloud, and infrastructure skills"
     },
     {
       "name": "shipshitdev-frontend",
       "source": "./bundles/frontend",
+      "version": "1.0.0",
       "description": "Frontend development and design skills"
     },
     {
       "name": "shipshitdev-backend",
       "source": "./bundles/backend",
+      "version": "1.0.0",
       "description": "Backend development and API skills"
     },
     {
       "name": "shipshitdev-ai-agents",
       "source": "./bundles/ai-agents",
+      "version": "1.0.0",
       "description": "AI agent development and prompt engineering"
     },
     {
       "name": "shipshitdev-workspace",
       "source": "./bundles/workspace",
+      "version": "1.0.0",
       "description": "Project setup and workspace initialization"
     },
     {
       "name": "shipshitdev-planning",
       "source": "./bundles/planning",
+      "version": "1.0.0",
       "description": "Strategy, planning, and analysis skills"
     },
     {
       "name": "shipshitdev-github",
       "source": "./bundles/github",
+      "version": "1.0.0",
       "description": "GitHub workflow and automation skills"
     },
     {
       "name": "shipshitdev-security",
       "source": "./bundles/security",
+      "version": "1.0.0",
       "description": "Security review, dependency safety, and release-risk skills"
     },
     {
       "name": "shipshitdev-dev-workflow",
       "source": "./bundles/dev-workflow",
+      "version": "1.0.0",
       "description": "Code review, debugging, refactoring, release, and AI-assisted development workflows"
     },
     {
       "name": "shipshitdev-session",
       "source": "./bundles/session",
+      "version": "1.0.0",
       "description": "Session management and documentation"
     },
     {
       "name": "shipshitdev-dev-loop",
       "source": "./bundles/dev-loop",
+      "version": "1.0.0",
       "description": "Autonomous GitHub issue-to-PR loop with PRDs, plans, board dispatch, QA, and review"
     },
     {
       "name": "accessibility",
       "source": "./skills/accessibility",
+      "version": "1.0.1",
       "description": "Applies WCAG 2.1 AA to web UI work and fixes what fails — semantic HTML, ARIA roles and states, keyboard access, focus management, contrast ratios, and screen-reader verification — while a component is being built or reviewed. Use when the user names accessibility, a11y, WCAG, ARIA, keyboard navigation, focus traps, screen readers, or contrast. For a scored multi-dimension quality report, use `audit`; for design-token consistency, use `design-consistency-auditor`."
     },
     {
       "name": "advanced-evaluation",
       "source": "./skills/advanced-evaluation",
+      "version": "2.1.1",
       "description": "Design and operate LLM-as-a-Judge evaluation systems using direct scoring, pairwise comparison, rubric calibration, evaluator bias mitigation, confidence scoring, and automated quality assessment. Use when building LLM-as-judge systems, comparing model responses, calibrating rubrics, debugging inconsistent evaluations, or designing A/B tests for prompt or model changes."
     },
     {
       "name": "agent-architecture-audit",
       "source": "./skills/agent-architecture-audit",
+      "version": "1.0.0",
       "description": "Audit LLM and agent applications for wrapper regressions, prompt or memory contamination, tool discipline failures, hidden repair loops, and output rendering corruption. Use before shipping agent features or when an agent works in a direct model call but fails inside the product."
     },
     {
       "name": "agent-browser",
       "source": "./skills/agent-browser",
+      "version": "1.0.1",
       "description": "Automates browser interactions for web testing, form filling, screenshots, and data extraction. Use when the user needs to navigate websites, interact with web pages, fill forms, take screenshots, test web applications, or extract information from web pages."
     },
     {
       "name": "agent-config-audit",
       "source": "./skills/agent-config-audit",
+      "version": "1.1.2",
       "description": "Audit AI agent instruction files (AGENTS.override.md, AGENTS.md, configured fallbacks, CLAUDE.md, hooks, and settings) across workspaces in read-only report mode. Use when agent configs drift, rules duplicate, files go stale, or after workspace restructuring; apply fixes only when explicitly requested."
     },
     {
       "name": "agent-dispatch",
       "source": "./skills/agent-dispatch",
+      "version": "1.1.0",
       "description": "Single front door for agent/subagent architecture, config, and setup. Parses a subcommand — audit, config, init, or route — and routes to the right engine: agent-architecture-audit (diagnose LLM wrapper and agent failures), agent-config-audit (audit and sync AI agent config files across workspaces), agent-folder-init (add or repair .agents/ project context for a repo), or setup-agent-routing (write a machine-readable routing block in CLAUDE.md/AGENTS.md). Backs the /agent command. Use when asked to audit an agent system, check config drift, initialize agent docs, or wire up routing, and the action must be picked from an argument like \"audit\", \"config\", \"init\", or \"route\"."
     },
     {
       "name": "agent-folder-init",
       "source": "./skills/agent-folder-init",
+      "version": "2.0.0",
       "description": "Add or repair .agents/ project context for an existing repo. Use for AI agent documentation, session tracking, task management, and coding standards; do not use as the primary new-product scaffold."
     },
     {
       "name": "ai-agent-cost-optimizer",
       "source": "./skills/ai-agent-cost-optimizer",
+      "version": "1.0.0",
       "description": "Audit and reduce AI agent token and inference spend through context discipline, prompt caching, model routing, batching, and workflow capture. Use when discussing AI coding bills, token waste, model selection, prompt caching, or agent cost optimization."
     },
     {
       "name": "ai-loading-ux",
       "source": "./skills/ai-loading-ux",
+      "version": "1.0.0",
       "description": "Design AI loading, thinking, and progress indicator UX. Use when explicitly asked to improve AI waiting states, add thinking indicators, or design loading UX for AI interfaces. Covers reasoning display (chain-of-thought), progress steps, streaming states, and the \"elevator mirror effect\" for reducing perceived wait time."
     },
     {
       "name": "ai-regression-testing",
       "source": "./skills/ai-regression-testing",
+      "version": "1.0.0",
       "description": "Design regression tests for AI-assisted development by targeting model blind spots such as sandbox versus production path drift, response-shape mismatches, untested bug fixes, and same-model review failures. Use after AI-generated code changes, bug fixes, API edits, or feature-flag/sandbox changes."
     },
     {
       "name": "api-design-expert",
       "source": "./skills/api-design-expert",
+      "version": "1.0.0",
       "description": "Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications. Use when designing API endpoints, building RESTful APIs, writing OpenAPI/Swagger docs, implementing versioning, or designing error responses and DTOs."
     },
     {
       "name": "artifacts-builder",
       "source": "./skills/artifacts-builder",
+      "version": "1.0.0",
       "description": "Suite of tools for creating elaborate, multi-component claude.ai HTML artifacts using modern frontend web technologies (React, Tailwind CSS, @agenticindiedev/ui). Use for complex artifacts requiring state management or shared UI components - not for simple single-file HTML/JSX artifacts."
     },
     {
       "name": "ask-dev-loop",
       "source": "./skills/ask-dev-loop",
+      "version": "1.0.0",
       "description": "Ask which Dev Loop skill or flow fits the current situation. A router over the flagship idea-to-ship path."
     },
     {
       "name": "audit",
       "source": "./skills/audit",
+      "version": "2.1.2",
       "description": "Sweeps implemented frontend code across five dimensions at once — accessibility, performance, theming, responsive design, and anti-patterns — scoring each 0-4 and emitting a single P0-P3 report with a prioritized plan. Reports only; it changes no code. Reach for it as the broad first pass when no one dimension has been named. For a deep WCAG conformance pass, use `accessibility`; for design-token drift, use `design-consistency-auditor`."
     },
     {
       "name": "aws-infrastructure",
       "source": "./skills/aws-infrastructure",
+      "version": "1.0.0",
       "description": "Expert in AWS infrastructure setup including EC2, VPC, security groups, Application Load Balancers, Route53 DNS, and SSL/TLS certificates. Use this skill for AWS infrastructure configuration and deployment."
     },
     {
       "name": "biome-validator",
       "source": "./skills/biome-validator",
+      "version": "1.0.1",
       "description": "Validate Biome 2.3+ configuration and detect outdated patterns. Ensures proper schema version, domains, assists, and recommended rules. Use before any linting work or when auditing existing projects."
     },
     {
       "name": "bug",
       "source": "./skills/bug",
+      "version": "1.0.1",
       "description": "File a GitHub issue of type Bug from a description — structures a clear bug report (summary, steps to reproduce, expected vs actual, environment), previews it, then on confirmation creates the issue with the Bug issue type (falling back to a bug label when the repo has no issue types). Use when the user asks to file a bug, open a bug report, create a GitHub bug issue, log a bug, or runs /bug."
     },
     {
       "name": "bun-validator",
       "source": "./skills/bun-validator",
+      "version": "1.0.1",
       "description": "Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices. Use when setting up a Bun monorepo, before adding workspace dependencies, auditing an existing Bun workspace, or validating package.json in CI."
     },
     {
       "name": "changelog-generator",
       "source": "./skills/changelog-generator",
+      "version": "1.0.0",
       "description": "Automatically creates user-facing changelogs from git commits by analyzing commit history, categorizing changes, and transforming technical commits into clear, customer-friendly release notes. Turns hours of manual changelog writing into minutes of automated generation. Use when preparing release notes, summarizing product updates, or turning git commits into customer-facing changelog entries."
     },
     {
       "name": "clarify",
       "source": "./skills/clarify",
+      "version": "2.1.1",
       "description": "Improve unclear UX copy, error messages, microcopy, labels, and instructions to make interfaces easier to understand. Use when the user mentions confusing text, unclear labels, bad error messages, hard-to-follow instructions, or wanting better UX writing."
     },
     {
       "name": "clerk-validator",
       "source": "./skills/clerk-validator",
+      "version": "1.0.1",
       "description": "Validate Clerk authentication configuration and detect deprecated patterns. Ensures proper proxy.ts usage (Next.js 16), ClerkProvider setup, and modern auth patterns. Use before any Clerk work or when auditing existing auth implementations."
     },
     {
       "name": "code-review",
       "source": "./skills/code-review",
+      "version": "1.2.0",
       "description": "Correctness, security, and spec-fidelity gate for incoming pull requests. Auto-invoked when reviewing a diff, evaluating a PR, running /code-review at any effort level, or asked \"is this safe to merge?\" Covers bugs, TypeScript hygiene, security, database safety, test existence, devex regressions, feature-flag leaks, and whether the diff matches the originating issue/spec. Multi-PR report-only review routes through review-dispatch; non-serial queue draining is exposed only through exact /merge force."
     },
     {
       "name": "codebase-advisor",
       "source": "./skills/codebase-advisor",
+      "version": "1.1.0",
       "description": "Survey any codebase as a senior advisor, then hand back either prioritized self-contained implementation plans for OTHER models/agents to execute, or a written architecture and health analysis for humans. Strictly read-only on source code — never implements, fixes, or refactors anything itself. Use when asked to audit or analyze a codebase, review its architecture, assess project health for onboarding, find improvement opportunities (bugs, security, performance, test coverage, tech debt, migrations, DX), suggest features or where to take the project next (roadmap, product direction), or generate handoff plans for another agent to implement. Does NOT edit code directly — it declines and hands off a plan instead."
     },
     {
       "name": "codebase-design",
       "source": "./skills/codebase-design",
+      "version": "1.0.0",
       "description": "Shared vocabulary for designing deep modules. Use when the user wants to design or improve a module's interface, find deepening opportunities, decide where a seam goes, make code more testable or AI-navigable, or when another skill needs the deep-module vocabulary."
     },
     {
       "name": "codex-image-gen",
       "source": "./skills/codex-image-gen",
+      "version": "1.0.0",
       "description": "Generate raster images (icons, illustrations, textures, app icons) from a text prompt by driving the Codex CLI's image tool, then extracting the finished PNG from the Codex session rollout. Use when an agent needs a real generated image and has no native image-generation tool. Requires the `codex` CLI, logged in."
     },
     {
       "name": "comment-mode",
       "source": "./skills/comment-mode",
+      "version": "1.0.0",
       "description": "Granular feedback on drafts without rewriting. Generates highlighted HTML with click-to-reveal inline comments. Use when user says \"comment on this\", \"leave comments on\", \"give feedback on\", or asks for feedback on a draft. Supports multiple lenses—editor feedback, POV simulation (\"as brian would react\"), or focused angles (\"word choice only\", \"weak arguments\"). A granular alternative to rewrites that lets users review feedback incrementally without losing their voice."
     },
     {
       "name": "commit-summary",
       "source": "./skills/commit-summary",
+      "version": "1.0.1",
       "description": "Generate Conventional Commit messages from staged or unstaged git changes, split unrelated changes into logical commits, detect breaking changes, and optionally create commits after approval. Use when writing commit messages, preparing commits, or committing local work."
     },
     {
       "name": "component-library",
       "source": "./skills/component-library",
+      "version": "1.0.0",
       "description": "Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects. Use when creating or refactoring UI components, reviewing component architecture, or setting up shared component patterns in a monorepo."
     },
     {
       "name": "content-script-developer",
       "source": "./skills/content-script-developer",
+      "version": "1.0.0",
       "description": "Expert in browser extension content scripts, DOM integration, and safe page augmentation across modern web apps. Use when building or updating a browser-extension content script, injecting UI into third-party pages, or handling SPA navigation and dynamic DOM changes."
     },
     {
       "name": "context-degradation",
       "source": "./skills/context-degradation",
+      "version": "2.1.0",
       "description": "Recognize, diagnose, and mitigate patterns of context degradation in agent systems. Use when context grows large, agent performance degrades unexpectedly, or debugging agent failures."
     },
     {
       "name": "context-engineering",
       "source": "./skills/context-engineering",
+      "version": "1.0.0",
       "description": "Supplementary context protocol for agents executing in a repo that has a CLAUDE.md / AGENTS.md (or equivalent config). Use to make an execution agent read project conventions first, treat inputs by trust level, surface plan-vs-convention conflicts instead of silently picking a side, and reuse existing patterns before writing new code."
     },
     {
       "name": "context-fundamentals",
       "source": "./skills/context-fundamentals",
+      "version": "2.2.0",
       "description": "Explain or reason about foundational context engineering concepts: what context is, the anatomy of a context window, attention mechanics, the U-shaped attention curve, why context quality matters more than quantity, and the mental models needed to interpret context-engineering decisions. Use for conceptual explanation, onboarding, and background reading. Route operational work to context-degradation for attention failures and context-optimization for token-efficiency work."
     },
     {
       "name": "context-optimization",
       "source": "./skills/context-optimization",
+      "version": "2.1.0",
       "description": "Improve context efficiency through context budgeting, observation masking, prefix or KV-cache strategy, partitioning, token-cost reduction, retrieval scoping, and extending effective context capacity without lowering answer quality. Use when token costs or context budgets constrain a task, tool outputs are verbose, cache hit rate is low, or context must be partitioned across agents."
     },
     {
       "name": "critique",
       "source": "./skills/critique",
+      "version": "2.1.1",
       "description": "Evaluate design from a UX perspective, assessing visual hierarchy, information architecture, emotional resonance, cognitive load, and overall quality with quantitative scoring, persona-based testing, automated anti-pattern detection, and actionable feedback. Use when the user asks to review, critique, evaluate, or give feedback on a design or component."
     },
     {
       "name": "cto-advisor",
       "source": "./skills/cto-advisor",
+      "version": "1.0.1",
       "description": "Advises engineering leadership on direction — architecture decisions recorded as ADRs, technology and vendor evaluation, team scaling ratios, and DORA/engineering-metric targets. Reasons from org-level indicators and frameworks, never from a repository scan. Use when the user asks which technology to adopt, how to structure or scale the engineering team, whether to write an ADR, what DORA targets to hold, or mentions CTO, technical leadership, technology strategy, vendor selection, or engineering metrics. To inventory and rank the debt already sitting in a codebase, use `tech-debt`."
     },
     {
       "name": "de-slop",
       "source": "./skills/de-slop",
+      "version": "1.3.0",
       "description": "Strip AI-generated slop from a codebase and product. Code slop — console statements, `any` types, unused imports, commented-out code, redundant comments, needless defensive try-catch on trusted paths, over-nesting. Product slop (with --product) — marketing-filler copy, generic AI phrasing, default-shadcn look, unstyled loading/error states, dead buttons and half-wired flows that make an app feel unfinished. UI slop (`ui`) runs a project-derived design-system primitive pass. Can scope to the current branch's diff or sweep the whole tree. Use when asked to clean up AI-generated code, remove slop, or make an app feel finished before shipping to customers."
     },
     {
       "name": "debug",
       "source": "./skills/debug",
+      "version": "2.0.0",
       "description": "Front door for a freshly reported failure: build a deterministic feedback loop, reproduce the symptom, rank falsifiable hypotheses, and instrument the narrowest point that separates them. Carries the lookup library — 54 rules across 10 categories covering observation technique, common bug patterns, and triage priority. Use on first contact with a bug, crash, wrong output, or performance regression before any fix has been attempted, and to look up a debugging technique or bug pattern by name. Hands off to `systematic-debugging` when a fix attempt has already failed or the cause survives the loop."
     },
     {
       "name": "dependency-audit",
       "source": "./skills/dependency-audit",
+      "version": "1.0.1",
       "description": "Audit a project's dependency supply chain — known CVEs in installed packages, secrets about to be committed, and lockfile/provenance integrity — and wire the checks into CI as a merge gate. Use when asked to audit dependencies, check for vulnerable packages, scan for leaked secrets, add a security gate to CI, or harden the supply chain. Complements security-audit (app-level) and git-safety (git history)."
     },
     {
       "name": "deploy",
       "source": "./skills/deploy",
+      "version": "1.0.1",
       "description": "Run deployment workflows for web applications (staging, production). Use when user says 'deploy', 'push to staging', 'release', 'ship it', or 'go live'."
     },
     {
       "name": "deploy-dispatch",
       "source": "./skills/deploy-dispatch",
+      "version": "1.0.0",
       "description": "Single front door for deployment and infra provisioning. Parses a subcommand — app, compose, ec2, monitor, or devcontainer — and routes to the right engine: deploy (web app deployment to staging/production), deployment-composer (compose the smallest safe deployment workflow from repo signals), ec2-backend-deployer (CI/CD pipeline to EC2 via Docker and GitHub Actions), monitoring-setup (Sentry + Google Analytics for NestJS/Next.js), or devcontainer-setup (VS Code Dev Container scaffold). Backs the /deploy command. Use when asked to deploy, set up infra, configure monitoring, or provision a dev container, and the action must be picked from an argument like \"app\", \"compose\", \"ec2\", \"monitor\", or \"devcontainer\"."
     },
     {
       "name": "deployment-composer",
       "source": "./skills/deployment-composer",
+      "version": "1.1.0",
       "description": "Compose deployment workflows from smaller skills and repo signals, including trunk-based releases, CI quality gates, provider deployment, post-deploy verification, rollback, and failed-check diagnosis. Use when the user asks for a deployment plan, release workflow, ship-to-staging/production environments, or a smart deploy process across GitHub, Vercel, EC2, Docker, or custom CI."
     },
     {
       "name": "design-consistency-auditor",
       "source": "./skills/design-consistency-auditor",
+      "version": "1.0.1",
       "description": "Hunts design-token drift across a frontend — hardcoded hex values where semantic tokens belong, arbitrary spacing outside the scale, one-off classes duplicating a design-system component, and patterns that diverge screen to screen. Measures against the project's own tokens and class conventions, discovered from the codebase first rather than assumed. Triggers on audit design consistency, review component styling, check color palette usage, find hardcoded colors, or identify design debt. For a scored multi-dimension quality report, use `audit`; for WCAG conformance, use `accessibility`."
     },
     {
       "name": "design-dispatch",
       "source": "./skills/design-dispatch",
+      "version": "1.0.0",
       "description": "Single front door for UI/design review and refinement. Parses a subcommand — audit, clarify, critique, layout, polish, quieter, shape, or consistency — and routes to the right design engine: audit (technical quality checks with scored report), clarify (UX copy and microcopy improvement), critique (UX evaluation with quantitative scoring), layout (layout and spacing improvement), polish (final pre-ship quality pass), quieter (tone down visually aggressive designs), shape (UX/UI planning and design brief), or design-consistency-auditor (cross-app design system consistency audit). Backs the /design command. Use when asked to review, audit, polish, plan, or refine UI, and the action must be picked from an argument like \"audit\", \"critique\", \"polish\", or \"shape\"."
     },
     {
       "name": "devcontainer-setup",
       "source": "./skills/devcontainer-setup",
+      "version": "1.0.1",
       "description": "Scaffolds a complete VS Code Dev Container configuration with Docker, docker-compose, and optional Claude Code CLI support. Activates when asked to \"set up devcontainer\", \"add docker development environment\", \"configure dev container\", or containerize a development workflow."
     },
     {
       "name": "docker-expert",
       "source": "./skills/docker-expert",
+      "version": "1.0.0",
       "description": "Expert in Docker, docker-compose, Dockerfile patterns, and container orchestration for NestJS and Next.js applications. Use this skill when users need Docker setup, containerization, or docker-compose configuration."
     },
     {
       "name": "docs",
       "source": "./skills/docs",
+      "version": "1.0.0",
       "description": "Creates clear, concise technical documentation for software projects, runbooks, and developer guides. Use when writing or updating a README, guide, runbook, API reference, setup instructions, or troubleshooting notes."
     },
     {
       "name": "domain-modeling",
       "source": "./skills/domain-modeling",
+      "version": "1.0.0",
       "description": "Build and sharpen a project's domain model. Use when discussing codebase terminology, writing or editing a CONTEXT.md, or recording or editing an ADR."
     },
     {
       "name": "ec2-backend-deployer",
       "source": "./skills/ec2-backend-deployer",
+      "version": "1.0.0",
       "description": "Deploys backend applications to EC2 instances using Docker, GitHub Actions CI/CD, and Tailscale for secure SSH access. Activates when setting up EC2 deployment pipelines, configuring container registries, or wiring automated deploys for NestJS, Next.js, or Express backends."
     },
     {
       "name": "error-handling-expert",
       "source": "./skills/error-handling-expert",
+      "version": "1.0.0",
       "description": "Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications. Use when implementing error handling, exception filters, error responses, error logging, or recovery strategies."
     },
     {
       "name": "evaluation",
       "source": "./skills/evaluation",
+      "version": "1.2.0",
       "description": "Build evaluation frameworks for agent systems. Use when testing agent performance, validating context engineering choices, or measuring improvements over time."
     },
     {
       "name": "executing-plans",
       "source": "./skills/executing-plans",
+      "version": "2.2.0",
       "description": "Orchestrate autonomous AI development with task-based workflow and QA gates. Use when implementing a development plan, picking tasks from a queue, or running multi-platform parallel execution with QA gates."
     },
     {
       "name": "execution-debugging",
       "source": "./skills/execution-debugging",
+      "version": "1.0.0",
       "description": "Scoped debugging methodology for when a test or build fails during execution/stabilization. Use to diagnose the failing check without scope-creeping — read the full error, reproduce in isolation, hypothesize before changing, localize, fix the root cause not the symptom, and guard with a regression test."
     },
     {
       "name": "expo-architect",
       "source": "./skills/expo-architect",
+      "version": "1.0.0",
       "description": "Scaffold a production-ready Expo React Native app with working screens, navigation, and optional Clerk auth. Generates complete mobile app structure that runs immediately with `bun start`. Use when scaffolding a new Expo or React Native app, setting up Expo Router navigation, or adding Clerk auth to a mobile app."
     },
     {
       "name": "feature-intake",
       "source": "./skills/feature-intake",
+      "version": "1.2.0",
       "description": "Capture a client or stakeholder feature request, turn it into a planner-ready PRD epic with scoped sub-issues, check for duplicate work, and place approved issues on a GitHub Projects kanban. Use when a user invokes feature intake, asks to turn a rough client requirement into GitHub issues, or wants an idea written as a PRD and pushed to a board."
     },
     {
       "name": "finishing-a-development-branch",
       "source": "./skills/finishing-a-development-branch",
+      "version": "1.0.0",
       "description": "Structured \"done coding, now what?\" workflow: verify tests pass, detect the repository environment (normal repo vs worktree, named branch vs detached HEAD), present exactly the right merge / PR / keep / discard options, and execute the chosen path including safe worktree cleanup. Use when implementation is complete and the branch needs to be integrated, published, or abandoned."
     },
     {
       "name": "fix-merge-conflicts",
       "source": "./skills/fix-merge-conflicts",
+      "version": "1.0.0",
       "description": "Resolve git merge conflicts correctness-first, then prove the tree still builds. Use when a merge, rebase, cherry-pick, or stash pop leaves conflict markers, when git status shows unmerged paths, or when the user asks to fix conflicts, resolve a merge, or rebase onto the trunk and clear the conflicts."
     },
     {
       "name": "frontend-design",
       "source": "./skills/frontend-design",
+      "version": "1.0.0",
       "description": "Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics."
     },
     {
       "name": "full-code-review",
       "source": "./skills/full-code-review",
+      "version": "1.0.2",
       "description": "Fan-out PR review across three parallel dimension agents (structural, security, devex/flag-hygiene), adversarially verify every finding, and synthesize a single prioritized verdict via a strongest-tier judge. Use when asked for a full, comprehensive, or end-to-end review of a branch or PR — after /code-review passes correctness, this skill covers the orthogonal dimensions it does not: security depth, structural health, devex regressions, and feature-flag hygiene. In retro mode (a commit log is passed in) it adds a cross-commit lens and emits a prioritized backlog instead of a merge verdict."
     },
     {
       "name": "fullstack-workspace-init",
       "source": "./skills/fullstack-workspace-init",
+      "version": "1.1.0",
       "description": "Initialize Shipshit.dev full-stack product workspaces through npx @shipshitdev/v0, then customize and verify the generated repo. Use for new product scaffolds or post-v0 workspace setup."
     },
     {
       "name": "gh-address-comments",
       "source": "./skills/gh-address-comments",
+      "version": "1.0.1",
       "description": "Implements the fixes a PR review asked for — maps each thread to the code it touches, edits that code, and drafts a reply per thread for approval before anything is posted. Starts from feedback that is already understood; producing the read-only digest is `pr-comments`."
     },
     {
       "name": "gh-fix-ci",
       "source": "./skills/gh-fix-ci",
+      "version": "1.1.0",
       "description": "Diagnoses failing or setup-stuck GitHub Actions checks on a PR, identifies root cause, and proposes or applies targeted fixes. Triggers when the user asks to fix CI, diagnose failing checks, fix a failing workflow, address GitHub Actions errors, get a green build, or continue PR queue work without waiting on unrelated pending checks. Can run autonomously in a loop — fix, push, recheck — until all required checks are green when the user asks to loop on CI."
     },
     {
       "name": "gh-inbox",
       "source": "./skills/gh-inbox",
+      "version": "1.0.0",
       "description": "Collect and triage a GitHub work inbox from assigned issues, review requests, mentions, authored PRs with failing checks, and optional project filters. Use when checking what needs attention across GitHub or prioritizing GitHub tasks."
     },
     {
       "name": "gh-pr-publish",
       "source": "./skills/gh-pr-publish",
+      "version": "1.0.2",
       "description": "Create, update, and publish GitHub pull requests with a clean title, durable body, branch hygiene, validation notes, and safe push/PR gates. Use when opening a PR, updating a PR description, preparing a draft PR, or publishing local changes to GitHub."
     },
     {
       "name": "gh-project-board",
       "source": "./skills/gh-project-board",
+      "version": "1.1.0",
       "description": "Configure GitHub Projects v2 kanban boards with Ship Shit Dev defaults: the Backlog / In Progress / Human Review / Done / Deferred Status columns (the dev-loop board-as-truth model) and P0-P3 Priority. Use when setting up, copying, auditing, or normalizing GitHub project boards."
     },
     {
       "name": "gh-review-suggestions",
       "source": "./skills/gh-review-suggestions",
+      "version": "1.0.0",
       "description": "Review GitHub pull requests and post precise inline suggested changes with GitHub suggestion blocks. Use when asked to review a PR, leave actionable GitHub comments, propose applyable fixes, or submit review suggestions through gh."
     },
     {
       "name": "git-safety",
       "source": "./skills/git-safety",
+      "version": "1.1.0",
       "description": "Guards day-to-day git work in an existing repository: blocks secrets from entering a commit, gates destructive git operations before they run, installs ignore rules and pre-commit hooks, and drives the rotate-first response when a credential has already leaked."
     },
     {
       "name": "github-actions-author",
       "source": "./skills/github-actions-author",
+      "version": "1.0.0",
       "description": "Author, review, and harden GitHub Actions workflows using current official documentation, secure trigger patterns, least-privilege permissions, current action versions, and CI/CD validation. Use when creating, editing, debugging, or security-reviewing workflow YAML."
     },
     {
       "name": "graphql-architect",
       "source": "./skills/graphql-architect",
+      "version": "1.0.0",
       "description": "Design and review GraphQL schemas, resolvers, mutations, pagination, and data-loading patterns. Use when building or refactoring GraphQL APIs, adding fields, fixing resolver design, or improving GraphQL performance and safety."
     },
     {
       "name": "grilling",
       "source": "./skills/grilling",
+      "version": "1.0.0",
       "description": "Grill the user relentlessly about a plan, decision, or idea. Use when the user wants to stress-test their thinking, asks to be grilled, or another skill needs the interview primitive."
     },
     {
       "name": "grok-review",
       "source": "./skills/grok-review",
+      "version": "1.0.0",
       "description": "Independent second-opinion code review through the Grok CLI. Builds a self-contained review prompt from the exact diff, runs one headless Grok invocation on the CLI's own default model and effort, then verifies every returned finding against the code before reporting. Use when asked to review with Grok, get a second opinion on a branch, worktree, or PR from another CLI, or cross-check a review with an independent engine."
     },
     {
       "name": "html-style",
       "source": "./skills/html-style",
+      "version": "1.0.0",
       "description": "Apply opinionated styling to barebones HTML. Use when user has plain/unstyled HTML and wants to apply consistent visual styling. Triggers: style this HTML, apply styling, make this look good, /html-style, or when user shares HTML that needs CSS. Transforms tables, lists, status indicators, buttons, and layouts into a cohesive design system."
     },
     {
       "name": "husky-test-coverage",
       "source": "./skills/husky-test-coverage",
+      "version": "1.0.1",
       "description": "Sets up or verifies Husky git hooks to enforce test coverage above 80% (configurable) for Node.js/TypeScript projects. Activates when enforcing coverage through pre-commit hooks, verifying existing Husky/test setup, or configuring coverage thresholds for Jest, Vitest, or Mocha test runners."
     },
     {
       "name": "icp",
       "source": "./skills/icp",
+      "version": "1.0.0",
       "description": "Discover and document a product's Ideal Customer Profile as a durable .agents/memory/icp.md — segments ranked by revenue potential, each with acute pain, willingness-to-pay, buying trigger, and churn reasons. Use when a user says \"define our ICP\", \"who is our customer\", \"who are we selling to\", \"document our ideal customer\", or before roadmap-analyzer / roadmap-to-milestones need a customer to prioritize against."
     },
     {
       "name": "incremental-fetch",
       "source": "./skills/incremental-fetch",
+      "version": "1.0.0",
       "description": "Guides construction of resilient data ingestion pipelines from paginated APIs. Activates on: \"ingest data from API\", \"pull tweets\", \"fetch historical data\", \"sync from X\", \"build a data pipeline\", \"fetch without re-downloading\", \"resume the download\", \"backfill older data\". NOT for: simple one-shot API calls, websocket/streaming connections, file downloads, or APIs without pagination."
     },
     {
       "name": "interview",
       "source": "./skills/interview",
+      "version": "1.2.0",
       "description": "Repo-grounded discovery interview that produces a handoff brief for PRD writing, feature intake, or planning."
     },
     {
       "name": "landing-page-vercel",
       "source": "./skills/landing-page-vercel",
+      "version": "1.0.1",
       "description": "Scaffolds a production-ready static landing page with working email capture form, analytics, and responsive design. Activates on \"create landing page\", \"build a landing page\", \"launch page for product\", or similar requests. Optionally deploys to Vercel on explicit request."
     },
     {
       "name": "layout",
       "source": "./skills/layout",
+      "version": "2.1.2",
       "description": "Reworks the structure underneath a UI — spacing scale, visual hierarchy, grid and composition, rhythm, and density — turning monotonous or crowded arrangements into intentional ones. Applies while the composition itself is still wrong, ahead of any detail pass. Use when the user says the layout feels off, every section looks the same, the UI is crowded or too sparse, hierarchy is unclear, or nothing guides the eye. For the last-mile pass on a finished feature, use `polish`."
     },
     {
       "name": "linter-formatter-init",
       "source": "./skills/linter-formatter-init",
+      "version": "1.0.1",
       "description": "Set up Biome (default) or ESLint + Prettier, Vitest testing, and pre-commit hooks for any JavaScript/TypeScript project. Uses Bun as the package manager. Use this skill when initializing code quality tooling for a new project or adding linting to an existing one."
     },
     {
       "name": "llm-structured-output",
       "source": "./skills/llm-structured-output",
+      "version": "1.0.0",
       "description": "Design prompts, schemas, validation, and recovery logic for reliable machine-readable model outputs. Use when generating JSON, typed objects, extraction results, tool arguments, or any output another system must parse safely."
     },
     {
       "name": "mcp-builder",
       "source": "./skills/mcp-builder",
+      "version": "1.0.1",
       "description": "Creates MCP (Model Context Protocol) servers that enable LLMs to interact with external services through well-designed tools. Activates on: \"build an MCP server\", \"create MCP tools\", \"integrate API via MCP\", \"write a FastMCP server\", \"add an MCP server to an agent\", or any request to wrap an external API as LLM-callable tools in Python or Node/TypeScript."
     },
     {
       "name": "memory-systems",
       "source": "./skills/memory-systems",
+      "version": "4.1.0",
       "description": "Design and implement memory architectures for agent systems that persist state across sessions, maintain entity consistency, and reason over structured knowledge. Use when building agents that persist knowledge across sessions, choosing between memory frameworks, maintaining entity consistency, or designing memory architectures for production."
     },
     {
       "name": "merge-open-prs",
       "source": "./skills/merge-open-prs",
+      "version": "1.3.0",
       "description": "Review and land open pull requests through one /merge command. The default mode runs a confirmation-gated trunk sweep and cleanup; exact /merge force drains the queue non-serially by merging green PRs and narrowly fixing red PRs. Use when asked to review and merge open PRs, batch-merge to trunk, drain PR WIP, or run /merge."
     },
     {
       "name": "micro-landing-builder",
       "source": "./skills/micro-landing-builder",
+      "version": "1.0.0",
       "description": "Scaffolds, clones, and deploys config-driven NextJS landing pages that use a shared UI components package. Use when creating single or multiple startup landing pages with email capture, analytics, and modern design. Supports batch creation from templates or CSV/JSON files and Vercel deployment with custom domains. Each landing is a standalone NextJS app driven by an app.json config file."
     },
     {
       "name": "mongodb-atlas-checker",
       "source": "./skills/mongodb-atlas-checker",
+      "version": "1.0.0",
       "description": "Verify MongoDB Atlas setup and configuration for backend applications. Checks connection strings, environment variables, connection pooling, and ensures proper setup for Next.js and NestJS applications. Use when verifying MongoDB Atlas setup, checking connection strings or environment variables, or troubleshooting database connection issues before deployment."
     },
     {
       "name": "mongodb-migration-expert",
       "source": "./skills/mongodb-migration-expert",
+      "version": "1.0.0",
       "description": "Database schema design, indexing, and migration guidance for MongoDB-based applications. Use when adding or changing MongoDB collections, indexes, or fields, designing schema for multi-tenant or large datasets, or planning forward-only migrations."
     },
     {
       "name": "monitoring-setup",
       "source": "./skills/monitoring-setup",
+      "version": "1.1.0",
       "description": "Sets up production monitoring for NestJS and Next.js apps — Sentry error tracking, Google Analytics, and operational signals (BullMQ queue depth, Postgres slow queries, connection saturation) with alerts on each. Activates when users need error tracking, production monitoring, analytics, queue/database observability, or alerting on operational health."
     },
     {
       "name": "multi-agent-patterns",
       "source": "./skills/multi-agent-patterns",
+      "version": "2.1.1",
       "description": "Design multi-agent architectures for complex tasks. Use when single-agent context limits are exceeded, when tasks decompose naturally into subtasks, or when specializing agents improves quality."
     },
     {
       "name": "nestjs-expert",
       "source": "./skills/nestjs-expert",
+      "version": "1.0.0",
       "description": "NestJS architecture, modules, DI, guards, interceptors, pipes, MongoDB/Mongoose integration, auth, and production patterns. Use when building NestJS APIs, designing module structure, implementing auth, handling errors, writing DTOs, or debugging NestJS-specific issues."
     },
     {
       "name": "nestjs-queue-architect",
       "source": "./skills/nestjs-queue-architect",
+      "version": "1.0.0",
       "description": "Queue job management patterns, processors, and async workflows for video/image processing. Use when building BullMQ queues, job processors, or async video/image processing workflows in NestJS."
     },
     {
       "name": "nestjs-testing-expert",
       "source": "./skills/nestjs-testing-expert",
+      "version": "1.1.0",
       "description": "NestJS testing mechanics with Jest — building testing modules, mocking providers and repositories, writing service and controller specs, and driving HTTP end-to-end tests through the real application. Use for any test touching a NestJS service, controller, guard, module, or API endpoint, including test-module setup, provider overrides, database fakes, and Supertest request flows."
     },
     {
       "name": "nextjs-validator",
       "source": "./skills/nextjs-validator",
+      "version": "1.0.1",
       "description": "Validate Next.js 16 configuration and detect/prevent deprecated patterns. Ensures proxy.ts usage, Turbopack, Cache Components, and App Router best practices. Use before any Next.js work or when auditing existing projects."
     },
     {
       "name": "nextra-writer",
       "source": "./skills/nextra-writer",
+      "version": "1.0.0",
       "description": "Expert in creating clear, comprehensive technical documentation with Nextra (Next.js-based docs framework), MDX, and modern documentation patterns. Use for documentation sites that need Next.js integration."
     },
     {
       "name": "open-source-checker",
       "source": "./skills/open-source-checker",
+      "version": "1.1.0",
       "description": "Audits a whole private repository once, at the decision to make it public. Runs four passes — license and attribution, secrets across the entire git history, private references (internal hostnames, employee emails, client and customer names, staging URLs), and publication readiness — then returns a publish or block verdict. Use when the user is preparing to open source a repository, asks whether a codebase is safe to publish, wants a pre-release audit before flipping a repo public, or needs to know what is still private in code that is about to ship publicly."
     },
     {
       "name": "package-architect",
       "source": "./skills/package-architect",
+      "version": "1.0.0",
       "description": "Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Use when creating or restructuring monorepo packages, defining package.json exports, or setting up tsconfig references."
     },
     {
       "name": "performance-expert",
       "source": "./skills/performance-expert",
+      "version": "1.1.0",
       "description": "Backend, database, and infrastructure performance expert covering API response times, query and index optimization, N+1 elimination, caching and background jobs, server profiling, and build/asset delivery. Use when improving API latency, optimizing database queries or indexes, designing a caching layer, moving heavy work to a queue, profiling a server process, shrinking a shipped bundle, or configuring CDN and edge caching. React render and component work belongs to `react-component-performance`."
     },
     {
       "name": "playwright-e2e-init",
       "source": "./skills/playwright-e2e-init",
+      "version": "1.0.0",
       "description": "Initialize Playwright end-to-end testing for Next.js and React projects. Sets up configuration, creates example tests, and integrates with existing CI/CD. Use when adding E2E tests to a frontend project."
     },
     {
       "name": "polish",
       "source": "./skills/polish",
+      "version": "2.1.2",
       "description": "Runs the last pass over a functionally complete feature — pixel alignment, interaction and loading states, empty and error states, copy consistency, transition smoothness, and micro-details measured against the design system. Requires the work to be finished first; it refines, it never restructures. Use when the user asks for polish, finishing touches, a pre-launch review, or wants to go from good to great. To fix the underlying composition instead, use `layout`."
     },
     {
       "name": "postgres-ops",
       "source": "./skills/postgres-ops",
+      "version": "1.0.1",
       "description": "Operate a production Postgres database — backup strategy, point-in-time recovery, restore drills, connection pooling for serverless, and a disaster-recovery runbook. Use when asked to set up Postgres backups, plan disaster recovery, configure connection pooling, restore a database, or harden Postgres for production. Covers managed (RDS / Prisma Postgres) and self-managed instances."
     },
     {
       "name": "pr-comments",
       "source": "./skills/pr-comments",
+      "version": "1.0.1",
       "description": "Reads a pull request's review threads and returns a digest — grouped by thread, severity-tagged, priority-ordered, with the open questions called out. Strictly read-only: no code edits, no replies, no thread resolution. Reach for it to triage feedback before deciding what to fix; implementing those fixes is `gh-address-comments`."
     },
     {
       "name": "prd-dispatch",
       "source": "./skills/prd-dispatch",
+      "version": "1.0.0",
       "description": "Single front door for product specs, PRDs, and feature planning. Parses a subcommand — new, spec, gate, write, intake, or interview — and routes to the right planning engine: prd-task-creator (GitHub issue or local PRD), spec-first (spec → plan → execute loop), prd-quality-gate (completeness validation), prd-writer (full PRD draft), feature-intake (client requirement → kanban issues), or interview (discovery interview before PRD writing). Backs the /prd command. Use when asked to create a PRD, plan a feature, write a spec, validate a PRD, run a discovery interview, or intake a stakeholder requirement, and the action must be picked from an argument like \"new\", \"spec\", \"gate\", \"write\", \"intake\", or \"interview\"."
     },
     {
       "name": "prd-quality-gate",
       "source": "./skills/prd-quality-gate",
+      "version": "1.1.0",
       "description": "PRD completeness validation. Use to check that a PRD (or issue body that serves as one) contains the required sections before it is handed to a planning/execution agent, so the plan is built from a complete spec instead of hallucinated scope. Run it as a blocking gate or a warning-only lint."
     },
     {
       "name": "prd-task-creator",
       "source": "./skills/prd-task-creator",
+      "version": "1.2.1",
       "description": "Files work into a tracker — turns a feature, bug, or finished PRD into GitHub issues, linked sub-issues, or local task files, slicing epics into thin vertical slices sized for one PR each and tagged AFK or HITL. Starts once the requirements are settled; authoring the PRD document itself is `prd-writer`."
     },
     {
       "name": "prd-writer",
       "source": "./skills/prd-writer",
+      "version": "1.2.1",
       "description": "Authors the PRD document itself — problem, scope boundaries, EARS acceptance criteria, and verification plan — as one self-contained contract a planning agent consumes without re-elicitation. Ends at the written PRD; slicing it into tracked issues is `prd-task-creator`."
     },
     {
       "name": "production-audit",
       "source": "./skills/production-audit",
+      "version": "1.0.0",
       "description": "Audit an application for production readiness using local evidence from code, CI, config, migrations, runtime checks, observability, and deployment paths. Use before launch, after risky merges, or when asked whether an app is ready to ship."
     },
     {
       "name": "project-init-orchestrator",
       "source": "./skills/project-init-orchestrator",
+      "version": "1.0.0",
       "description": "Selects the correct project initialization route and orchestrates setup. Triggers on \"initialize project\", \"set up new project\", \"bootstrap project\", or when scaffolding a new Shipshit.dev product repo. Use v0 for new Shipshit.dev product repos; use lower-level setup skills only for existing repo repair, customization, or small additions."
     },
     {
       "name": "prompt-engineering",
       "source": "./skills/prompt-engineering",
+      "version": "1.0.0",
       "description": "Expert guide on prompt engineering patterns, best practices, and optimization techniques. Use when user wants to improve prompts, learn prompting strategies, debug agent behavior, or design content generation prompts."
     },
     {
       "name": "prototype",
       "source": "./skills/prototype",
+      "version": "1.0.0",
       "description": "Build a throwaway prototype to answer a design question. Use when the user wants to sanity-check whether a state model or logic feels right, or explore what a UI should look like."
     },
     {
       "name": "qa-loop",
       "source": "./skills/qa-loop",
+      "version": "1.0.0",
       "description": "Runs an interactive localhost QA session that accepts issues, screenshots, routes, and browser evidence; reproduces and fixes each defect; verifies the result; and creates one local commit per fix. Use when asked to start QA, QA a local app, fix localhost issues as they arrive, or work through screenshot feedback without leaving the current checkout."
     },
     {
       "name": "qa-reviewer",
       "source": "./skills/qa-reviewer",
+      "version": "1.1.0",
       "description": "Runs a structured multi-phase verification pass on completed AI agent work — catching bugs, missed requirements, and incorrect assumptions before changes are committed. Triggers on: \"check your work\", \"review this\", after complex multi-step implementations, before committing major refactors, or proactively after any task longer than five steps."
     },
     {
       "name": "quick-view",
       "source": "./skills/quick-view",
+      "version": "1.0.1",
       "description": "Generates minimal HTML pages to review structured data in a browser with maximum readability. Triggers on: \"show me\", \"view this\", \"make reviewable\", \"open as webpage\", or any request to review lists, tables, drafts, or summaries that are hard to read in the terminal."
     },
     {
       "name": "quieter",
       "source": "./skills/quieter",
+      "version": "2.1.1",
       "description": "Tones down visually aggressive or overstimulating designs, reducing intensity while preserving quality. Use when the user mentions too bold, too loud, overwhelming, aggressive, garish, or wants a calmer, more refined aesthetic."
     },
     {
       "name": "react-component-performance",
       "source": "./skills/react-component-performance",
+      "version": "1.1.0",
       "description": "Diagnose slow React components and apply targeted render-time fixes. Use when profiling a slow React component, cutting re-renders or props churn, fixing list lag or janky typing and scrolling, deciding where `memo`, `useMemo`, or `useCallback` pay off, virtualizing a long list, or reading a React DevTools Profiler trace. API latency, database queries, caching, and infrastructure belong to `performance-expert`."
     },
     {
       "name": "react-hook-form",
       "source": "./skills/react-hook-form",
+      "version": "1.0.0",
       "description": "Provides 41 prioritized performance rules for React Hook Form across form configuration, field subscription, controlled components, validation, and field arrays. Invoke when writing or reviewing forms with useForm, useWatch, useController, or useFieldArray; integrating shadcn/MUI with Controller; or diagnosing unexpected re-renders in RHF-based forms. Covers client-side validation only — does not cover React Server Actions or useActionState."
     },
     {
       "name": "react-native-components",
       "source": "./skills/react-native-components",
+      "version": "1.0.0",
       "description": "Master React Native 0.79.5 components, styling, performance optimization, and mobile UI best practices with real-world examples. Use when building React Native UI components, implementing StyleSheet or dynamic styling, optimizing list performance, or creating accessible mobile interfaces."
     },
     {
       "name": "react-patterns",
       "source": "./skills/react-patterns",
+      "version": "1.0.0",
       "description": "Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Use when writing or reviewing React components, applying hooks and composition patterns, or improving React performance and TypeScript usage."
     },
     {
       "name": "react-refactor",
       "source": "./skills/react-refactor",
+      "version": "1.0.0",
       "description": "Architectural refactoring guide for React applications covering component architecture, state architecture, hook patterns, component decomposition, coupling and cohesion, data flow, and refactoring safety. Triggers when refactoring React codebases, reviewing PRs for architectural issues, decomposing oversized components, or improving module boundaries."
     },
     {
       "name": "react-testing-library",
       "source": "./skills/react-testing-library",
+      "version": "1.1.0",
       "description": "React Testing Library mechanics for testing React components and hooks — query selection, async handling, user interaction, assertions, provider setup, and the anti-patterns that make tests brittle. Use for any test that renders a React component or a hook, including choosing between getBy/queryBy/findBy, userEvent flows, waitFor usage, renderHook, custom render wrappers, and reviewing RTL tests for implementation-detail assertions."
     },
     {
       "name": "receiving-code-review",
       "source": "./skills/receiving-code-review",
+      "version": "1.0.0",
       "description": "Evaluate incoming code-review feedback with technical rigor before implementing any change. Verify each point against the codebase, push back with reasoning when the reviewer is wrong, and never perform empty agreement. Use when you receive a review, before touching any code, especially when feedback seems unclear or technically questionable."
     },
     {
       "name": "redis-caching",
       "source": "./skills/redis-caching",
+      "version": "1.0.1",
       "description": "Redis caching, rate limiting, session storage, pub/sub, and production integration patterns for TypeScript, Next.js, NestJS, and Prisma applications. Use when adding cache-aside or write-through caching, rate limiting, session or lock storage, pub/sub fanout, or reviewing Redis key design and TTLs."
     },
     {
       "name": "refactor-code",
       "source": "./skills/refactor-code",
+      "version": "1.1.0",
       "description": "Systematic approach to safely refactoring code with tests. Use when user says 'refactor', 'clean up code', 'simplify', 'reduce complexity', or 'technical debt'."
     },
     {
       "name": "refactor-dispatch",
       "source": "./skills/refactor-dispatch",
+      "version": "1.0.0",
       "description": "Single front door for improving existing code — routes to the right engine by mode: deslop (strip AI slop, code + product), code (safe behavior-preserving refactor), debt (tech-debt register), perf (frontend + backend optimization), structure (read-only structural review), or stack (dependency + framework-pattern modernization). Backs the /refactor command. Use when asked to refactor, clean up, de-slop, pay down tech debt, optimize, or modernize, and the mode must be picked from an argument like \"deslop\", \"debt\", \"perf\", or \"stack\"."
     },
     {
       "name": "release",
       "source": "./skills/release",
+      "version": "2.0.1",
       "description": "Cuts the release itself — derives the next semantic version from commits since the last tag, writes plain-English patch notes, previews the plan, then on confirmation creates an annotated tag plus GitHub release, or dispatches the repo's guarded release workflow where production sits behind a workflow_dispatch promote gate. Trunk-based; no develop or staging branch promotion. Assumes the trunk is already green — to open a release PR or wait on required checks first, use `release-pr-gates`."
     },
     {
       "name": "release-cleanup",
       "source": "./skills/release-cleanup",
+      "version": "2.1.1",
       "description": "Verify a release branch is provably merged into the trunk (default branch) via the squash-aware GitHub PR merge oracle, then prune merged local and remote feature branches and stale git worktrees. Squash-merge aware — uses GitHub PR merge state as the merge oracle, not commit ancestry. Use when the user asks to clean up branches after a deploy, prune worktrees, remove merged branches, or confirm nothing stale was left behind before pruning."
     },
     {
       "name": "release-dispatch",
       "source": "./skills/release-dispatch",
+      "version": "1.0.1",
       "description": "Single front door for releases. Parses a subcommand — gates, cut, notes, or cleanup — and routes to the right release engine: release-pr-gates (verify CI green, then cut a tag/release or open a release PR), release (semver bump + plain-English patch notes), or release-cleanup (prune merged branches and stale worktrees). Backs the /release command. Use when asked to release, cut a tag, open a release PR, wait for CI to go green, generate patch notes, or clean up branches after a deploy, and the action must be picked from an argument like \"gates\", \"cut\", \"notes\", or \"cleanup\"."
     },
     {
       "name": "release-pr-gates",
       "source": "./skills/release-pr-gates",
+      "version": "1.1.1",
       "description": "Holds a release at the gate — opens or reuses a release PR into the trunk, runs local format, lint, and type-check, watches required GitHub checks through to green, and summarizes the failing run's root cause when they are not. Tags only after the gate passes. Reach for it during the pre-merge wait; for version derivation and plain-English patch notes, use `release`."
     },
     {
       "name": "review-dispatch",
       "source": "./skills/review-dispatch",
+      "version": "1.4.0",
       "description": "Single front door for code review. Resolves a target — working-tree changes, one PR, all open PRs, the last N commits, a time window, or a retrospective over merged history — into the right workflow, natively or through an external second-opinion engine (grok). Keeps every /review mode report-only except confirmation-gated retrospective issue filing. Backs the /review command. Use when asked to review changes, a PR, all PRs, recent commits, or merged history, or to get a second opinion from another CLI."
     },
     {
       "name": "roadmap-analyzer",
       "source": "./skills/roadmap-analyzer",
+      "version": "2.0.0",
       "description": "Turn a product's ICP into a revenue-ranked roadmap. Reads .agents/memory/icp.md (from the icp skill), inventories what already ships, finds the gaps that block landing/retaining/expanding the primary segment, and outputs a prioritized backlog plus strategic themes. Use when asked what to build next, how to prioritize the roadmap, what's blocking revenue, or to plan toward MRR. Hands off to roadmap-to-milestones."
     },
     {
       "name": "roadmap-to-milestones",
       "source": "./skills/roadmap-to-milestones",
+      "version": "1.0.1",
       "description": "Turn a revenue-ranked roadmap into tracked GitHub Milestones with due dates, assign issues to them, and report burndown. Bridges roadmap-analyzer's backlog to the dev-loop board. Use when asked to create milestones, set milestone due dates, group issues under milestones, turn a roadmap into a schedule, or track milestone progress. Creates and edits GitHub milestones only after confirmation."
     },
     {
       "name": "rules-capture",
       "source": "./skills/rules-capture",
+      "version": "1.1.0",
       "description": "Automatically detects and documents user preferences, coding standards, and workflow rules from conversation — capturing them to `.agents/memory/captured-rules.md` for promotion to permanent project or user rules. Triggers on: \"always do X\", \"never do X\", \"from now on\", \"the rule is\", \"stop doing X\", \"I prefer\", frustration indicators, or any correction to AI behavior."
     },
     {
       "name": "scaffold",
       "source": "./skills/scaffold",
+      "version": "1.0.0",
       "description": "Generate incremental local code modules following existing codebase patterns. Use for endpoints, components, packages, collections, or modules inside an existing repo; not for full project scaffolds."
     },
     {
       "name": "security-audit",
       "source": "./skills/security-audit",
+      "version": "1.0.0",
       "description": "Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting. Use when auditing a web app or API for security issues, reviewing auth or session handling, checking input validation and injection risk, or hardening before release."
     },
     {
       "name": "security-expert",
       "source": "./skills/security-expert",
+      "version": "1.1.0",
       "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing."
     },
     {
       "name": "setup-agent-routing",
       "source": "./skills/setup-agent-routing",
+      "version": "1.2.0",
       "description": "Sets up an `## Agent skills` routing block in CLAUDE.md/AGENTS.md plus docs/agents/ so the dev-loop skills (executing-plans, feature-intake, prd-writer, qa-reviewer) know this repo's GitHub issue tracker, kanban label vocabulary, and domain doc layout. Run once per repo before first use of the loop, or when those skills appear to lack tracker, label, or domain context."
     },
     {
       "name": "shadcn",
       "source": "./skills/shadcn",
+      "version": "1.0.0",
       "description": "Provides shadcn/ui component library best practices and patterns. Triggers when writing, reviewing, or refactoring shadcn/ui components; when working with Radix primitives, Tailwind styling, React Hook Form validation, data tables, theming, or component composition patterns."
     },
     {
       "name": "shadcn-setup",
       "source": "./skills/shadcn-setup",
+      "version": "1.0.1",
       "description": "Sets up shadcn/ui with Tailwind CSS v4 CSS-first configuration — installs packages, generates globals.css with @theme tokens, creates components.json, and adds the cn() utility. Use when starting a new Next.js or React project that needs a shadcn component library, or migrating from shadcn + Tailwind v3."
     },
     {
       "name": "shape",
       "source": "./skills/shape",
+      "version": "2.2.0",
       "description": "Plan the UX and UI for a feature before writing code. Produces a design brief that guides implementation."
     },
     {
       "name": "skill-capture",
       "source": "./skills/skill-capture",
+      "version": "1.0.0",
       "description": "Extracts valuable workflows, patterns, and domain knowledge from conversations and persists them as reusable SKILL.md files. Triggers on: \"save this as a skill\", \"capture this as a skill\", \"make this reusable\", \"this workflow should be reusable\", \"this was tricky to figure out\", \"I wish I knew this earlier\", or on completion of complex multi-step procedures."
     },
     {
       "name": "skill-comply",
       "source": "./skills/skill-comply",
+      "version": "1.0.0",
       "description": "Measure whether agents actually follow a skill, rule, command, or agent definition by deriving expected behaviors, running representative scenarios, and comparing observed action timelines against the spec. Use after adding or changing instructions, before publishing skills, or when rules appear to be ignored."
     },
     {
       "name": "skill-creator",
       "source": "./skills/skill-creator",
+      "version": "1.1.0",
       "description": "Guide for creating effective skills. Use when creating a new skill or updating an existing one to extend agent capabilities with specialized knowledge, workflows, or tool integrations."
     },
     {
       "name": "skill-dispatch",
       "source": "./skills/skill-dispatch",
+      "version": "1.0.0",
       "description": "Single front door for authoring and maintaining agent skills. Parses a subcommand — create, capture, comply, or scout — and routes to the right engine: skill-creator (guide for creating or updating a skill), skill-capture (extract a workflow from conversation into a SKILL.md), skill-comply (measure whether agents follow a skill or rule), or skill-scout (search for existing skills before building new ones). Backs the /skill command. Use when asked to create a skill, capture a pattern, test compliance of a skill, or scout for an existing skill, and the action must be picked from an argument like \"create\", \"capture\", \"comply\", or \"scout\"."
     },
     {
       "name": "skill-scout",
       "source": "./skills/skill-scout",
+      "version": "1.0.0",
       "description": "Search local, marketplace, repository, package, GitHub, and web sources before creating a new skill or custom implementation. Use when asked to create, fork, import, or evaluate a skill, or before writing code for functionality that likely already exists."
     },
     {
       "name": "spec-first",
       "source": "./skills/spec-first",
+      "version": "1.1.0",
       "description": "Enforces a spec → plan → execute → verify loop before writing code, preventing \"looks right\" failures. Activates on \"build X\", \"implement...\", \"add a feature that...\", or any multi-file/unclear-requirements request. Creates spec.md, todo.md, and decisions.md as durable artifacts."
     },
     {
       "name": "stack-modernization",
       "source": "./skills/stack-modernization",
+      "version": "1.0.0",
       "description": "Modernize a project's stack — outdated dependencies, dead/unused packages, deprecated packages, and framework-pattern drift (old patterns lingering after a major upgrade). Verifies the current latest of each package before proposing an upgrade, then applies changes incrementally with tests between each. Use when asked to update dependencies, modernize the stack, remove dead packages, or migrate stale framework patterns, across frontend and backend."
     },
     {
       "name": "standup",
       "source": "./skills/standup",
+      "version": "1.0.0",
       "description": "Summarize what you personally shipped over a time window from git history — an engineer standup or weekly recap, not a customer changelog. Scopes commits to your git author identity, reads the diffs, and classifies each as a feature, fix, refactor, tech-debt, or docs change. Use when the user asks what did I get done, write my standup, what did I ship this week, weekly recap, or runs /standup."
     },
     {
       "name": "stripe-implementer",
       "source": "./skills/stripe-implementer",
+      "version": "1.0.0",
       "description": "Implement Stripe payment processing, subscription management, webhook handling, and customer management in Next.js and NestJS applications. Use when integrating Stripe payments, subscription billing, webhooks, customer management, or checkout and payment intents."
     },
     {
       "name": "structural-review",
       "source": "./skills/structural-review",
+      "version": "1.0.2",
       "description": "Perform a structural and maintainability review of a PR or codebase diff — covering file-size blockers, abstraction quality, layer violations, type structural discipline, spaghetti branching, non-atomic mutations, stack-specific hygiene (Bun, Tailwind v4, Next.js 16, shadcn/ui), design purity (code-judo), and directness over magic (no speculative generality). Use when asked to review code quality, maintainability, structural health, or architecture of a change. Orthogonal to /code-review (which owns correctness bugs and repo rule compliance) — run after correctness passes or in parallel when a thorough PR review is requested."
     },
     {
       "name": "systematic-debugging",
       "source": "./skills/systematic-debugging",
+      "version": "1.1.0",
       "description": "Full four-phase root-cause loop — investigate, analyze patterns, hypothesize, implement — for a failure that survived a first pass. Bars any further fix until the cause is proven, counts failed attempts, and turns the third failure into an architecture question. Use when a fix attempt has already failed, the same defect keeps coming back, each fix exposes a new problem elsewhere, or the root cause must be proven before another line changes — including when time pressure makes guessing tempting. `debug` is the front door that hands cases here."
     },
     {
       "name": "table-filters",
       "source": "./skills/table-filters",
+      "version": "1.0.0",
       "description": "Designs optimal filtering UX for data tables. Use when building a table that needs filters - analyzes the data columns and determines the best filter type for each. Outputs a unified filter field with inline header filters."
     },
     {
       "name": "tailwind",
       "source": "./skills/tailwind",
+      "version": "1.0.0",
       "description": "Provides Tailwind CSS v4 performance optimization and best practices guidelines. Triggers when writing, reviewing, or refactoring Tailwind CSS v4 code; when working with Tailwind configuration, @theme directive, utility classes, responsive design, dark mode, container queries, or CSS generation optimization."
     },
     {
       "name": "tailwind-validator",
       "source": "./skills/tailwind-validator",
+      "version": "1.0.1",
       "description": "Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns. Use this skill when setting up Tailwind, auditing CSS configuration, or when you suspect outdated Tailwind patterns are being used. Ensures CSS-first configuration with @theme blocks."
     },
     {
       "name": "tdd",
       "source": "./skills/tdd",
+      "version": "1.0.1",
       "description": "Test-driven development workflow for feature work and bug fixes. Use when the user asks for TDD, red-green-refactor, test-first implementation, regression-first bug fixes, or vertical-slice delivery."
     },
     {
       "name": "tech-debt",
       "source": "./skills/tech-debt",
+      "version": "1.0.1",
       "description": "Inventories a real codebase and ranks its technical debt into a register scored by interest (how often it hurts) over principal (effort to fix), every item anchored to a file-and-line or a metric. Covers code smells, dependency debt, test gaps, and architectural churn hotspots across frontend and backend. Use when asked what to pay down, where the codebase is rotting, or to turn debt into a tracked backlog. Files the register as GitHub issues on request. For org-level technology strategy and architecture direction, use `cto-advisor`."
     },
     {
       "name": "test-dispatch",
       "source": "./skills/test-dispatch",
+      "version": "1.0.0",
       "description": "Single front door for testing. Parses a subcommand — run, qa, tdd, e2e, coverage, init, or regression — and routes to the right testing engine: test-runner (run tests, fix failures), qa-reviewer (structured verification pass on completed work), tdd (red-green-refactor workflow), playwright-e2e-init (scaffold E2E tests for frontend projects), husky-test-coverage (enforce coverage thresholds via git hooks), testing-cicd-init (Vitest + GitHub Actions CI setup), or ai-regression-testing (design regression tests targeting AI blind spots). Backs the /test command. Use when asked to run tests, write tests, set up testing, check coverage, or start TDD, and the action must be picked from an argument like \"run\", \"qa\", \"tdd\", \"e2e\", \"coverage\", \"init\", or \"regression\"."
     },
     {
       "name": "test-runner",
       "source": "./skills/test-runner",
+      "version": "1.0.0",
       "description": "Run a project's tests at the right scope — changed-only, focused, full, type-check, or e2e — then, on failure, read the output and traces, apply a minimal fix, and rerun until green or blocked. Detects the test runner and package manager from the repo. Use when the user asks to run tests, run the suite, run smoke/e2e tests, type-check, check the build compiles, fix failing tests, or runs /tests."
     },
     {
       "name": "testing-cicd-init",
       "source": "./skills/testing-cicd-init",
+      "version": "1.0.0",
       "description": "Installs Vitest testing infrastructure and GitHub Actions CI/CD for TypeScript projects (Next.js, NestJS, React). Configures 80% coverage thresholds, test setup files, and Bun-based CI workflows. Use when adding tests to a new project, migrating from Jest to Vitest, or setting up GitHub Actions CI/CD for the first time."
     },
     {
       "name": "testing-expert",
       "source": "./skills/testing-expert",
+      "version": "1.1.0",
       "description": "Framework-agnostic testing strategy — which level to test at, what coverage numbers mean, how to design a test that survives refactoring, how to choose test data, and how to kill flakes. Use when deciding what is worth testing, setting or defending a coverage target, reviewing the shape of an existing suite, or diagnosing a flaky or slow test. Framework-specific work routes to a specialist skill instead of being answered here."
     },
     {
       "name": "theme-factory",
       "source": "./skills/theme-factory",
+      "version": "1.0.0",
       "description": "Toolkit for styling artifacts with a theme. These artifacts can be slides, docs, reportings, HTML landing pages, etc. There are 10 pre-set themes with colors/fonts that you can apply to any artifact that has been creating, or can generate a new theme on-the-fly. Use when styling an artifact such as slides, docs, or an HTML landing page with a preset or custom theme of colors and fonts."
     },
     {
       "name": "tool-design",
       "source": "./skills/tool-design",
+      "version": "2.2.0",
       "description": "Design tools that agents can use effectively, including when to reduce tool complexity. Use when creating, optimizing, or reducing the set of tools available to an agent."
     },
     {
       "name": "turborepo",
       "source": "./skills/turborepo",
+      "version": "1.0.0",
       "description": "Turborepo monorepo build system guidance. Triggers on: `turbo.json`, task pipelines, `dependsOn`, caching, remote cache, the `turbo` CLI, `--filter`, `--affected`, CI optimization, environment variables, internal packages, monorepo structure, and package boundaries. Use when the user configures tasks or workflows, creates packages, sets up a monorepo, shares code between apps, runs changed packages, debugs cache behavior, or works in an `apps/` plus `packages/` workspace."
     },
     {
       "name": "typescript-expert",
       "source": "./skills/typescript-expert",
+      "version": "1.0.1",
       "description": "Resolves TypeScript and JavaScript problems across type-level programming, performance, monorepo management, migration, and modern tooling. Invoke when diagnosing \"type instantiation excessively deep\" errors, migrating JS to TS, configuring strict tsconfig, debugging module resolution, or choosing between Biome/ESLint/Turborepo/Nx."
     },
     {
       "name": "typescript-refactor",
       "source": "./skills/typescript-refactor",
+      "version": "1.0.0",
       "description": "TypeScript refactoring and modernization guidelines from a principal specialist perspective. This skill should be used when refactoring, reviewing, or modernizing TypeScript code to ensure type safety, compiler performance, and idiomatic patterns. Triggers on tasks involving TypeScript type architecture, narrowing, generics, error handling, or migration to modern TypeScript features."
     },
     {
       "name": "vercel-deploy",
       "source": "./skills/vercel-deploy",
+      "version": "1.0.1",
       "description": "Deploy a Next.js app to Vercel and manage its environment — preview and production deploys, environment variables per environment, promotion, and rollback to a previous deployment. Use when asked to deploy to Vercel, ship a preview, promote to production, roll back a bad deploy, or manage Vercel env vars. Confirms the project is linked before any deploy and never links unattended."
     },
     {
       "name": "verification-before-completion",
       "source": "./skills/verification-before-completion",
+      "version": "1.0.0",
       "description": "Enforce evidence-based completion: no success, done, fixed, or passing claim may be made without first running the verification command and reading its full output. Use when about to claim work is complete, a bug is fixed, tests pass, a build succeeds, or before committing, pushing, or opening a PR."
     },
     {
       "name": "wait-what",
       "source": "./skills/wait-what",
+      "version": "1.0.0",
       "description": "Re-pitch the last message in plain English using the project's CONTEXT.md vocabulary."
     },
     {
       "name": "wizard",
       "source": "./skills/wizard",
+      "version": "1.0.0",
       "description": "Generate an interactive bash wizard that walks a human through steps only they can perform. Use when provisioning infrastructure, setting up credentials or CI secrets, walking an unfamiliar third-party dashboard, or running a one-off migration or cutover."
     },
     {
       "name": "workspace-performance-audit",
       "source": "./skills/workspace-performance-audit",
+      "version": "1.0.0",
       "description": "Orchestrates comprehensive performance audits across full-stack monorepos. Coordinates performance-expert, design-consistency-auditor, accessibility, security-expert, and qa-reviewer skills to audit frontend, backend, database, browser extensions, and shared packages. Use when asked for a full workspace performance review, monorepo audit, or to identify bottlenecks across frontend, backend, and extensions."
     },
     {
       "name": "worktree",
       "source": "./skills/worktree",
+      "version": "1.0.1",
       "description": "Create an isolated git worktree from the correct base branch and check it out into a clean, gitignored directory. Use when the user asks to make a worktree, spin up a parallel/isolated workspace, work on something without disturbing the current checkout, branch off the current work, or run multiple agents on the same repo at once. Picks the base branch smartly — the current feature branch when you are on one, otherwise the repository's default/trunk branch — so worktrees continue your in-progress work by default instead of forking from the wrong place."
     },
     {
       "name": "writing-plans",
       "source": "./skills/writing-plans",
+      "version": "1.1.0",
       "description": "Turn a spec or requirements doc into a comprehensive, bite-sized implementation plan: map every file, define 2-5 minute TDD tasks with complete code, and enforce DRY/YAGNI/frequent-commits discipline. Use when you have requirements ready and need a concrete execution plan before touching code, when a feature spans multiple files and needs decomposition, or when you want agentic workers to execute tasks reliably without guessing."
     }
   ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          fetch-depth: 0 # version:check diffs against origin/master
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -52,6 +54,11 @@ jobs:
 
       - name: Validate skills
         run: bun run validate
+
+      - name: Require version bumps on changed skills
+        run: bun run version:check
+        env:
+          BASE_REF: origin/${{ github.base_ref || 'master' }}
 
       - name: Check agent-folder-init safety fixtures
         run: python3 -m unittest discover -s skills/agent-folder-init/tests -p 'test_*.py'

--- a/bundles/ai-agents/skills/context-degradation/plugin.json
+++ b/bundles/ai-agents/skills/context-degradation/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-degradation",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "Recognize, diagnose, and mitigate patterns of context degradation in agent systems. Use when context",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/context-fundamentals/plugin.json
+++ b/bundles/ai-agents/skills/context-fundamentals/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-fundamentals",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "description": "Understand the components, mechanics, and constraints of context in agent systems. Use when designin",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/context-optimization/plugin.json
+++ b/bundles/ai-agents/skills/context-optimization/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-optimization",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "Apply optimization techniques to extend effective context capacity. Use when context limits constrai",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/evaluation/plugin.json
+++ b/bundles/ai-agents/skills/evaluation/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Build evaluation frameworks for agent systems. Use when testing agent performance, validating contex",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/memory-systems/plugin.json
+++ b/bundles/ai-agents/skills/memory-systems/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-systems",
-  "version": "1.0.0",
+  "version": "4.1.0",
   "description": "Design and implement memory architectures for agent systems. Use when building agents that need to p",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/spec-first/plugin.json
+++ b/bundles/ai-agents/skills/spec-first/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-first",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when building anything non-trivial. Enforces a spec → plan → execute → verify loop that pr",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/ai-agents/skills/tool-design/plugin.json
+++ b/bundles/ai-agents/skills/tool-design/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tool-design",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "description": "Design tools that agents can use effectively, including when to reduce tool complexity. Use when cre",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/backend/skills/turborepo/plugin.json
+++ b/bundles/backend/skills/turborepo/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "turborepo",
-  "version": "2.9.7-canary.12",
-  "description": "|",
+  "version": "1.0.0",
+  "description": "Turborepo monorepo guidance: turbo.json pipelines, caching, --filter/--affected, package boundaries.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/dev-loop/skills/feature-intake/plugin.json
+++ b/bundles/dev-loop/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-loop/skills/prd-quality-gate/plugin.json
+++ b/bundles/dev-loop/skills/prd-quality-gate/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-quality-gate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PRD completeness validation — check required sections before a spec is handed to a planning agent",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/agent-config-audit/plugin.json
+++ b/bundles/dev-workflow/skills/agent-config-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-config-audit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Audit and sync AI agent config files, hooks, settings, and workspace rules.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/dev-workflow/skills/refactor-code/plugin.json
+++ b/bundles/dev-workflow/skills/refactor-code/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "refactor-code",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Systematic approach to safely refactoring code with tests",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/frontend/skills/html-style/plugin.json
+++ b/bundles/frontend/skills/html-style/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "html-style",
   "version": "1.0.0",
-  "description": ">",
+  "description": "Apply an opinionated, cohesive design system to barebones or unstyled HTML on request.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/bundles/github/skills/feature-intake/plugin.json
+++ b/bundles/github/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/planning/skills/feature-intake/plugin.json
+++ b/bundles/planning/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/bundles/planning/skills/prd-quality-gate/plugin.json
+++ b/bundles/planning/skills/prd-quality-gate/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-quality-gate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PRD completeness validation — check required sections before a spec is handed to a planning agent",
   "author": {
     "name": "Ship Shit Dev",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "marketplace:generate": "bun run catalog:generate && bun scripts/generate-marketplace-bundles.js && bun scripts/generate-marketplace-json.js",
     "prepare": "husky",
     "validate": "bash scripts/validate-skill-sync.sh",
-    "validate:skill": "bash scripts/validate-skill-sync.sh"
+    "validate:skill": "bash scripts/validate-skill-sync.sh",
+    "version:check": "bash scripts/check-skill-version-bumps.sh"
   },
   "version": "1.0.0"
 }

--- a/scripts/check-skill-version-bumps.sh
+++ b/scripts/check-skill-version-bumps.sh
@@ -1,0 +1,91 @@
+#!/bin/bash
+#
+# Require a metadata.version bump for every skill whose content changed.
+#
+# Compares HEAD against BASE_REF (default: origin/master). For each
+# skills/<name>/ with a changed file other than plugin.json, the SKILL.md
+# metadata.version at HEAD must differ from the version at BASE_REF.
+#
+#   - New skills (no SKILL.md at base) pass.
+#   - Deleted skills (no SKILL.md at HEAD) pass.
+#   - plugin.json-only edits pass: that file is metadata sync, not content,
+#     and validate-skill-sync.sh already forces it to mirror SKILL.md.
+#
+# Usage:
+#   bash scripts/check-skill-version-bumps.sh            # BASE_REF=origin/master
+#   BASE_REF=origin/main bash scripts/check-skill-version-bumps.sh
+#
+
+set -euo pipefail
+
+BASE_REF="${BASE_REF:-origin/master}"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+if ! git rev-parse --verify --quiet "$BASE_REF" >/dev/null; then
+  echo -e "${RED}✗ BASE_REF '$BASE_REF' is not a known ref (need fetch-depth: 0 in CI).${NC}"
+  exit 2
+fi
+
+MERGE_BASE=$(git merge-base "$BASE_REF" HEAD)
+
+# Skill directories with any change other than plugin.json.
+CHANGED_SKILLS=$(git diff --name-only "$MERGE_BASE" HEAD -- skills/ \
+  | grep -E '^skills/[^/]+/' \
+  | grep -vE '^skills/[^/]+/plugin\.json$' \
+  | sed -E 's|^skills/([^/]+)/.*|\1|' \
+  | sort -u || true)
+
+if [[ -z "$CHANGED_SKILLS" ]]; then
+  echo -e "${GREEN}✓ No skill content changed vs $BASE_REF — nothing to bump.${NC}"
+  exit 0
+fi
+
+# Extract metadata.version from a SKILL.md blob at a given rev ("" if absent).
+skill_version_at() {
+  local rev="$1" name="$2"
+  git show "$rev:skills/$name/SKILL.md" 2>/dev/null | awk '
+    NR == 1 && $0 != "---" { exit }
+    NR > 1 && $0 == "---" { exit }
+    /^metadata:$/ { in_metadata = 1; next }
+    in_metadata && /^[A-Za-z0-9_-]+:/ { in_metadata = 0 }
+    in_metadata && /^  version:/ {
+      sub(/^  version:[[:space:]]*/, "")
+      gsub(/["'"'"']/, "")
+      print
+      exit
+    }
+  ' || true
+}
+
+failures=0
+for name in $CHANGED_SKILLS; do
+  base_version=$(skill_version_at "$MERGE_BASE" "$name")
+  head_version=$(skill_version_at HEAD "$name")
+
+  if [[ -z "$base_version" ]]; then
+    echo -e "${GREEN}✓${NC} $name — new skill (${head_version:-no version}), no bump required"
+    continue
+  fi
+  if [[ -z "$head_version" ]]; then
+    echo -e "${GREEN}✓${NC} $name — removed at HEAD, no bump required"
+    continue
+  fi
+  if [[ "$base_version" == "$head_version" ]]; then
+    echo -e "${RED}✗${NC} $name — content changed but metadata.version is still $head_version (bump it in SKILL.md and mirror plugin.json)"
+    ((++failures))
+  else
+    echo -e "${GREEN}✓${NC} $name — $base_version → $head_version"
+  fi
+done
+
+echo
+if [[ $failures -gt 0 ]]; then
+  echo -e "${RED}✗ $failures skill(s) changed without a version bump.${NC}"
+  echo -e "${YELLOW}  Bump metadata.version in skills/<name>/SKILL.md, then set the same version in skills/<name>/plugin.json.${NC}"
+  exit 1
+fi
+echo -e "${GREEN}✓ Every changed skill carries a version bump.${NC}"

--- a/scripts/fixtures/skill-validation/invalid-plugin-description/SKILL.md
+++ b/scripts/fixtures/skill-validation/invalid-plugin-description/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: invalid-plugin-description
+description: Reports portable validation evidence when checking a fixture skill.
+metadata:
+  version: "1.0.0"
+  tags: "fixture, validation"
+---
+
+# Invalid Plugin Description Fixture
+
+Report evidence without changing files.

--- a/scripts/fixtures/skill-validation/invalid-plugin-version/SKILL.md
+++ b/scripts/fixtures/skill-validation/invalid-plugin-version/SKILL.md
@@ -1,0 +1,11 @@
+---
+name: invalid-plugin-version
+description: Reports portable validation evidence when checking a fixture skill.
+metadata:
+  version: "1.2.0"
+  tags: "fixture, validation"
+---
+
+# Invalid Plugin Version Fixture
+
+Report evidence without changing files.

--- a/scripts/generate-marketplace-bundles.js
+++ b/scripts/generate-marketplace-bundles.js
@@ -16,6 +16,8 @@ const ROOT = join(__dirname, '..');
 const SKILLS_DIR = join(ROOT, 'skills');
 const BUNDLES_DIR = join(ROOT, 'bundles');
 const CATEGORIES = JSON.parse(readFileSync(join(__dirname, 'plugin-categories.json'), 'utf-8'));
+// Bundles are versioned with the repo release, not per skill — release-please bumps package.json.
+const PACKAGE_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')).version;
 
 function ensureDir(dir) {
   if (!existsSync(dir)) {
@@ -27,7 +29,7 @@ function generatePluginJson(name, description) {
   return `${JSON.stringify(
     {
       name,
-      version: '1.0.0',
+      version: PACKAGE_VERSION,
       description,
       author: 'Ship Shit Dev',
       license: 'MIT',

--- a/scripts/generate-marketplace-json.js
+++ b/scripts/generate-marketplace-json.js
@@ -12,6 +12,20 @@ const ROOT = join(__dirname, '..');
 const SKILLS_DIR = join(ROOT, 'skills');
 const CATEGORIES = JSON.parse(readFileSync(join(__dirname, 'plugin-categories.json'), 'utf-8'));
 const CATALOG = JSON.parse(readFileSync(join(ROOT, 'catalog.json'), 'utf-8'));
+const PACKAGE_VERSION = JSON.parse(readFileSync(join(ROOT, 'package.json'), 'utf-8')).version;
+
+// Per-skill version comes from plugin.json, which the validator forces to mirror
+// SKILL.md metadata.version.
+function getSkillVersion(skillName) {
+  const pluginPath = join(SKILLS_DIR, skillName, 'plugin.json');
+  if (!existsSync(pluginPath)) return null;
+  try {
+    const version = JSON.parse(readFileSync(pluginPath, 'utf-8')).version;
+    return typeof version === 'string' && version ? version : null;
+  } catch {
+    return null;
+  }
+}
 
 // Get skill description from SKILL.md frontmatter.
 // Handles plain/quoted single-line values AND YAML block scalars
@@ -62,6 +76,7 @@ for (const [category, config] of Object.entries(CATEGORIES.bundles)) {
   plugins.push({
     name: `shipshitdev-${category}`,
     source: `./bundles/${category}`,
+    version: PACKAGE_VERSION,
     description: config.description,
   });
 }
@@ -80,9 +95,11 @@ for (const skillName of skills) {
     console.warn(`Skipping invalid skill directory without SKILL.md: ${skillName}`);
     continue;
   }
+  const version = getSkillVersion(skillName);
   plugins.push({
     name: skillName,
     source: `./skills/${skillName}`,
+    ...(version ? { version } : {}),
     // Mirror the full SKILL.md description so the "Use when …" trigger clause
     // is discoverable in the catalog. The source frontmatter is already length-
     // capped (1024/1536); the previous slice(0, 100) cut clauses off mid-word.

--- a/scripts/tests/test_validate_skill_sync.py
+++ b/scripts/tests/test_validate_skill_sync.py
@@ -15,7 +15,9 @@ VALIDATOR = REPO_ROOT / "scripts/validate-skill-sync.sh"
 
 
 class SkillValidatorFixtureTests(unittest.TestCase):
-    def run_fixture(self, name: str) -> subprocess.CompletedProcess[str]:
+    def run_fixture(
+        self, name: str, manifest_overrides: dict[str, str] | None = None
+    ) -> subprocess.CompletedProcess[str]:
         with tempfile.TemporaryDirectory() as directory:
             skills_dir = Path(directory) / "skills"
             fixture_dir = skills_dir / name
@@ -27,6 +29,7 @@ class SkillValidatorFixtureTests(unittest.TestCase):
                 "author": {"name": "Fixture"},
                 "license": "MIT",
                 "skills": ".",
+                **(manifest_overrides or {}),
             }
             (fixture_dir / "plugin.json").write_text(json.dumps(manifest))
             environment = os.environ.copy()
@@ -40,8 +43,14 @@ class SkillValidatorFixtureTests(unittest.TestCase):
                 check=False,
             )
 
-    def assert_finding(self, fixture: str, finding: str, returncode: int) -> None:
-        result = self.run_fixture(fixture)
+    def assert_finding(
+        self,
+        fixture: str,
+        finding: str,
+        returncode: int,
+        manifest_overrides: dict[str, str] | None = None,
+    ) -> None:
+        result = self.run_fixture(fixture, manifest_overrides)
         self.assertEqual(result.returncode, returncode, result.stdout + result.stderr)
         self.assertIn(finding, result.stdout)
 
@@ -84,6 +93,22 @@ class SkillValidatorFixtureTests(unittest.TestCase):
             "invalid-codex-path-claim",
             "Unsupported Codex path claim",
             1,
+        )
+
+    def test_plugin_version_drift_is_rejected(self) -> None:
+        # Fixture SKILL.md says 1.2.0; the harness manifest says 1.0.0.
+        self.assert_finding(
+            "invalid-plugin-version",
+            "plugin.json version 1.0.0 != SKILL.md metadata.version 1.2.0",
+            1,
+        )
+
+    def test_plugin_block_marker_description_is_rejected(self) -> None:
+        self.assert_finding(
+            "invalid-plugin-description",
+            "plugin.json description is a YAML block marker",
+            1,
+            manifest_overrides={"description": "|"},
         )
 
 

--- a/scripts/validate-skill-sync.sh
+++ b/scripts/validate-skill-sync.sh
@@ -435,6 +435,80 @@ PY
     return $warnings
 }
 
+# Hard gate: plugin.json must mirror SKILL.md metadata.version (SKILL.md is
+# canonical) and must carry a real description — not a YAML block scalar
+# marker ("|" / ">") that leaked in from a frontmatter copy.
+check_plugin_manifest_sync() {
+    local skill_dir="$1"
+    local issues=0
+    local plugin_json="$skill_dir/plugin.json"
+    local skill_file="$skill_dir/SKILL.md"
+
+    if [[ ! -f "$plugin_json" ]] || [[ ! -f "$skill_file" ]]; then
+        return 0
+    fi
+
+    local findings
+    findings=$(python3 - "$plugin_json" "$skill_file" <<'PY'
+import json
+import pathlib
+import re
+import sys
+
+plugin_path = pathlib.Path(sys.argv[1])
+skill_path = pathlib.Path(sys.argv[2])
+
+try:
+    data = json.loads(plugin_path.read_text())
+except json.JSONDecodeError:
+    sys.exit(0)  # reported by check_plugin_manifest
+
+description = data.get("description", "")
+if isinstance(description, str) and re.fullmatch(r"\s*[|>][+-]?\s*", description):
+    print(f"plugin.json description is a YAML block marker ({description.strip()!r}), not text")
+
+lines = skill_path.read_text().splitlines()
+if not lines or lines[0].strip() != "---":
+    sys.exit(0)
+try:
+    end = lines.index("---", 1)
+except ValueError:
+    sys.exit(0)
+
+skill_version = None
+in_metadata = False
+for line in lines[1:end]:
+    if line == "metadata:":
+        in_metadata = True
+        continue
+    if in_metadata and line and not line.startswith((" ", "\t")):
+        break
+    if in_metadata:
+        match = re.match(r'^  version:\s*["\']?([^"\']*)["\']?\s*$', line)
+        if match:
+            skill_version = match.group(1).strip()
+            break
+
+plugin_version = data.get("version")
+if skill_version and isinstance(plugin_version, str) and plugin_version != skill_version:
+    print(
+        f"plugin.json version {plugin_version} != SKILL.md metadata.version {skill_version}"
+        " (SKILL.md is canonical — sync plugin.json)"
+    )
+PY
+)
+
+    if [[ -n "$findings" ]]; then
+        while IFS= read -r finding; do
+            [[ -n "$finding" ]] || continue
+            echo -e "  ${RED}✗${NC} $finding"
+            ((++issues))
+        done <<< "$findings"
+    fi
+
+    return $issues
+}
+
 # Function to check required metadata keys
 check_metadata_fields() {
     local file="$1"
@@ -1205,6 +1279,10 @@ validate_skill() {
         local plugin_warnings=0
         check_plugin_manifest "$SKILLS_DIR/$skill_name" || plugin_warnings=$?
         ((skill_warnings += plugin_warnings, 1))
+
+        local plugin_sync_issues=0
+        check_plugin_manifest_sync "$SKILLS_DIR/$skill_name" || plugin_sync_issues=$?
+        ((skill_issues += plugin_sync_issues, 1))
 
         # Also check references/ directory
         if [[ -d "$SKILLS_DIR/$skill_name/references" ]]; then

--- a/skills/agent-config-audit/plugin.json
+++ b/skills/agent-config-audit/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-config-audit",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Audit and sync AI agent config files, hooks, settings, and workspace rules.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/context-degradation/plugin.json
+++ b/skills/context-degradation/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-degradation",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "Recognize, diagnose, and mitigate patterns of context degradation in agent systems. Use when context",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/context-fundamentals/plugin.json
+++ b/skills/context-fundamentals/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-fundamentals",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "description": "Understand the components, mechanics, and constraints of context in agent systems. Use when designin",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/context-optimization/plugin.json
+++ b/skills/context-optimization/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "context-optimization",
-  "version": "1.0.0",
+  "version": "2.1.0",
   "description": "Apply optimization techniques to extend effective context capacity. Use when context limits constrai",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/evaluation/plugin.json
+++ b/skills/evaluation/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "evaluation",
-  "version": "1.0.0",
+  "version": "1.2.0",
   "description": "Build evaluation frameworks for agent systems. Use when testing agent performance, validating contex",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/feature-intake/plugin.json
+++ b/skills/feature-intake/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "feature-intake",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Capture client requirements as PRD epics, sub-issues, and GitHub Projects kanban items.",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/html-style/plugin.json
+++ b/skills/html-style/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "html-style",
   "version": "1.0.0",
-  "description": ">",
+  "description": "Apply an opinionated, cohesive design system to barebones or unstyled HTML on request.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",

--- a/skills/memory-systems/plugin.json
+++ b/skills/memory-systems/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "memory-systems",
-  "version": "1.0.0",
+  "version": "4.1.0",
   "description": "Design and implement memory architectures for agent systems. Use when building agents that need to p",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/prd-quality-gate/plugin.json
+++ b/skills/prd-quality-gate/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "prd-quality-gate",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "PRD completeness validation — check required sections before a spec is handed to a planning agent",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/refactor-code/plugin.json
+++ b/skills/refactor-code/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "refactor-code",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Systematic approach to safely refactoring code with tests",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/spec-first/plugin.json
+++ b/skills/spec-first/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "spec-first",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Use when building anything non-trivial. Enforces a spec → plan → execute → verify loop that pr",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/tool-design/plugin.json
+++ b/skills/tool-design/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tool-design",
-  "version": "1.0.0",
+  "version": "2.2.0",
   "description": "Design tools that agents can use effectively, including when to reduce tool complexity. Use when cre",
   "author": {
     "name": "Ship Shit Dev",

--- a/skills/turborepo/plugin.json
+++ b/skills/turborepo/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "turborepo",
-  "version": "2.9.7-canary.12",
-  "description": "|",
+  "version": "1.0.0",
+  "description": "Turborepo monorepo guidance: turbo.json pipelines, caching, --filter/--affected, package boundaries.",
   "author": {
     "name": "Ship Shit Dev",
     "email": "hello@shipshit.dev",


### PR DESCRIPTION
## Summary
- **Hard gate in `bun run validate`**: `plugin.json.version` must equal `SKILL.md metadata.version` (SKILL.md canonical); `plugin.json.description` may not be a YAML block marker (`|` / `>`).
- **New `bun run version:check`** (`scripts/check-skill-version-bumps.sh`): fails CI when any file under `skills/<name>/` other than `plugin.json` changes without a `metadata.version` bump vs the PR base. New/deleted skills pass.
- CI: `fetch-depth: 0` + the new step after "Validate skills".
- Fixed 12 drifted skills (plugin.json ← SKILL.md) and the junk `turborepo` (`"|"`, `2.9.7-canary.12`) / `html-style` (`">"`) manifests.
- Bundle `plugin.json` versions ← `package.json.version` (was hardcoded `1.0.0`); `marketplace.json` entries now carry `version` (skills ← plugin.json, bundles ← package.json).
- Fixtures + tests in `scripts/tests/test_validate_skill_sync.py` for both gates; `skill-standards.md` Versioning section documents the enforcement.

## Verification
- `bun run validate` → 0 errors (was 13 with the gate on before fixes).
- `bun run version:check` on #105 / #107 history → both bumped correctly (`✓`).
- Manual run of the validator against the two new fixtures → each reports the expected `✗` and exits 1.
- `bun run lint` clean; `bun run marketplace:generate` produced only the expected plugin.json / marketplace.json diffs.

Closes the version-drift half of the "proper versioning" ask; releases follow in the release-please PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI merge gates and release/catalog metadata for the whole skill library; incorrect rules could block valid PRs or mis-version marketplace entries, but changes are mostly validation and generated JSON sync.
> 
> **Overview**
> **Enforces skill versioning end-to-end** so `SKILL.md` stays canonical and distribution metadata cannot drift silently.
> 
> `bun run validate` now **hard-fails** when `plugin.json.version` ≠ `metadata.version` or when `plugin.json.description` is a YAML block marker (`|` / `>`). A new **`bun run version:check`** compares the PR to `BASE_REF` and fails if any file under `skills/<name>/` changed (except `plugin.json` alone) without a `metadata.version` bump. CI runs it after validate with **`fetch-depth: 0`** so merge-base diffs work.
> 
> **Marketplace generation** adds `version` on every plugin entry: per-skill from `plugin.json`, category bundles from **`package.json.version`**. Bundle `plugin.json` generation no longer hardcodes `1.0.0`.
> 
> This PR **repairs existing drift** (synced `plugin.json` to `SKILL.md` for several skills, fixed broken `turborepo` / `html-style` manifests) and documents the rules in **`skill-standards.md`**, with validator fixtures and unit tests for the new gates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51f522b00b5b18beed92e6f8b6db8ce6d36c43f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->