### PR TITLE
fix: run release-please on GITHUB_TOKEN and dispatch CI on the release branch

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,10 +5,11 @@ name: Release Please
 # (feat → minor, fix/chore/refactor → patch, ! → major). Merging that PR cuts
 # the vX.Y.Z tag and GitHub release.
 #
-# Uses a PAT instead of GITHUB_TOKEN so the release PR triggers CI — required
-# checks would otherwise never go green on it. Prefers RELEASE_PLEASE_TOKEN
-# (Contents + Pull requests write on this repo); falls back to PROJECTS_TOKEN,
-# the same PAT the dev-loop workflows use, when the dedicated one is not set.
+# Runs on the built-in GITHUB_TOKEN — no PAT to provision or rotate. GitHub
+# deliberately does not fire push/pull_request workflow runs for anything
+# GITHUB_TOKEN does, so the release PR would never produce the `checks` status
+# that master requires. workflow_dispatch is exempt from that rule, so the sync
+# job kicks CI on the release branch explicitly once its head SHA is final.
 
 on:
   push:
@@ -19,6 +20,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write # dispatch CI on the release branch
 
 concurrency:
   group: release-please
@@ -37,24 +39,27 @@ jobs:
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
         with:
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.PROJECTS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
   # The release PR bumps package.json, and bundle/marketplace versions are
   # generated from it — regenerate on the release branch so CI's
-  # "Verify generated bundles are current" gate stays green.
+  # "Verify generated bundles are current" gate stays green. Then dispatch CI
+  # so the required `checks` status actually lands on the PR head.
   sync-generated:
     needs: release-please
     if: ${{ needs.release-please.outputs.pr }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    env:
+      RELEASE_BRANCH: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
     steps:
       - name: Checkout release branch
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
-          ref: ${{ fromJSON(needs.release-please.outputs.pr).headBranchName }}
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.PROJECTS_TOKEN }}
+          ref: ${{ env.RELEASE_BRANCH }}
+          fetch-depth: 0 # CI's version:check diffs against origin/master
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -78,3 +83,8 @@ jobs:
           git add -A
           git commit -m "chore: regenerate bundles for release"
           git push
+
+      - name: Dispatch CI on the release branch
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run CI --repo "$GITHUB_REPOSITORY" --ref "$RELEASE_BRANCH"


### PR DESCRIPTION
The first Release Please run 403'd: `POST /git/refs` → `Resource not accessible by personal access token`. `PROJECTS_TOKEN` is Projects-scoped, so it cannot create the release branch.

Rather than provision a new PAT, switch to the built-in `GITHUB_TOKEN`. The only reason a PAT was there at all: GitHub suppresses `push`/`pull_request` workflow runs for GITHUB_TOKEN actions, so the release PR would never produce the `checks` status that master now requires.

`workflow_dispatch` is exempt from that suppression, so the `sync-generated` job now dispatches CI on the release branch after the regenerated commit lands — the required check reports against the final head SHA.

- `token: ${{ secrets.GITHUB_TOKEN }}` for release-please; checkout uses the default token.
- `permissions: actions: write` for the dispatch.
- `fetch-depth: 0` on the release-branch checkout (CI's `version:check` diffs against `origin/master`).
- No repo secret needed. Nothing to rotate.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release automation and how required CI status is produced on release PRs; mis-dispatch or token permissions could block merges or leave release branches unchecked.
> 
> **Overview**
> **Release Please** no longer depends on `RELEASE_PLEASE_TOKEN` / `PROJECTS_TOKEN` (which failed on `POST /git/refs` and couldn’t create the release branch). It now uses **`secrets.GITHUB_TOKEN`** for release-please and default checkout auth.
> 
> Because **GITHUB_TOKEN** pushes don’t trigger `pull_request` CI, the release PR wouldn’t get the required **`checks`** status. The **`sync-generated`** job now grants **`actions: write`**, checks out the release branch with **`fetch-depth: 0`** for `version:check` against `origin/master`, and after bundle regeneration **dispatches the `CI` workflow** via `gh workflow run` on that branch so checks land on the final head SHA.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4259d4b197bf43b4034f84db8abaaf1671512bd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved the release process to better automate version updates and generated-file synchronization.
  - Release-related changes now reliably trigger continuous integration checks before completion.
  - Updated release documentation with the latest process details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->