### PR TITLE
chore: open the release PR as a draft

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -2,8 +2,10 @@ name: Release Please
 
 # Every push to master feeds a rolling "chore(master): release X.Y.Z" PR that
 # bumps package.json + CHANGELOG.md from conventional-commit PR titles
-# (feat → minor, fix/chore/refactor → patch, ! → major). Merging that PR cuts
-# the vX.Y.Z tag and GitHub release.
+# (feat → minor, fix/chore/refactor → patch, ! → major). It opens as a draft
+# (`draft-pull-request` in release-please-config.json) because it accumulates
+# every merge until someone decides to cut a release — mark it ready for
+# review when that moment comes. Merging it cuts the vX.Y.Z tag and release.
 #
 # Runs on the built-in GITHUB_TOKEN — no PAT to provision or rotate. The
 # tradeoff: GitHub queues the release PR's CI at `action_required` instead of

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "include-component-in-tag": false,
   "include-v-in-tag": true,
   "bump-minor-pre-major": false,
+  "draft-pull-request": true,
   "changelog-sections": [
     { "type": "feat", "section": "Features" },
     { "type": "fix", "section": "Bug Fixes" },


### PR DESCRIPTION
## What

Sets `draft-pull-request: true` in `release-please-config.json`, and documents the resulting flow in the workflow header.

## Why

The release PR is not a normal PR — it is a rolling accumulator that stays open across every merge to master, retitling itself as the pending version changes. Presenting that as ready-for-review is wrong on both counts: nobody is reviewing it, and it is not ready.

Draft makes readiness an explicit act. Cutting a release becomes "mark ready → merge" instead of "merge whatever happens to be in there right now", which also removes the accidental-merge path.

CI is unaffected — `pull_request` events still fire for drafts, so the `checks` run still queues (and still needs its one approval click, per #113).

## Note on the open PR

`draft-pull-request` applies to PRs release-please creates; it does not convert an already-open one. #114 will be flipped to draft manually so the current state matches the config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config and documentation only; release automation behavior is limited to draft vs ready PR state, with no application or security impact.
> 
> **Overview**
> Release-please will now open the rolling version-bump PR as a **draft** via `draft-pull-request: true` in `release-please-config.json`, so it is not presented as ready for review while it keeps accumulating merges to master.
> 
> The **Release Please** workflow header comment is updated to describe that flow: mark the PR ready when you intend to cut a release, then merge to create the tag and GitHub release. No workflow job or CI behavior changes in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35cc21484311db891fcf0a5b2749cef2e254077c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Release pull requests are now created as drafts.
  - Updated release workflow guidance to clarify that changes accumulate until the pull request is marked ready and merged.
  - Merging the release pull request creates the version tag and GitHub release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->